### PR TITLE
Use an alternate form of SSH options to prevent quote issues

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -4,4 +4,4 @@ all:
     watch:
       ansible_host: i-0e3777724198d81d1
       ansible_user: ubuntu
-      ansible_ssh_common_args: "-o ProxyCommand aws ssm start-session --target %h --document-name RGD_SSHDocument --parameters 'portNumber=%p'"
+      ansible_ssh_common_args: "-o ProxyCommand=aws ssm start-session --target %h --document-name RGD_SSHDocument --parameters 'portNumber=%p'"


### PR DESCRIPTION
The SSH config docs specify that using `=` to delimit option values will help avoid whitespace escaping issues.