### PR TITLE
Improved ingest error messages

### DIFF
--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -256,6 +256,23 @@ python-versions = ">=3.7"
 Django = ">=3.2"
 
 [[package]]
+name = "django-ninja"
+version = "0.21.0"
+description = "Django Ninja - Fast Django REST framework"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+Django = ">=2.2"
+pydantic = ">=1.6,<2.0.0"
+
+[package.extras]
+dev = ["pre-commit"]
+doc = ["mkdocs", "mkdocs-material", "markdown-include", "mkdocstrings"]
+test = ["pytest", "pytest-cov", "pytest-django", "pytest-asyncio", "psycopg2-binary", "black", "isort", "flake8", "mypy (==0.931)", "django-stubs"]
+
+[[package]]
 name = "django-redis"
 version = "5.2.0"
 description = "Full featured redis cache backend for Django."
@@ -685,7 +702,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pydantic"
-version = "1.10.5"
+version = "1.10.6"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
@@ -1077,7 +1094,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10.0"
-content-hash = "74da5022d8a46de6b112ef64b838b6f4945ceb328120390e4d590627b45df643"
+content-hash = "fdb9e7f5935752591c2fee32d427935a63941e0f6265e83a00c74dba3236798f"
 
 [metadata.files]
 affine = [
@@ -1270,6 +1287,10 @@ django = [
 django-filter = [
     {file = "django-filter-22.1.tar.gz", hash = "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"},
     {file = "django_filter-22.1-py3-none-any.whl", hash = "sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb"},
+]
+django-ninja = [
+    {file = "django-ninja-0.21.0.tar.gz", hash = "sha256:3ed90fc55877408d5c42ec3d3cec8384c9a0cc7adf2cd66d6669561bed10a485"},
+    {file = "django_ninja-0.21.0-py3-none-any.whl", hash = "sha256:b6ed7647212a4647682b134a6f82277ecf02e9d99960777aa75d124685682d25"},
 ]
 django-redis = [
     {file = "django-redis-5.2.0.tar.gz", hash = "sha256:8a99e5582c79f894168f5865c52bd921213253b7fd64d16733ae4591564465de"},
@@ -1649,42 +1670,42 @@ pycodestyle = [
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
 ]
 pydantic = [
-    {file = "pydantic-1.10.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5920824fe1e21cbb3e38cf0f3dd24857c8959801d1031ce1fac1d50857a03bfb"},
-    {file = "pydantic-1.10.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3bb99cf9655b377db1a9e47fa4479e3330ea96f4123c6c8200e482704bf1eda2"},
-    {file = "pydantic-1.10.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2185a3b3d98ab4506a3f6707569802d2d92c3a7ba3a9a35683a7709ea6c2aaa2"},
-    {file = "pydantic-1.10.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f582cac9d11c227c652d3ce8ee223d94eb06f4228b52a8adaafa9fa62e73d5c9"},
-    {file = "pydantic-1.10.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c9e5b778b6842f135902e2d82624008c6a79710207e28e86966cd136c621bfee"},
-    {file = "pydantic-1.10.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:72ef3783be8cbdef6bca034606a5de3862be6b72415dc5cb1fb8ddbac110049a"},
-    {file = "pydantic-1.10.5-cp310-cp310-win_amd64.whl", hash = "sha256:45edea10b75d3da43cfda12f3792833a3fa70b6eee4db1ed6aed528cef17c74e"},
-    {file = "pydantic-1.10.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:63200cd8af1af2c07964546b7bc8f217e8bda9d0a2ef0ee0c797b36353914984"},
-    {file = "pydantic-1.10.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:305d0376c516b0dfa1dbefeae8c21042b57b496892d721905a6ec6b79494a66d"},
-    {file = "pydantic-1.10.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fd326aff5d6c36f05735c7c9b3d5b0e933b4ca52ad0b6e4b38038d82703d35b"},
-    {file = "pydantic-1.10.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6bb0452d7b8516178c969d305d9630a3c9b8cf16fcf4713261c9ebd465af0d73"},
-    {file = "pydantic-1.10.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:9a9d9155e2a9f38b2eb9374c88f02fd4d6851ae17b65ee786a87d032f87008f8"},
-    {file = "pydantic-1.10.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f836444b4c5ece128b23ec36a446c9ab7f9b0f7981d0d27e13a7c366ee163f8a"},
-    {file = "pydantic-1.10.5-cp311-cp311-win_amd64.whl", hash = "sha256:8481dca324e1c7b715ce091a698b181054d22072e848b6fc7895cd86f79b4449"},
-    {file = "pydantic-1.10.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:87f831e81ea0589cd18257f84386bf30154c5f4bed373b7b75e5cb0b5d53ea87"},
-    {file = "pydantic-1.10.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ce1612e98c6326f10888df951a26ec1a577d8df49ddcaea87773bfbe23ba5cc"},
-    {file = "pydantic-1.10.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58e41dd1e977531ac6073b11baac8c013f3cd8706a01d3dc74e86955be8b2c0c"},
-    {file = "pydantic-1.10.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6a4b0aab29061262065bbdede617ef99cc5914d1bf0ddc8bcd8e3d7928d85bd6"},
-    {file = "pydantic-1.10.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:36e44a4de37b8aecffa81c081dbfe42c4d2bf9f6dff34d03dce157ec65eb0f15"},
-    {file = "pydantic-1.10.5-cp37-cp37m-win_amd64.whl", hash = "sha256:261f357f0aecda005934e413dfd7aa4077004a174dafe414a8325e6098a8e419"},
-    {file = "pydantic-1.10.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b429f7c457aebb7fbe7cd69c418d1cd7c6fdc4d3c8697f45af78b8d5a7955760"},
-    {file = "pydantic-1.10.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:663d2dd78596c5fa3eb996bc3f34b8c2a592648ad10008f98d1348be7ae212fb"},
-    {file = "pydantic-1.10.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51782fd81f09edcf265823c3bf43ff36d00db246eca39ee765ef58dc8421a642"},
-    {file = "pydantic-1.10.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c428c0f64a86661fb4873495c4fac430ec7a7cef2b8c1c28f3d1a7277f9ea5ab"},
-    {file = "pydantic-1.10.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:76c930ad0746c70f0368c4596020b736ab65b473c1f9b3872310a835d852eb19"},
-    {file = "pydantic-1.10.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3257bd714de9db2102b742570a56bf7978e90441193acac109b1f500290f5718"},
-    {file = "pydantic-1.10.5-cp38-cp38-win_amd64.whl", hash = "sha256:f5bee6c523d13944a1fdc6f0525bc86dbbd94372f17b83fa6331aabacc8fd08e"},
-    {file = "pydantic-1.10.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:532e97c35719f137ee5405bd3eeddc5c06eb91a032bc755a44e34a712420daf3"},
-    {file = "pydantic-1.10.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ca9075ab3de9e48b75fa8ccb897c34ccc1519177ad8841d99f7fd74cf43be5bf"},
-    {file = "pydantic-1.10.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd46a0e6296346c477e59a954da57beaf9c538da37b9df482e50f836e4a7d4bb"},
-    {file = "pydantic-1.10.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3353072625ea2a9a6c81ad01b91e5c07fa70deb06368c71307529abf70d23325"},
-    {file = "pydantic-1.10.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3f9d9b2be177c3cb6027cd67fbf323586417868c06c3c85d0d101703136e6b31"},
-    {file = "pydantic-1.10.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b473d00ccd5c2061fd896ac127b7755baad233f8d996ea288af14ae09f8e0d1e"},
-    {file = "pydantic-1.10.5-cp39-cp39-win_amd64.whl", hash = "sha256:5f3bc8f103b56a8c88021d481410874b1f13edf6e838da607dcb57ecff9b4594"},
-    {file = "pydantic-1.10.5-py3-none-any.whl", hash = "sha256:7c5b94d598c90f2f46b3a983ffb46ab806a67099d118ae0da7ef21a2a4033b28"},
-    {file = "pydantic-1.10.5.tar.gz", hash = "sha256:9e337ac83686645a46db0e825acceea8e02fca4062483f40e9ae178e8bd1103a"},
+    {file = "pydantic-1.10.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f9289065611c48147c1dd1fd344e9d57ab45f1d99b0fb26c51f1cf72cd9bcd31"},
+    {file = "pydantic-1.10.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8c32b6bba301490d9bb2bf5f631907803135e8085b6aa3e5fe5a770d46dd0160"},
+    {file = "pydantic-1.10.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd9b9e98068fa1068edfc9eabde70a7132017bdd4f362f8b4fd0abed79c33083"},
+    {file = "pydantic-1.10.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c84583b9df62522829cbc46e2b22e0ec11445625b5acd70c5681ce09c9b11c4"},
+    {file = "pydantic-1.10.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b41822064585fea56d0116aa431fbd5137ce69dfe837b599e310034171996084"},
+    {file = "pydantic-1.10.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:61f1f08adfaa9cc02e0cbc94f478140385cbd52d5b3c5a657c2fceb15de8d1fb"},
+    {file = "pydantic-1.10.6-cp310-cp310-win_amd64.whl", hash = "sha256:32937835e525d92c98a1512218db4eed9ddc8f4ee2a78382d77f54341972c0e7"},
+    {file = "pydantic-1.10.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bbd5c531b22928e63d0cb1868dee76123456e1de2f1cb45879e9e7a3f3f1779b"},
+    {file = "pydantic-1.10.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e277bd18339177daa62a294256869bbe84df1fb592be2716ec62627bb8d7c81d"},
+    {file = "pydantic-1.10.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f15277d720aa57e173954d237628a8d304896364b9de745dcb722f584812c7"},
+    {file = "pydantic-1.10.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b243b564cea2576725e77aeeda54e3e0229a168bc587d536cd69941e6797543d"},
+    {file = "pydantic-1.10.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3ce13a558b484c9ae48a6a7c184b1ba0e5588c5525482681db418268e5f86186"},
+    {file = "pydantic-1.10.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3ac1cd4deed871dfe0c5f63721e29debf03e2deefa41b3ed5eb5f5df287c7b70"},
+    {file = "pydantic-1.10.6-cp311-cp311-win_amd64.whl", hash = "sha256:b1eb6610330a1dfba9ce142ada792f26bbef1255b75f538196a39e9e90388bf4"},
+    {file = "pydantic-1.10.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4ca83739c1263a044ec8b79df4eefc34bbac87191f0a513d00dd47d46e307a65"},
+    {file = "pydantic-1.10.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea4e2a7cb409951988e79a469f609bba998a576e6d7b9791ae5d1e0619e1c0f2"},
+    {file = "pydantic-1.10.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53de12b4608290992a943801d7756f18a37b7aee284b9ffa794ee8ea8153f8e2"},
+    {file = "pydantic-1.10.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:60184e80aac3b56933c71c48d6181e630b0fbc61ae455a63322a66a23c14731a"},
+    {file = "pydantic-1.10.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:415a3f719ce518e95a92effc7ee30118a25c3d032455d13e121e3840985f2efd"},
+    {file = "pydantic-1.10.6-cp37-cp37m-win_amd64.whl", hash = "sha256:72cb30894a34d3a7ab6d959b45a70abac8a2a93b6480fc5a7bfbd9c935bdc4fb"},
+    {file = "pydantic-1.10.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3091d2eaeda25391405e36c2fc2ed102b48bac4b384d42b2267310abae350ca6"},
+    {file = "pydantic-1.10.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:751f008cd2afe812a781fd6aa2fb66c620ca2e1a13b6a2152b1ad51553cb4b77"},
+    {file = "pydantic-1.10.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12e837fd320dd30bd625be1b101e3b62edc096a49835392dcf418f1a5ac2b832"},
+    {file = "pydantic-1.10.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:587d92831d0115874d766b1f5fddcdde0c5b6c60f8c6111a394078ec227fca6d"},
+    {file = "pydantic-1.10.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:476f6674303ae7965730a382a8e8d7fae18b8004b7b69a56c3d8fa93968aa21c"},
+    {file = "pydantic-1.10.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3a2be0a0f32c83265fd71a45027201e1278beaa82ea88ea5b345eea6afa9ac7f"},
+    {file = "pydantic-1.10.6-cp38-cp38-win_amd64.whl", hash = "sha256:0abd9c60eee6201b853b6c4be104edfba4f8f6c5f3623f8e1dba90634d63eb35"},
+    {file = "pydantic-1.10.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6195ca908045054dd2d57eb9c39a5fe86409968b8040de8c2240186da0769da7"},
+    {file = "pydantic-1.10.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:43cdeca8d30de9a897440e3fb8866f827c4c31f6c73838e3a01a14b03b067b1d"},
+    {file = "pydantic-1.10.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c19eb5163167489cb1e0161ae9220dadd4fc609a42649e7e84a8fa8fff7a80f"},
+    {file = "pydantic-1.10.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:012c99a9c0d18cfde7469aa1ebff922e24b0c706d03ead96940f5465f2c9cf62"},
+    {file = "pydantic-1.10.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:528dcf7ec49fb5a84bf6fe346c1cc3c55b0e7603c2123881996ca3ad79db5bfc"},
+    {file = "pydantic-1.10.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:163e79386c3547c49366e959d01e37fc30252285a70619ffc1b10ede4758250a"},
+    {file = "pydantic-1.10.6-cp39-cp39-win_amd64.whl", hash = "sha256:189318051c3d57821f7233ecc94708767dd67687a614a4e8f92b4a020d4ffd06"},
+    {file = "pydantic-1.10.6-py3-none-any.whl", hash = "sha256:acc6783751ac9c9bc4680379edd6d286468a1dc8d7d9906cd6f1186ed682b2b0"},
+    {file = "pydantic-1.10.6.tar.gz", hash = "sha256:cf95adb0d1671fc38d8c43dd921ad5814a735e7d9b4d9e437c088002863854fd"},
 ]
 pyflakes = [
     {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -33,7 +33,7 @@ rio-tiler = "^3.1.6"
 mercantile = "^1.2.1"
 django-filter = "^22.1"
 django-redis = "^5.2.0"
-pydantic = "^1.10.5"
+django-ninja = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 black = "~22.6.0"

--- a/django/src/rdwatch/api.py
+++ b/django/src/rdwatch/api.py
@@ -1,0 +1,3 @@
+from ninja import NinjaAPI
+
+api = NinjaAPI()

--- a/django/src/rdwatch/api.py
+++ b/django/src/rdwatch/api.py
@@ -1,3 +1,7 @@
 from ninja import NinjaAPI
 
+from .views.site_model import router as site_model_router
+
 api = NinjaAPI()
+
+api.add_router('/model-runs/', site_model_router)

--- a/django/src/rdwatch/schemas/region_model.py
+++ b/django/src/rdwatch/schemas/region_model.py
@@ -3,12 +3,13 @@ import json
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, constr, validator
+from ninja import Schema
+from pydantic import constr, validator
 
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 
 
-class RegionFeature(BaseModel):
+class RegionFeature(Schema):
     type: Literal['region']
     region_id: constr(regex=r'^[A-Z]{2}_[RCST]\d{3}$')
     version: str | None
@@ -41,7 +42,7 @@ class RegionFeature(BaseModel):
         return datetime.strptime(v, '%Y-%m-%d')
 
 
-class SiteSummaryFeature(BaseModel):
+class SiteSummaryFeature(Schema):
     type: Literal['site_summary']
     site_id: constr(regex=r'^[A-Z]{2}_[RCST]\d{3}_\d{4}$')
     version: str | None
@@ -95,7 +96,7 @@ class SiteSummaryFeature(BaseModel):
         return int(self.site_id[8:])
 
 
-class Feature(BaseModel):
+class Feature(Schema):
     class Config:
         arbitrary_types_allowed = True
 
@@ -111,7 +112,7 @@ class Feature(BaseModel):
         return geom
 
 
-class RegionModel(BaseModel):
+class RegionModel(Schema):
     type: Literal['FeatureCollection']
     features: list[Feature]
 

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from ninja import Schema
 from pydantic import constr, validator
 
+from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry
 
 
@@ -116,7 +117,10 @@ class Feature(Schema):
 
     @validator('geometry', pre=True)
     def parse_geometry(cls, v: dict[str, Any]):
-        return GEOSGeometry(json.dumps(v))
+        try:
+            return GEOSGeometry(json.dumps(v))
+        except GDALException:
+            raise ValueError('Failed to parse geometry.')
 
     @validator('geometry')
     def ensure_correct_geometry_type(cls, v: GEOSGeometry, values: dict[str, Any]):

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -3,12 +3,13 @@ import json
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, constr, validator
+from ninja import Schema
+from pydantic import constr, validator
 
 from django.contrib.gis.geos import GEOSGeometry
 
 
-class SiteFeature(BaseModel):
+class SiteFeature(Schema):
     type: Literal['site']
     region_id: constr(regex=r'^[A-Z]{2}_[RCST][\dx]{3}$')
     site_id: str
@@ -67,7 +68,7 @@ class SiteFeature(BaseModel):
         return int(self.site_id[8:])
 
 
-class ObservationFeature(BaseModel):
+class ObservationFeature(Schema):
     type: Literal['observation']
     observation_date: datetime | None
     source: str | None
@@ -105,7 +106,7 @@ class ObservationFeature(BaseModel):
     misc_info: dict[Any, Any] | None
 
 
-class Feature(BaseModel):
+class Feature(Schema):
     class Config:
         arbitrary_types_allowed = True
 
@@ -129,7 +130,7 @@ class Feature(BaseModel):
         return v
 
 
-class SiteModel(BaseModel):
+class SiteModel(Schema):
     type: Literal['FeatureCollection']
     features: list[Feature]
 

--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -39,8 +39,6 @@ urlpatterns = [
         views.satelliteimage_visual_tile,
         name='satellite-visual-tiles',
     ),
-    path('model-runs/<int:hyper_parameters_id>/site-model', views.post_site_model),
-    path('model-runs/<int:hyper_parameters_id>/region-model', views.post_region_model),
 ]
 
 urlpatterns += router.urls

--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -4,6 +4,7 @@ from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.schemas import get_schema_view
 
 from rdwatch import views
+from rdwatch.api import api
 
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'model-runs', views.ModelRunViewSet, basename='model-runs')
@@ -11,6 +12,7 @@ router.register(r'performers', views.PerformerViewSet, basename='performers')
 router.register(r'regions', views.RegionViewSet, basename='regions')
 
 urlpatterns = [
+    path('', api.urls),
     path(
         'openapi.json',
         get_schema_view(

--- a/django/src/rdwatch/views/site_model.py
+++ b/django/src/rdwatch/views/site_model.py
@@ -1,36 +1,31 @@
-from django.core.exceptions import ObjectDoesNotExist
-from rest_framework.decorators import api_view
-from rest_framework.exceptions import ValidationError
-from rest_framework.request import Request
-from rest_framework.response import Response
+from ninja import Router
+
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404
 
 from rdwatch.models import HyperParameters, SiteEvaluation
 from rdwatch.schemas import RegionModel, SiteModel
 
+router = Router()
 
-@api_view(['POST'])
-def post_site_model(request: Request, hyper_parameters_id: int):
-    try:
-        hyper_parameters = HyperParameters.objects.get(pk=hyper_parameters_id)
-    except ObjectDoesNotExist:
-        raise ValidationError(f"unkown model-run ID: '{hyper_parameters_id}'")
 
-    site_model = SiteModel(**request.data)
-
+@router.post('/{hyper_parameters_id}/site-model')
+def post_site_model(
+    request: HttpRequest,
+    hyper_parameters_id: int,
+    site_model: SiteModel,
+):
+    hyper_parameters = get_object_or_404(HyperParameters, pk=hyper_parameters_id)
     SiteEvaluation.bulk_create_from_site_model(site_model, hyper_parameters)
+    return 201
 
-    return Response(status=201)
 
-
-@api_view(['POST'])
-def post_region_model(request: Request, hyper_parameters_id: int):
-    try:
-        hyper_parameters = HyperParameters.objects.get(pk=hyper_parameters_id)
-    except ObjectDoesNotExist:
-        raise ValidationError(f"unknown model-run ID: '{hyper_parameters_id}'")
-
-    region_model = RegionModel(**request.data)
-
+@router.post('/{hyper_parameters_id}/region-model')
+def post_region_model(
+    request: HttpRequest,
+    hyper_parameters_id: int,
+    region_model: RegionModel,
+):
+    hyper_parameters = get_object_or_404(HyperParameters, pk=hyper_parameters_id)
     SiteEvaluation.bulk_create_from_from_region_model(region_model, hyper_parameters)
-
-    return Response(status=201)
+    return 201


### PR DESCRIPTION
Currently, the ingest API returns 500 errors if an invalid site or region model JSON is posted. To fix this, we could catch these errors, format them in a useful way, and send them back in the endpoint response.

There's also another option. We're currently using `pydantic` to parse and validate these JSONs. `django-ninja` uses pydantic models for request/response serialization, and will automatically handle validation errors and send back an appropriate response for us, without needing any manual exception handling. So, I used this as an opportunity to convert the two ingest endpoints from DRF to django-ninja. The nice thing is that the rest of the endpoints can continue to use DRF or Django views, and we can convert those piecemeal over to `django-ninja` when we have time.

With these changes, an error message like this will be returned when, for example, a required field is missing in the site/region model:
```
{
  "detail": [
    {
      "loc": [
        "body",
        "site_model",
        "features",
        1,
        "geometry"
      ],
      "msg": "field required",
      "type": "value_error.missing"
    }
  ]
}
```

(This error indicates that the 2nd element in the site model's `features` array is missing the `geometry` field)