### PR TITLE
Fix performance issue in ModelRun listing endpoint

### DIFF
--- a/vue/src/client/models/ModelRunList.ts
+++ b/vue/src/client/models/ModelRunList.ts
@@ -8,6 +8,6 @@ export type ModelRunList = {
     min: number;
     max: number;
   };
-  bbox: GeoJSON.Polygon;
+  bbox: GeoJSON.Polygon | null;
   results: ModelRun[];
 };

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -46,18 +46,21 @@ async function loadMore() {
     };
   });
 
-  const bounds = new LngLatBounds();
-  modelRunList.bbox.coordinates
-    .flat()
-    .forEach((c) => bounds.extend(c as [number, number]));
-  const bbox = {
-    xmin: bounds.getWest(),
-    ymin: bounds.getSouth(),
-    xmax: bounds.getEast(),
-    ymax: bounds.getNorth(),
-  };
-  resultsBoundingBox.value = bbox;
-  state.bbox = bbox;
+  // If a bounding box was provided for this model run list, zoom the camera to it.
+  if (modelRunList.bbox) {
+    const bounds = new LngLatBounds();
+    modelRunList.bbox.coordinates
+      .flat()
+      .forEach((c) => bounds.extend(c as [number, number]));
+    const bbox = {
+      xmin: bounds.getWest(),
+      ymin: bounds.getSouth(),
+      xmax: bounds.getEast(),
+      ymax: bounds.getNorth(),
+    };
+    resultsBoundingBox.value = bbox;
+    state.bbox = bbox;
+  }
 
   // If we're on page 1, we *might* have switched to a different filter/grouping in the UI,
   // meaning we would need to clear out any existing results.


### PR DESCRIPTION
This attempts to limit the amount of polygons that we're asking PostGIS to dynamically calculate a bounding box for in the model runs listing endpoint. If the user doesn't supply a region to filter by, the server will now *not* send back a bounding box to avoid an expensive PostGIS query across every polygon in the system.