### PR TITLE
Add Django admin

### DIFF
--- a/django/src/rdwatch/admin.py
+++ b/django/src/rdwatch/admin.py
@@ -1,0 +1,50 @@
+from django.contrib import admin
+
+from .models import (
+    PredictionConfiguration,
+    Saliency,
+    SaliencyTile,
+    SatelliteImage,
+    Site,
+    TrackingConfiguration,
+)
+
+# general admin settings
+admin.site.site_header = "WATCH Admin"
+admin.site.site_title = "WATCH Admin"
+
+
+@admin.register(PredictionConfiguration)
+class PredictionConfigurationAdmin(admin.ModelAdmin):
+    list_display = ("id", "timestamp")
+
+
+@admin.register(Saliency)
+class SaliencyAdmin(admin.ModelAdmin):
+    list_display = ("id", "configuration", "source")
+
+
+@admin.register(SaliencyTile)
+class SaliencyTileAdmin(admin.ModelAdmin):
+    list_display = ("id", "raster", "saliency")
+
+
+@admin.register(SatelliteImage)
+class SatelliteImageAdmin(admin.ModelAdmin):
+    list_display = ("id", "sensor", "timestamp")
+
+
+@admin.register(Site)
+class SiteAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "configuration",
+        "saliency",
+        "label",
+        "score",
+    )
+
+
+@admin.register(TrackingConfiguration)
+class TrackingConfigurationAdmin(admin.ModelAdmin):
+    list_display = ("id", "timestamp", "threshold")

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -29,17 +29,43 @@ DATABASES = {
 }
 DEBUG = environ["RDWATCH_DJANGO_DEBUG"].lower() in ("1", "true", "yes", "on")
 INSTALLED_APPS = [
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.gis",
+    "django.contrib.messages",
+    "django.contrib.humanize",
     "django.contrib.postgres",
+    "django.contrib.sessions",
+    "django.contrib.staticfiles",
     "rest_framework",
     "rdwatch",
 ]
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+STATIC_URL = "static/"
+
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": ["rest_framework.parsers.JSONParser"],

--- a/django/src/rdwatch/server/urls.py
+++ b/django/src/rdwatch/server/urls.py
@@ -1,5 +1,7 @@
+from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
+    path('admin/', admin.site.urls),
     path("api/", include("rdwatch.urls")),
 ]


### PR DESCRIPTION
Adds the settings needed to enable the Django admin (taken mostly from `django-composed-configuration`), plus adds some auto-generated Admin classes.