### PR TITLE
Reset Configuration Ids when Perform/Region filter changes.

### DIFF
--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ModelRunDetail from "./ModelRunDetail.vue";
 import type { ModelRun, QueryArguments } from "../client";
-import { ref, watchEffect } from "vue";
+import { ref, watch, watchEffect } from "vue";
 import type { Ref } from "vue";
 import { ApiService } from "../client";
 import { state } from "../store";
@@ -138,6 +138,14 @@ async function handleScroll(event: Event) {
 }
 
 watchEffect(loadMore);
+watch([() => props.filters.region, ()=> props.filters.performer], () => {
+  openedModelRuns.value.clear();
+  state.filters = {
+      ...state.filters,
+      configuration_id: [],
+    };
+
+})
 </script>
 
 <template>

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -61,6 +61,14 @@ async function loadMore() {
     };
     resultsBoundingBox.value = bbox;
     state.bbox = bbox;
+  } else {
+    const bbox = {
+      xmin: -180,
+      ymin: -90,
+      xmax: 180,
+      ymax: 90,
+    };
+    state.bbox = bbox;
   }
 
   // If we're on page 1, we *might* have switched to a different filter/grouping in the UI,
@@ -141,10 +149,9 @@ watchEffect(loadMore);
 watch([() => props.filters.region, ()=> props.filters.performer], () => {
   openedModelRuns.value.clear();
   state.filters = {
-      ...state.filters,
-      configuration_id: [],
-    };
-
+    ...state.filters,
+    configuration_id: [],
+  };
 })
 </script>
 


### PR DESCRIPTION
The previous issue can be replicated by (on previous code):

Loading the dataset:
Select any region and then select the first model run in that region.
Next clear the region filter using the X in the dropdown and then select any model run which isn't the same as step 1.
Toggling off and on other regions will now cause the camera to get into a weird state where it may not properly zoom out to the entire world or zoom in the proper region.

The update will clear out the list each time the performer/region is changed.  This means each time the filter is updated you start from the beginning.  So the zooming and state shouldn't get into its weird state.
