### PR TITLE
Fix raster tile endpoint

### DIFF
--- a/django/src/rdwatch/db/functions.py
+++ b/django/src/rdwatch/db/functions.py
@@ -118,8 +118,15 @@ class RasterTile(Func):
             **extra,
         )
         resampled = Func(union, empty_reference, function="ST_Resample")
-        tile = Func(resampled, reference, Value("[rast1]"), function="ST_MapAlgebra")
-        super().__init__(tile)
+        tile = Func(
+            resampled,
+            reference,
+            Value("[rast1]"),
+            Value("16BUI"),
+            Value("SECOND"),
+            function="ST_MapAlgebra",
+        )
+        super().__init__(Func(tile, None, function="ST_SetBandNoDataValue"))
 
 
 class VectorTile(Aggregate):


### PR DESCRIPTION
Forgot to cache-bust while working on #86.

This ensures the tiles are always 512-by-512px and disables transparency.