### PR TITLE
Allow non-unique times

### DIFF
--- a/django/src/rdwatch/db/functions.py
+++ b/django/src/rdwatch/db/functions.py
@@ -1,5 +1,5 @@
 from django.contrib.gis.db.models.functions import Envelope, Transform
-from django.db.models import FloatField, Func, IntegerField
+from django.db.models import FloatField, Func, IntegerField, RowRange
 from django.db.models.functions import JSONObject  # type: ignore
 
 
@@ -38,3 +38,12 @@ class BoundingBox(JSONObject):
                 output_field=FloatField(),
             ),
         )
+
+
+class GroupExcludeRowRange(RowRange):
+    """A RowRange that excludes the current group
+
+    https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS
+    """
+
+    template = RowRange.template + " EXCLUDE GROUP"

--- a/django/src/rdwatch/views/tile.py
+++ b/django/src/rdwatch/views/tile.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 import mercantile
 
 from django.db import connection
-from django.db.models import BooleanField, F, Field, Func, Max, Min, Q, RowRange, Window
+from django.db.models import BooleanField, F, Field, Func, Max, Min, Q, Window
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -16,7 +16,7 @@ from django.http import (
 from django.views.decorators.cache import cache_page
 from rest_framework.reverse import reverse
 
-from rdwatch.db.functions import ExtractEpoch
+from rdwatch.db.functions import ExtractEpoch, GroupExcludeRowRange
 from rdwatch.models import SiteEvaluation, SiteObservation
 from rdwatch.models.lookups import Constellation
 from rdwatch.utils.raster_tile import get_raster_tile
@@ -80,9 +80,9 @@ def vector_tile(
             timemin=ExtractEpoch("timestamp"),
             timemax=ExtractEpoch(
                 Window(
-                    expression=Max("timestamp"),
+                    expression=Min("timestamp"),
                     partition_by=[F("siteeval")],
-                    frame=RowRange(start=0, end=1),
+                    frame=GroupExcludeRowRange(start=0, end=None),
                     order_by="timestamp",  # type: ignore
                 ),
             ),

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -16,8 +16,8 @@ export const buildObservationFilter = (
   ["<=", ["get", "timemin"], timestamp],
   [
     "any",
+    ["!", ["to-boolean", ["get", "timemax"]]],
     [">", ["get", "timemax"], timestamp],
-    ["==", ["get", "timemin"], ["get", "timemax"]],
   ],
 ];
 


### PR DESCRIPTION
The [Site Model Specification](https://smartgitlab.com/TE/standards/-/wikis/Site-Model-Specification#sensor_name-string-or-null) allows multiple observations to be labeled at the same time for a site. It is unclear what this actually _means_, but the spec allows it, and there's data that shows it, so we should handle visualizing it.