### PR TITLE
Allow setting page size

### DIFF
--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -1,3 +1,5 @@
+import sys
+
 import django_filters
 
 from django.contrib.gis.db.models.aggregates import Collect
@@ -64,7 +66,8 @@ def site_evaluations(request: HttpRequest):
 
     # Pagination
     assert api_settings.PAGE_SIZE, "PAGE_SIZE must be set."
-    paginator = Paginator(queryset, api_settings.PAGE_SIZE)
+    limit = int(request.GET.get("limit", api_settings.PAGE_SIZE)) or sys.maxsize
+    paginator = Paginator(queryset, limit)
     page = paginator.page(request.GET.get("page", 1))
 
     if page.has_next():


### PR DESCRIPTION
A limit of "0" results in essentially no limit. Rather than handling this as a completely separate case, I just default to a really big integer when providing a limit of "0". This results in a really small diff, but may be confusing later on. @mvandenburgh, let me know if you have a better way of doing this.