### PR TITLE
UI Improvements

### DIFF
--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -70,6 +70,26 @@ async function loadMore() {
   emit("update:timerange", modelRunList["timerange"]);
 }
 
+/**
+ * Set the camera bounds/viewport based on the currently selected model run(s).
+ */
+function updateCameraBounds() {
+  const bounds = new LngLatBounds();
+  modelRuns.value
+    .filter((modelRun) => openedModelRuns.value.has(modelRun.key))
+    .forEach((modelRun) =>
+      modelRun.bbox?.coordinates
+        .flat()
+        .forEach((c) => bounds.extend(c as [number, number]))
+    );
+  state.bbox = {
+    xmin: bounds.getWest(),
+    ymin: bounds.getSouth(),
+    xmax: bounds.getEast(),
+    ymax: bounds.getNorth(),
+  };
+}
+
 function handleToggle(modelRun: KeyedModelRun) {
   if (openedModelRuns.value.has(modelRun.key)) {
     openedModelRuns.value.delete(modelRun.key);
@@ -78,20 +98,10 @@ function handleToggle(modelRun: KeyedModelRun) {
   }
 
   if (openedModelRuns.value.size > 0) {
-    const bounds = new LngLatBounds();
-    modelRuns.value
-      .filter((modelRun) => openedModelRuns.value.has(modelRun.key))
-      .forEach((modelRun) =>
-        modelRun.bbox?.coordinates
-          .flat()
-          .forEach((c) => bounds.extend(c as [number, number]))
-      );
-    state.bbox = {
-      xmin: bounds.getWest(),
-      ymin: bounds.getSouth(),
-      xmax: bounds.getEast(),
-      ymax: bounds.getNorth(),
-    };
+    // Only move camera if we're *not* currently filtering by region
+    if (!state.filters.region_id?.length) {
+      updateCameraBounds();
+    }
 
     const configurationIds: Set<number> = new Set();
     modelRuns.value

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -111,7 +111,6 @@ function handleToggle(modelRun: KeyedModelRun) {
       ...state.filters,
       configuration_id: Array.from(configurationIds),
     };
-    console.log(state.filters);
   } else {
     state.bbox = resultsBoundingBox.value;
     state.filters = {

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -2,7 +2,6 @@
 import ModelRunList from "./ModelRunList.vue";
 import TimeSlider from "./TimeSlider.vue";
 import PerformerFilter from "./filters/PerformerFilter.vue";
-import FilterCheckBox from "./FilterCheckBox.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
 import { state } from "../store";
 import { ref, watch } from "vue";
@@ -14,7 +13,6 @@ const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
 
 const selectedPerformer: Ref<Performer | null> = ref(null);
 const selectedRegion: Ref<Region | null> = ref(null);
-const groundTruth = ref(false);
 watch(selectedPerformer, (val) => {
   queryFilters.value = {
     ...queryFilters.value,
@@ -32,19 +30,6 @@ watch(selectedRegion, (val) => {
     ...state.filters,
     region_id: val?.id === undefined ? undefined : [val.id],
   };
-});
-watch(groundTruth, (val) => {
-  if (val) {
-    queryFilters.value = { ...queryFilters.value, groundtruth: true, page: 1 };
-    state.filters = { ...state.filters, groundtruth: true };
-  } else {
-    queryFilters.value = {
-      ...queryFilters.value,
-      groundtruth: undefined,
-      page: 1,
-    };
-    state.filters = { ...state.filters, groundtruth: undefined };
-  }
 });
 
 function nextPage() {
@@ -76,7 +61,6 @@ function nextPage() {
         >
           <PerformerFilter v-model="selectedPerformer" />
           <RegionFilter v-model="selectedRegion" />
-          <FilterCheckBox v-model="groundTruth" label="Ground Truth" />
         </div>
       </div>
 

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -3,6 +3,7 @@ import ModelRunList from "./ModelRunList.vue";
 import TimeSlider from "./TimeSlider.vue";
 import PerformerFilter from "./filters/PerformerFilter.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
+import FilterCheckBox from "./FilterCheckBox.vue";
 import { state } from "../store";
 import { ref, watch } from "vue";
 import type { Performer, QueryArguments, Region } from "../client";
@@ -13,6 +14,7 @@ const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
 
 const selectedPerformer: Ref<Performer | null> = ref(null);
 const selectedRegion: Ref<Region | null> = ref(null);
+const showSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   queryFilters.value = {
     ...queryFilters.value,
@@ -30,6 +32,9 @@ watch(selectedRegion, (val) => {
     ...state.filters,
     region_id: val?.id === undefined ? undefined : [val.id],
   };
+});
+watch(showSiteOutline, (val) => {
+  state.filters = { ...state.filters, showSiteOutline: val };
 });
 
 function nextPage() {
@@ -61,6 +66,7 @@ function nextPage() {
         >
           <PerformerFilter v-model="selectedPerformer" />
           <RegionFilter v-model="selectedRegion" />
+          <FilterCheckBox v-model="showSiteOutline" label="Site Outline" />
         </div>
       </div>
 

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -59,7 +59,7 @@ export const buildObservationFilter = (
 
   // Add any filters set in the UI
   Object.entries(filters).forEach(([key, value]) => {
-    if (value !== undefined && key !== "groundtruth") {
+    if (value !== undefined && typeof value === "string") {
       filter.push(["in", ["get", key], ["literal", value]]);
     }
   });
@@ -81,11 +81,12 @@ export const buildSiteFilter = (
       ],
     ],
     ["<=", ["get", "timemin"], timestamp],
+    ["literal", !!filters.showSiteOutline],
   ];
 
   // Add any filters set in the UI
   Object.entries(filters).forEach(([key, value]) => {
-    if (value !== undefined && key !== "groundtruth") {
+    if (value !== undefined && typeof value === "string") {
       filter.push(["in", ["get", key], ["literal", value]]);
     }
   });

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -41,6 +41,14 @@ export const buildObservationFilter = (
 ): FilterSpecification => {
   const filter: FilterSpecification = [
     "all",
+    [
+      "in",
+      ["get", "configuration_id"],
+      [
+        "literal",
+        filters.configuration_id?.length ? filters.configuration_id : [""],
+      ],
+    ],
     ["<=", ["get", "timemin"], timestamp],
     [
       "any",
@@ -72,6 +80,14 @@ export const buildSiteFilter = (
 ): FilterSpecification => {
   const filter: FilterSpecification = [
     "all",
+    [
+      "in",
+      ["get", "configuration_id"],
+      [
+        "literal",
+        filters.configuration_id?.length ? filters.configuration_id : [""],
+      ],
+    ],
     ["<=", ["get", "timemin"], timestamp],
   ];
 

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -60,15 +60,7 @@ export const buildObservationFilter = (
   // Add any filters set in the UI
   Object.entries(filters).forEach(([key, value]) => {
     if (value !== undefined && key !== "groundtruth") {
-      filter.push(
-        filters.groundtruth === undefined
-          ? ["in", ["get", key], ["literal", value]]
-          : [
-              "any",
-              ["in", ["get", key], ["literal", value]],
-              ["get", "groundtruth"],
-            ]
-      );
+      filter.push(["in", ["get", key], ["literal", value]]);
     }
   });
   return filter;
@@ -94,15 +86,7 @@ export const buildSiteFilter = (
   // Add any filters set in the UI
   Object.entries(filters).forEach(([key, value]) => {
     if (value !== undefined && key !== "groundtruth") {
-      filter.push(
-        filters.groundtruth === undefined
-          ? ["in", ["get", key], ["literal", value]]
-          : [
-              "any",
-              ["in", ["get", key], ["literal", value]],
-              ["get", "groundtruth"],
-            ]
-      );
+      filter.push(["in", ["get", key], ["literal", value]]);
     }
   });
 

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -4,6 +4,7 @@ export interface MapFilters {
   configuration_id?: number[];
   performer_id?: number[];
   region_id?: number[];
+  showSiteOutline?: boolean;
 }
 
 export const state = reactive<{

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -4,7 +4,6 @@ export interface MapFilters {
   configuration_id?: number[];
   performer_id?: number[];
   region_id?: number[];
-  groundtruth?: boolean;
 }
 
 export const state = reactive<{


### PR DESCRIPTION
Changes in this PR:

- Currently, when no model runs are selected in the UI, we render the tiles for _all_ of them. This PR changes this behavior to only render tiles for the selected model runs; i.e. if no model runs are selected, no tiles will be rendered.
- Remove the "Ground Truth" toggle. We discussed removing this before because it causes a lot of confusion and doesn't always make sense. Instead, the user can simply toggle the "Ground Truth" model run on/off in sidebar.
- _If a region is currently selected_, don't do any camera zooming when model runs are selected/deselected.
- Add UI toggle for "Site Outlines", and turn it off by default.