### PR TITLE
Environment Variable Tile Server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,6 @@ services:
   # RD-WATCH
   rdwatch:
     image: ghcr.io/resonantgeodata/rd-watch/rdwatch:latest
-    build: 
-      context: '.'
     depends_on:
       - postgresql
       - redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
   # RD-WATCH
   rdwatch:
     image: ghcr.io/resonantgeodata/rd-watch/rdwatch:latest
+    build: 
+      context: '.'
     depends_on:
       - postgresql
       - redis
@@ -19,6 +21,7 @@ services:
       RDWATCH_REDIS_URI: ${RDWATCH_REDIS_URI:?}
       RDWATCH_SMART_STAC_URL: ${RDWATCH_SMART_STAC_URL:?}
       RDWATCH_SMART_STAC_KEY: ${RDWATCH_SMART_STAC_KEY:?}
+      VITE_TILE_SERVER_URL: ${VITE_TILE_SERVER_URL:?}
     ports:
       - 8000:80
 
@@ -56,6 +59,7 @@ services:
     entrypoint: npm
     environment:
       RDWATCH_FILE_POLLING: ${RDWATCH_FILE_POLLING:?}
+      VITE_TILE_SERVER_URL: ${VITE_TILE_SERVER_URL:?}
     ports:
       - 9000:9000
     profiles:

--- a/template.env
+++ b/template.env
@@ -45,4 +45,4 @@ AWS_SECRET_ACCESS_KEY=
 RDWATCH_FILE_POLLING=
 
 # This needs to be set for the build process of the front-end
-VITE_TILE_SERVER_URL="https://tiles.mcovalt.com"
+VITE_TILE_SERVER_URL="https://basemap.kitware.watch"

--- a/template.env
+++ b/template.env
@@ -43,3 +43,6 @@ AWS_SECRET_ACCESS_KEY=
 # to check for project file changes. Docker in WSL
 # and macOS will need to use this. Set to "1" to enable.
 RDWATCH_FILE_POLLING=
+
+# This needs to be set for the build process of the front-end
+VITE_TILE_SERVER_URL="https://tiles.mcovalt.com"

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./rdwatchtiles";
 import type { StyleSpecification } from "maplibre-gl";
 
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
 export const style = (
   timestamp: number,
   filters: Record<string, number>
@@ -22,8 +23,8 @@ export const style = (
     ...openmaptilesSources,
     ...rdwatchtilesSources,
   },
-  sprite: "https://tiles.mcovalt.com/sprites/osm-liberty",
-  glyphs: "https://tiles.mcovalt.com/fonts/{fontstack}/{range}.pbf",
+  sprite: `${tileServerURL}/sprites/osm-liberty`,
+  glyphs: `${tileServerURL}/fonts/{fontstack}/{range}.pbf`,
   layers: [
     {
       id: "background",

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -12,7 +12,7 @@ import {
 } from "./rdwatchtiles";
 import type { StyleSpecification } from "maplibre-gl";
 
-const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL || 'https://basemap.kitware.watch'
 export const style = (
   timestamp: number,
   filters: Record<string, number>

--- a/vue/src/mapstyle/naturalearth.ts
+++ b/vue/src/mapstyle/naturalearth.ts
@@ -5,7 +5,7 @@
 import type { LayerSpecification, SourceSpecification } from "maplibre-gl";
 
 const naturalearth = "naturalearth";
-const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL || 'https://basemap.kitware.watch'
 const source: SourceSpecification = {
   maxzoom: 6,
   tileSize: 256,

--- a/vue/src/mapstyle/naturalearth.ts
+++ b/vue/src/mapstyle/naturalearth.ts
@@ -5,11 +5,11 @@
 import type { LayerSpecification, SourceSpecification } from "maplibre-gl";
 
 const naturalearth = "naturalearth";
-
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
 const source: SourceSpecification = {
   maxzoom: 6,
   tileSize: 256,
-  tiles: ["https://tiles.mcovalt.com/raster/{z}/{x}/{y}.webp"],
+  tiles: [`${tileServerURL}/raster/{z}/{x}/{y}.webp`],
   type: "raster",
 };
 export const sources = { naturalearth: source };

--- a/vue/src/mapstyle/openmaptiles.ts
+++ b/vue/src/mapstyle/openmaptiles.ts
@@ -5,7 +5,7 @@
 import type { LayerSpecification, SourceSpecification } from "maplibre-gl";
 
 const openmaptiles = "openmaptiles";
-const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL || 'https://basemap.kitware.watch'
 
 const source: SourceSpecification = {
   type: "vector",

--- a/vue/src/mapstyle/openmaptiles.ts
+++ b/vue/src/mapstyle/openmaptiles.ts
@@ -5,10 +5,11 @@
 import type { LayerSpecification, SourceSpecification } from "maplibre-gl";
 
 const openmaptiles = "openmaptiles";
+const tileServerURL = import.meta.env.VITE_TILE_SERVER_URL
 
 const source: SourceSpecification = {
   type: "vector",
-  tiles: ["https://tiles.mcovalt.com/vector/{z}/{x}/{y}.pbf"],
+  tiles: [`${tileServerURL}/vector/{z}/{x}/{y}.pbf`],
   minzoom: 0,
   maxzoom: 14,
   attribution:

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => {
       port: 9000,
       proxy: {
         "/api": {
-          target: "http://localhost:8000",
+          target: "http://django:80",
           xfwd: true,
         },
       },

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => {
       port: 9000,
       proxy: {
         "/api": {
-          target: "http://django:80",
+          target: "http://localhost:8000",
           xfwd: true,
         },
       },


### PR DESCRIPTION
Switches the front-end to using an environment variable for the tile server instead of the hardcoded URLS.

Note this will need to be set during the build process so that the production build has the proper variable.
I made it default to the new URL if it can't find the env anyways.
ALSO:
```
VITE_TILE_SERVER_URL="https://basemap.kitware.watch"
```
Will need to be added to the .env file.
