### PR TITLE
Miscellaneous development environment update

### DIFF
--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -56,7 +56,9 @@ flake8-django = "^1.1.5"
 
 [tool.isort]
 profile = "black"
-known_first_party = ["django", "rdwatch", "rest_framework"]
+known_first_party = ["rdwatch"]
+known_django=["django", "rest_framework"]
+sections=["FUTURE", "STDLIB", "THIRDPARTY", "DJANGO", "FIRSTPARTY", "LOCALFOLDER"]
 
 
 [tool.mypy]

--- a/django/src/rdwatch/management/commands/ingest.py
+++ b/django/src/rdwatch/management/commands/ingest.py
@@ -11,6 +11,7 @@ import iso3166
 
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.core.management.base import BaseCommand
+
 from rdwatch.models import (
     HyperParameters,
     Region,

--- a/django/src/rdwatch/migrations/0002_initial.py
+++ b/django/src/rdwatch/migrations/0002_initial.py
@@ -6,8 +6,9 @@ import django.contrib.postgres.fields.ranges
 import django.contrib.postgres.indexes
 import django.core.validators
 import django.db.models.deletion
-import rdwatch.validators
 from django.db import migrations, models
+
+import rdwatch.validators
 
 
 class Migration(migrations.Migration):

--- a/django/src/rdwatch/models/region.py
+++ b/django/src/rdwatch/models/region.py
@@ -1,6 +1,7 @@
 import iso3166
 
 from django.db import models
+
 from rdwatch.validators import validate_iso3166
 
 

--- a/django/src/rdwatch/models/satellite_image.py
+++ b/django/src/rdwatch/models/satellite_image.py
@@ -2,6 +2,7 @@ from django.contrib.gis.db.models import PolygonField
 from django.contrib.postgres.indexes import GistIndex
 from django.core.validators import URLValidator
 from django.db import models
+
 from rdwatch.validators import validate_bbox
 
 

--- a/django/src/rdwatch/serializers/server_status.py
+++ b/django/src/rdwatch/serializers/server_status.py
@@ -1,5 +1,6 @@
-from rdwatch.dataclasses import ServerStatus
 from rest_framework import serializers
+
+from rdwatch.dataclasses import ServerStatus
 
 
 class UptimeSerializer(serializers.Serializer):

--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from rdwatch import views
 from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.schemas import get_schema_view
+
+from rdwatch import views
 
 urlpatterns = [
     path(

--- a/django/src/rdwatch/views/server_status.py
+++ b/django/src/rdwatch/views/server_status.py
@@ -1,12 +1,13 @@
 import datetime
 import socket
 
-from rdwatch.dataclasses import ServerStatus
-from rdwatch.serializers import ServerStatusSerializer
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
 from rest_framework.views import APIView
+
+from rdwatch.dataclasses import ServerStatus
+from rdwatch.serializers import ServerStatusSerializer
 
 SERVER_INSTANCE_EPOCH = datetime.datetime.now()
 

--- a/django/src/rdwatch/views/site.py
+++ b/django/src/rdwatch/views/site.py
@@ -2,11 +2,12 @@ from django.contrib.gis.db.models.aggregates import Collect
 from django.contrib.gis.db.models.functions import Envelope, Transform
 from django.http import HttpRequest
 from django.views.decorators.cache import cache_page
-from rdwatch.models import SiteEvaluation, SiteObservation
-from rdwatch.serializers import SiteEvaluationSerializer, SiteObservationSerializer
 from rest_framework.decorators import api_view, schema
 from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
+
+from rdwatch.models import SiteEvaluation, SiteObservation
+from rdwatch.serializers import SiteEvaluationSerializer, SiteObservationSerializer
 
 
 class SiteEvaluationsSchema(AutoSchema):

--- a/django/src/rdwatch/views/tile.py
+++ b/django/src/rdwatch/views/tile.py
@@ -11,10 +11,11 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_page
+from rest_framework.reverse import reverse
+
 from rdwatch.db.functions import GistDistance
 from rdwatch.models import SatelliteImage, SiteEvaluation, SiteObservation
 from rdwatch.utils.raster_tile import get_raster_tile
-from rest_framework.reverse import reverse
 
 
 def site_evaluation_vector_tile(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -133,6 +133,7 @@ services:
     volumes:
       - .:/app
       - poetry-cache:/tmp/poetry-cache
+      - ipython-profile:/root/.ipython/profile_default
     working_dir: /app/django
 
   # Run npm commands
@@ -174,6 +175,7 @@ services:
     volumes:
       - .:/app
       - poetry-cache:/tmp/poetry-cache
+      - ipython-profile:/root/.ipython/profile_default
 
 volumes:
   pgadmin-data:
@@ -182,3 +184,4 @@ volumes:
   # debug volumes
   unit-socket:
   poetry-cache:
+  ipython-profile:

--- a/vscode.code-workspace
+++ b/vscode.code-workspace
@@ -137,6 +137,13 @@
     "python.linting.pydocstyleEnabled": false,
     "python.linting.pylamaEnabled": false,
     "python.linting.pylintEnabled": false,
+    "python.linting.mypyArgs": [
+      "--follow-imports=silent",
+      "--ignore-missing-imports",
+      "--show-column-numbers",
+      "--no-pretty",
+      "--cache-dir=.mypy_cache/.vscode"
+    ],
 
     "stylelint.enable": true,
     "stylelint.validate": [


### PR DESCRIPTION
- **Fix MyPy cache location in VS Code**: MyPy in VS Code needs its own cache directory. See
https://stackoverflow.com/a/73617677.
- **Persist IPython history in development container**: IPython is popular enough that adding a persistent store of its readline entries makes sense.
- **Order imports to put `rdwatch` in its own section**: I found looking for it in the Django section a bit tiresome