### PR TITLE
Fix CLI spatial transform

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rdwatch-cli"
-version = "0.0.1"
+version = "0.0.2"
 description = "Client for the RD-WATCH server."
 license = "Apache-2.0"
 authors = [ "Kitware, Inc. <kitware@kitware.com>" ]

--- a/cli/src/rdwatch_cli/image.py
+++ b/cli/src/rdwatch_cli/image.py
@@ -77,8 +77,8 @@ async def image(bbox: tuple[float, float, float, float], time: datetime) -> Imag
 
     crop_left = (bbox[0] - bbox_xmin) * xscale
     crop_right = (bbox[2] - bbox_xmin) * xscale
-    crop_top = (bbox[1] - bbox_ymin) * yscale
-    crop_bottom = (bbox[3] - bbox_ymin) * yscale
+    crop_top = (bbox[3] - bbox_ymax) * -yscale
+    crop_bottom = (bbox[1] - bbox_ymax) * -yscale
     crop = merged.crop((crop_left, crop_top, crop_right, crop_bottom))
 
     return crop


### PR DESCRIPTION
Geospatial coordinates were incorrectly being transformed to display coordinates.