### PR TITLE
Filter `SiteEvaluations` by timestamp

### DIFF
--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -243,6 +243,17 @@ bcrypt = ["bcrypt"]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 
 [[package]]
+name = "django-filter"
+version = "22.1"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+Django = ">=3.2"
+
+[[package]]
 name = "django-stubs"
 version = "1.12.0"
 description = "Mypy stubs for Django"
@@ -991,7 +1002,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10.0"
-content-hash = "5c2c6b4a5f4d7b50f423aed7df0d02c04fa3d5e4aff5bfac0593b691c59069da"
+content-hash = "0c5f7e7895e90e85458bc83b12cf890bb4b2bdd73313d28838ffc2bb5997c257"
 
 [metadata.files]
 affine = [
@@ -1090,6 +1101,10 @@ deprecated = [
 django = [
     {file = "Django-4.1-py3-none-any.whl", hash = "sha256:031ccb717782f6af83a0063a1957686e87cb4581ea61b47b3e9addf60687989a"},
     {file = "Django-4.1.tar.gz", hash = "sha256:032f8a6fc7cf05ccd1214e4a2e21dfcd6a23b9d575c6573cacc8c67828dbe642"},
+]
+django-filter = [
+    {file = "django-filter-22.1.tar.gz", hash = "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"},
+    {file = "django_filter-22.1-py3-none-any.whl", hash = "sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb"},
 ]
 django-stubs = [
     {file = "django-stubs-1.12.0.tar.gz", hash = "sha256:ea8b35d0da49f7b2ee99a79125f1943e033431dd114726d6643cc35de619230e"},

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -31,6 +31,7 @@ uritemplate = "^4.1.1"
 iso3166 = "^2.1.1"
 rio-tiler = "^3.1.6"
 mercantile = "^1.2.1"
+django-filter = "^22.1"
 
 [tool.poetry.dev-dependencies]
 black = "~22.6.0"
@@ -67,7 +68,10 @@ plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
 
 
 [[tool.mypy.overrides]]
-module = "mercantile"
+module = [
+  "django_filters",
+  "mercantile"
+]
 ignore_missing_imports = true
 
 


### PR DESCRIPTION
Closes #103

Uses [`django-filter`](https://django-filter.readthedocs.io/) to add filtering by timestamp range to the site evaluations endpoint.

The user can specify one or both of `timestamp_before` and `timestamp_after` as query params to the site evaluations endpoint to filter by date/time range. Uses the `DateTimeFromToRangeFilter`, docs are here https://django-filter.readthedocs.io/en/stable/ref/filters.html#datetimefromtorangefilter