### PR TITLE
Fix sidebar scrolling

### DIFF
--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -125,13 +125,12 @@ watchEffect(loadMore);
 </script>
 
 <template>
-  <div class="h-4/5 overflow-y-scroll px-2" @scroll="handleScroll">
+  <div class="flex flex-col gap-2 overflow-y-scroll p-2" @scroll="handleScroll">
     <ModelRunDetail
       v-for="modelRun in modelRuns"
       :key="modelRun.key"
       :model-run="modelRun"
       :open="openedModelRuns.has(modelRun.key)"
-      class="mt-2"
       @toggle="() => handleToggle(modelRun)"
     />
   </div>

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -114,7 +114,7 @@ async function handleScroll(event: Event) {
   // If the user has scrolled to the bottom of the list AND there are still more model runs to
   // fetch, bump the current page to trigger the loadMore function via a watcher.
   if (
-    target.scrollHeight - target.scrollTop === target.clientHeight &&
+    target.scrollHeight - target.scrollTop <= target.clientHeight &&
     modelRuns.value.length < totalModelRuns.value
   ) {
     emit("nextPage");

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -56,23 +56,21 @@ function nextPage() {
 </script>
 
 <template>
-  <div class="relative">
-    <div class="fixed h-screen w-80 pt-2 pb-2 pl-2">
-      <div
-        class="relative h-full overflow-hidden rounded-xl bg-white drop-shadow-2xl"
-      >
-        <div
-          class="relative rounded-t-xl bg-gray-100 p-4 text-center text-sm font-light"
-        >
-          <img
-            class="mx-auto pb-4"
-            src="../assets/logo.svg"
-            alt="Resonant GeoData"
-            draggable="false"
-          />
-          <TimeSlider :min="timemin" :max="Math.floor(Date.now() / 1000)" />
-          {{ new Date(state.timestamp * 1000).toLocaleString() }}
-        </div>
+  <div class="fixed h-screen w-80 pt-2 pb-2 pl-2">
+    <div
+      class="flex h-full flex-col overflow-hidden rounded-xl bg-white drop-shadow-2xl"
+    >
+      <div class="bg-gray-100 p-4 text-center text-sm font-light">
+        <img
+          class="mx-auto pb-4"
+          src="../assets/logo.svg"
+          alt="Resonant GeoData"
+          draggable="false"
+        />
+        <TimeSlider :min="timemin" :max="Math.floor(Date.now() / 1000)" />
+        {{ new Date(state.timestamp * 1000).toLocaleString() }}
+      </div>
+      <div>
         <div
           class="flex flex-nowrap gap-2 overflow-x-scroll border-t border-gray-300 bg-gray-100 p-2"
         >
@@ -80,19 +78,20 @@ function nextPage() {
           <RegionFilter v-model="selectedRegion" />
           <FilterCheckBox v-model="groundTruth" label="Ground Truth" />
         </div>
-
-        <ModelRunList
-          :filters="queryFilters"
-          @next-page="nextPage"
-          @update:timerange="
-            (timerange) => {
-              if (timerange !== null) {
-                timemin = timerange.min;
-              }
-            }
-          "
-        />
       </div>
+
+      <ModelRunList
+        :filters="queryFilters"
+        class="basis-full"
+        @next-page="nextPage"
+        @update:timerange="
+          (timerange) => {
+            if (timerange !== null) {
+              timemin = timerange.min;
+            }
+          }
+        "
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Scrolling to the bottom of the list was possible, but extended beyond the screen. This PR switches to using Flexbox for the sidebar which seems to have a better handling of height calculation.

Before (scrolled to bottom) |  After (scrolled to bottom)
:-:|:-:
<img width="737" alt="before" src="https://user-images.githubusercontent.com/13244041/209986547-0e38721b-dc3e-44c7-a5cf-f07c3dbb2127.png">  | <img width="737" alt="after" src="https://user-images.githubusercontent.com/13244041/209986570-9c2d9c7a-b7b0-48c8-ba32-3a96a3888c23.png">


