### PR TITLE
Paginate Site Evaluations endpoint

### DIFF
--- a/django/src/rdwatch/serializers/site_evaluation.py
+++ b/django/src/rdwatch/serializers/site_evaluation.py
@@ -36,3 +36,5 @@ class SiteEvaluationListSerializer(serializers.Serializer):
     timerange = TimeRangeSerializer()
     bbox = BoundingBoxSerializer()
     results = SiteEvaluationSerializer(many=True)
+    next = serializers.CharField()
+    previous = serializers.CharField()

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -44,6 +44,8 @@ MIDDLEWARE = [
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": ["rest_framework.parsers.JSONParser"],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 25,
 }
 ROOT_URLCONF = "rdwatch.server.urls"
 USE_I18N = False

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -44,13 +44,8 @@ def site_evaluations(request: HttpRequest):
         queryset=SiteEvaluation.objects.order_by("-timestamp"),
     ).qs
 
-    # Pagination
-    assert api_settings.PAGE_SIZE, "PAGE_SIZE must be set."
-    paginator = Paginator(queryset, api_settings.PAGE_SIZE)
-    page = paginator.page(request.GET.get("page", 1))
-    queryset = page.object_list  # get the paginated queryset
-
-    queryset = queryset.annotate(
+    # Overview
+    overview = queryset.annotate(
         timemin=Min("observations__timestamp"),
         timemax=Max("observations__timestamp"),
     ).aggregate(
@@ -60,6 +55,36 @@ def site_evaluations(request: HttpRequest):
             max=ExtractEpoch(Max("timemax")),
         ),
         bbox=BoundingBox(Collect("geom")),
+    )
+
+    # Pagination
+    assert api_settings.PAGE_SIZE, "PAGE_SIZE must be set."
+    paginator = Paginator(queryset, api_settings.PAGE_SIZE)
+    page = paginator.page(request.GET.get("page", 1))
+
+    if page.has_next():
+        next_page_query_params = request.GET.copy()
+        next_page_query_params["page"] = str(page.next_page_number())
+        overview[
+            "next"
+        ] = f"{request.get_full_path()}?{next_page_query_params.urlencode()}"
+    else:
+        overview["next"] = None
+
+    if page.has_previous():
+        prev_page_query_params = request.GET.copy()
+        prev_page_query_params["page"] = str(page.previous_page_number())
+        overview[
+            "previous"
+        ] = f"{request.get_full_path()}?{prev_page_query_params.urlencode()}"
+    else:
+        overview["previous"] = None
+
+    # Results
+    results = page.object_list.annotate(
+        timemin=Min("observations__timestamp"),
+        timemax=Max("observations__timestamp"),
+    ).aggregate(
         results=JSONBAgg(
             JSONObject(
                 id="pk",
@@ -87,24 +112,5 @@ def site_evaluations(request: HttpRequest):
         ),
     )
 
-    # Set `next` and `prev` response values for pagination
-    if page.has_next():
-        next_page_query_params = request.GET.copy()
-        next_page_query_params["page"] = str(page.next_page_number())
-        queryset[
-            "next"
-        ] = f"{request.get_full_path()}?{next_page_query_params.urlencode()}"
-    else:
-        queryset["next"] = None
-
-    if page.has_previous():
-        prev_page_query_params = request.GET.copy()
-        prev_page_query_params["page"] = str(page.previous_page_number())
-        queryset[
-            "previous"
-        ] = f"{request.get_full_path()}?{prev_page_query_params.urlencode()}"
-    else:
-        queryset["previous"] = None
-
-    serializer = SiteEvaluationListSerializer(queryset)
+    serializer = SiteEvaluationListSerializer(overview | results)
     return Response(serializer.data)

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -81,7 +81,7 @@ def site_evaluations(request: HttpRequest):
         overview["previous"] = None
 
     # Results
-    results = page.object_list.annotate(
+    results = page.object_list.annotate(  # type: ignore
         timemin=Min("observations__timestamp"),
         timemax=Max("observations__timestamp"),
     ).aggregate(

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -2,12 +2,14 @@ import django_filters
 
 from django.contrib.gis.db.models.aggregates import Collect
 from django.contrib.postgres.aggregates import JSONBAgg
+from django.core.paginator import Paginator
 from django.db.models import Count, Max, Min
 from django.db.models.functions import JSONObject  # type: ignore
 from django.http import HttpRequest
 from rest_framework.decorators import api_view, schema
 from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
+from rest_framework.settings import api_settings
 
 from rdwatch.db.functions import BoundingBox, ExtractEpoch
 from rdwatch.models import SiteEvaluation
@@ -37,47 +39,72 @@ class SiteEvaluationsSchema(AutoSchema):
 @api_view(["GET"])
 @schema(SiteEvaluationsSchema())
 def site_evaluations(request: HttpRequest):
-    queryset = (
-        SiteEvaluationsFilter(
-            request.GET, queryset=SiteEvaluation.objects.order_by("-timestamp")
-        )
-        .qs.annotate(
-            timemin=Min("observations__timestamp"),
-            timemax=Max("observations__timestamp"),
-        )
-        .aggregate(
-            count=Count("pk"),
-            timerange=JSONObject(
-                min=ExtractEpoch(Min("timemin")),
-                max=ExtractEpoch(Max("timemax")),
-            ),
-            bbox=BoundingBox(Collect("geom")),
-            results=JSONBAgg(
-                JSONObject(
-                    id="pk",
-                    site=JSONObject(
-                        region=JSONObject(
-                            country="region__country",
-                            classification="region__classification__slug",
-                            number="region__number",
-                        ),
-                        number="number",
+    queryset = SiteEvaluationsFilter(
+        request.GET,
+        queryset=SiteEvaluation.objects.order_by("-timestamp"),
+    ).qs
+
+    # Pagination
+    assert api_settings.PAGE_SIZE, "PAGE_SIZE must be set."
+    paginator = Paginator(queryset, api_settings.PAGE_SIZE)
+    page = paginator.page(request.GET.get("page", 1))
+    queryset = page.object_list  # get the paginated queryset
+
+    queryset = queryset.annotate(
+        timemin=Min("observations__timestamp"),
+        timemax=Max("observations__timestamp"),
+    ).aggregate(
+        count=Count("pk"),
+        timerange=JSONObject(
+            min=ExtractEpoch(Min("timemin")),
+            max=ExtractEpoch(Max("timemax")),
+        ),
+        bbox=BoundingBox(Collect("geom")),
+        results=JSONBAgg(
+            JSONObject(
+                id="pk",
+                site=JSONObject(
+                    region=JSONObject(
+                        country="region__country",
+                        classification="region__classification__slug",
+                        number="region__number",
                     ),
-                    configuration="configuration__parameters",
-                    performer=JSONObject(
-                        team_name="configuration__performer__description",
-                        short_code="configuration__performer__slug",
-                    ),
-                    score="score",
-                    bbox=BoundingBox("geom"),
-                    timestamp=ExtractEpoch("timestamp"),
-                    timerange=JSONObject(
-                        min=ExtractEpoch("timemin"),
-                        max=ExtractEpoch("timemax"),
-                    ),
-                )
-            ),
-        )
+                    number="number",
+                ),
+                configuration="configuration__parameters",
+                performer=JSONObject(
+                    team_name="configuration__performer__description",
+                    short_code="configuration__performer__slug",
+                ),
+                score="score",
+                bbox=BoundingBox("geom"),
+                timestamp=ExtractEpoch("timestamp"),
+                timerange=JSONObject(
+                    min=ExtractEpoch("timemin"),
+                    max=ExtractEpoch("timemax"),
+                ),
+            )
+        ),
     )
+
+    # Set `next` and `prev` response values for pagination
+    if page.has_next():
+        next_page_query_params = request.GET.copy()
+        next_page_query_params["page"] = str(page.next_page_number())
+        queryset[
+            "next"
+        ] = f"{request.get_full_path()}?{next_page_query_params.urlencode()}"
+    else:
+        queryset["next"] = None
+
+    if page.has_previous():
+        prev_page_query_params = request.GET.copy()
+        prev_page_query_params["page"] = str(page.previous_page_number())
+        queryset[
+            "previous"
+        ] = f"{request.get_full_path()}?{prev_page_query_params.urlencode()}"
+    else:
+        queryset["previous"] = None
+
     serializer = SiteEvaluationListSerializer(queryset)
     return Response(serializer.data)


### PR DESCRIPTION
Closes #89 

Unfortunately, DRF's default pagination mechanism doesn't completely work here. DRF's `paginate_queryset` method returns a `list` instead of a `QuerySet`, and thus is intended to be called after all other queries have been made. Unfortunately, the end result of the queries made in the site evaluations endpoint is not a `QuerySet` but a `dict`, due to the use of `.aggregate()`. So, there doesn't appear to be a way to use DRF's native pagination methods here; instead, I've dropped down a level to Django's native `Paginator`, which the DRF one uses under the hood. 

I went ahead and configured pagination for DRF anyway in `settings.py`, and also refer to the `PAGE_SIZE` setting in the manual pagination code I wrote so it will be consistent with any DRF-paginated endpoints we have in the future.