### PR TITLE
Configure `pytest` and add test for ingest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ env:
   DJANGO_SETTINGS_MODULE: rdwatch.server.settings
   RDWATCH_SECRET_KEY: ff07f533a59fed1349a4fc49941d02ff22514f6dbf6086a44ea0c0a8952e8644
   RDWATCH_POSTGRESQL_URI: postgresql://rdwatch:ff07f533a59fed1349a4fc49941d02ff22514f6dbf6086a44ea0c0a8952e8644@localhost:5432/rdwatch
-  RDWATCH_REDIS_URI: redis://rdwatch:ff07f533a59fed1349a4fc49941d02ff22514f6dbf6086a44ea0c0a8952e8644@localhost:6379/rdwatch
+  RDWATCH_REDIS_URI: redis://localhost:6379/rdwatch
   RDWATCH_DJANGO_DEBUG: 0
 jobs:
   lint-python:
@@ -58,13 +58,15 @@ jobs:
         tox-env: [test, check-migrations]
     services:
       postgres:
-        image: ghcr.io/resonantgeodata/rd-watch/postgresql:latest
+        image: postgis/postgis:latest
         env:
+          POSTGRES_DB: rdwatch
+          POSTGRES_USER: rdwatch
           POSTGRES_PASSWORD: ${{ env.RDWATCH_SECRET_KEY }}
+        ports:
+          - 5432:5432
       redis:
-        image: ghcr.io/resonantgeodata/rd-watch/redis:latest
-        env:
-          RDWATCH_SECRET_KEY: ${{ env.RDWATCH_SECRET_KEY }}
+        image: redis:latest
     steps:
       - name: Install system dependencies
         run: apt-fast install --no-install-recommends --yes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,6 @@ Two ports will be open:
 
 - [`django-admin`](https://docs.djangoproject.com/en/4.1/ref/django-admin) commands:
   - e.g. run migrations: `docker compose run --rm poetry run django-admin migrate`
-  - e.g. run tests: `docker compose run --rm poetry run django-admin test`
 - `npm` commands and scripts (see [`scripts` in `package.json`](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/vue/package.json#L5)):
   - e.g. lint and fix code: `docker compose run --rm npm run lint:fix`
   - e.g. run tests: `docker compose run --rm npm run test`
@@ -33,6 +32,7 @@ Two ports will be open:
   - e.g. lint and fix code: `docker compose run --rm poetry run task lint:fix`
   - e.g. build the OpenAPI spec: `docker compose run --rm poetry run task build:openapi`
   - e.g. install a package: `docker compose run --rm poetry add some-pacakge`
+  - e.g. run tests: `docker compose run --rm poetry run task test`
 
 ### Type support for ".vue" imports in VS Code
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@ Get up and running with the recommended development setup. It's advised to devel
 
 1. Make a copy of the file ["template.env"](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/template.env) as ".env" and fill it out
 2. Pull in the Docker images: `docker compose --profile vscode pull`
-3. Install the dependencies for Django: `docker compose run --rm poetry install`
+3. Install the dependencies for Django: `docker compose run --rm poetry install --all-extras`
 4. Install the dependencies for Vue: `docker compose run --rm npm install`
 5. Run migrations: `docker compose run --rm poetry run django-admin migrate`
 6. Load test data: `docker compose run --rm poetry run django-admin loaddata testdata`

--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -140,6 +140,14 @@ optional = false
 python-versions = ">=3.6.1"
 
 [[package]]
+name = "chardet"
+version = "5.1.0"
+description = "Universal encoding detector for Python 3"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "charset-normalizer"
 version = "3.0.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -223,7 +231,7 @@ jinja2 = "*"
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -362,7 +370,7 @@ compatible-mypy = ["mypy (>=0.950,<0.970)"]
 name = "filelock"
 version = "3.9.0"
 description = "A platform independent file lock."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -650,13 +658,25 @@ python-versions = ">=3.7"
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.5)", "sphinx (>=5.3)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -744,6 +764,22 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 certifi = "*"
+
+[[package]]
+name = "pyproject-api"
+version = "1.5.1"
+description = "API to interact with the python pyproject.toml based projects"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = ">=23"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)", "sphinx (>=6.1.3)"]
+testing = ["covdefaults (>=2.2.2)", "importlib-metadata (>=6)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2.1)", "virtualenv (>=20.17.1)", "wheel (>=0.38.4)"]
 
 [[package]]
 name = "pystac"
@@ -990,9 +1026,33 @@ tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version >= \"3.7\" and py
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "tox"
+version = "4.4.7"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cachetools = ">=5.3"
+chardet = ">=5.1"
+colorama = ">=0.4.6"
+filelock = ">=3.9"
+packaging = ">=23"
+platformdirs = ">=2.6.2"
+pluggy = ">=1"
+pyproject-api = ">=1.5"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.17.1"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "sphinx-argparse-cli (>=1.11)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)", "sphinx-copybutton (>=0.5.1)", "sphinx-inline-tabs (>=2022.1.2b11)", "sphinx (>=6.1.3)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+testing = ["build[virtualenv] (>=0.10)", "covdefaults (>=2.2.2)", "devpi-process (>=0.3)", "diff-cover (>=7.4)", "distlib (>=0.3.6)", "flaky (>=3.7)", "hatch-vcs (>=0.3)", "hatchling (>=1.12.2)", "psutil (>=5.9.4)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-xdist (>=3.1)", "pytest (>=7.2.1)", "re-assert (>=1.1)", "time-machine (>=2.9)", "wheel (>=0.38.4)"]
 
 [[package]]
 name = "types-markdown"
@@ -1078,7 +1138,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "virtualenv"
 version = "20.17.1"
 description = "Virtual Python Environment builder"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1094,7 +1154,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10.0"
-content-hash = "fdb9e7f5935752591c2fee32d427935a63941e0f6265e83a00c74dba3236798f"
+content-hash = "89dca924b11e072eae8c31514166fff983d8e22f8a43a91405203d89b391f01a"
 
 [metadata.files]
 affine = [
@@ -1161,6 +1221,10 @@ certifi = [
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
+chardet = [
+    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
+    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-3.0.1.tar.gz", hash = "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f"},
@@ -1630,6 +1694,10 @@ platformdirs = [
     {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
     {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 pre-commit = [
     {file = "pre_commit-3.0.3-py2.py3-none-any.whl", hash = "sha256:83e2e8cc5cbb3691cff9474494816918d865120768aa36c9eda6185126667d21"},
     {file = "pre_commit-3.0.3.tar.gz", hash = "sha256:4187e74fda38f0f700256fb2f757774385503b04292047d0899fc913207f314b"},
@@ -1751,6 +1819,10 @@ pyproj = [
     {file = "pyproj-3.4.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c240fe6bcb5c325b50fc967d5458d708412633f4f05fefc7fb14c14254ebf421"},
     {file = "pyproj-3.4.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef76abfee1a0676ef973470abe11e22998750f2bd944afaf76d44ad70b538c06"},
     {file = "pyproj-3.4.1.tar.gz", hash = "sha256:261eb29b1d55b1eb7f336127344d9b31284d950a9446d1e0d1c2411f7dd8e3ac"},
+]
+pyproject-api = [
+    {file = "pyproject_api-1.5.1-py3-none-any.whl", hash = "sha256:4698a3777c2e0f6b624f8a4599131e2a25376d90fe8d146d7ac74c67c6f97c43"},
+    {file = "pyproject_api-1.5.1.tar.gz", hash = "sha256:435f46547a9ff22cf4208ee274fca3e2869aeb062a4834adfc99a4dd64af3cf9"},
 ]
 pystac = [
     {file = "pystac-1.6.1-py3-none-any.whl", hash = "sha256:4c40e6d3a832b9992e9dc2aa9c276322fbd851e441888b5fc2024397477abec8"},
@@ -1892,6 +1964,10 @@ taskipy = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tox = [
+    {file = "tox-4.4.7-py3-none-any.whl", hash = "sha256:da10ca1d809b99fae80b706b9dc9656b1daf505a395ac427d130a8a85502d08f"},
+    {file = "tox-4.4.7.tar.gz", hash = "sha256:52c92a96e2c3fd47c5301e9c26f5a871466133d5376958c1ed95ef4ff4629cbe"},
 ]
 types-markdown = [
     {file = "types-Markdown-3.4.2.2.tar.gz", hash = "sha256:394e205effefbd12103220f370287ab28e99534f3e12a6408734aae79b7e6119"},

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -57,6 +57,7 @@ pre-commit = "^3.0.3"
 "lint:isort" = "isort --check --diff src"
 "lint:isort:fix" = "isort src"
 "lint:mypy" = "mypy src"
+"test" = "tox"
 
 [tool.black]
 skip-string-normalization = true

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -34,6 +34,7 @@ mercantile = "^1.2.1"
 django-filter = "^22.1"
 django-redis = "^5.2.0"
 django-ninja = "^0.21.0"
+tox = {version = "^4.4.7", extras = ["test"]}
 
 [tool.poetry.dev-dependencies]
 black = "~22.6.0"

--- a/django/src/rdwatch/tests/conftest.py
+++ b/django/src/rdwatch/tests/conftest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from ninja.testing import TestClient
+
+from django.core.management import call_command
+
+from rdwatch.api import api
+from rdwatch.models import HyperParameters
+from rdwatch.models.lookups import Performer
+
+if TYPE_CHECKING:
+    from pytest_django.plugin import _DatabaseBlocker
+
+
+@pytest.fixture(scope='session')
+def django_db_setup(django_db_setup, django_db_blocker: _DatabaseBlocker) -> None:
+    with django_db_blocker.unblock():
+        call_command('loaddata', 'lookups')
+
+
+@pytest.fixture
+def test_client() -> TestClient:
+    return TestClient(router_or_app=api)
+
+
+@pytest.fixture
+def hyper_parameters() -> HyperParameters:
+    return HyperParameters.objects.create(
+        title='Test',
+        parameters={},
+        performer=Performer.objects.all().first(),
+    )

--- a/django/src/rdwatch/tests/test_ingest.py
+++ b/django/src/rdwatch/tests/test_ingest.py
@@ -1,0 +1,55 @@
+import pytest
+from ninja.testing import TestClient
+
+from rdwatch.models import HyperParameters
+
+
+@pytest.mark.django_db
+def test_site_model_ingest_malformed_geometry(
+    test_client: TestClient,
+    hyper_parameters: HyperParameters,
+) -> None:
+    """
+    Test that ensures a malformed geometry gracefully fails (i.e. returns
+    a 422 with an informative error instead of a 500 error)
+    """
+    site_model = {
+        'type': 'FeatureCollection',
+        'features': [
+            {
+                'type': 'Feature',
+                'properties': {
+                    'type': 'site',
+                    'region_id': 'XX_R000',
+                    'site_id': 'XX_R001_0000',
+                    'version': '2.0.0',
+                    'status': 'positive_annotated',
+                    'mgrs': '40RBN',
+                    'score': 1.0,
+                    'start_date': '2023-03-15',
+                    'end_date': '2023-03-16',
+                    'model_content': 'annotation',
+                    'originator': 'kit',
+                },
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [],
+                },
+            },
+        ],
+    }
+    res = test_client.post(
+        f'/model-runs/{hyper_parameters.id}/site-model',
+        json=site_model,
+    )
+
+    assert res.status_code == 422
+    assert res.json() == {
+        'detail': [
+            {
+                'loc': ['body', 'site_model', 'features', 0, 'geometry'],
+                'msg': 'Failed to parse geometry.',
+                'type': 'value_error',
+            }
+        ]
+    }

--- a/django/tox.ini
+++ b/django/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-isolated_build = True
 envlist =
     test,
     check-migrations,
@@ -13,8 +12,11 @@ passenv =
     RDWATCH_POSTGRESQL_URI
     RDWATCH_REDIS_URI
     RDWATCH_DJANGO_DEBUG
+deps =
+    pytest
+    pytest-django
 commands =
-    django-admin test {posargs}
+    pytest {posargs}
 
 [testenv:check-migrations]
 setenv =
@@ -29,5 +31,5 @@ commands =
     {envpython} src/manage.py makemigrations --check --dry-run
 
 [pytest]
-DJANGO_SETTINGS_MODULE = rdwatch.settings
+DJANGO_SETTINGS_MODULE = rdwatch.server.settings
 addopts = --strict-markers --showlocals --verbose


### PR DESCRIPTION
Configures `pytest` and `pytest-django`, and adds a single test for ingest.

There's definitely more aspects of the system that need to be tested, this is just a start to get everything in place we need to be able to write more tests easily in the future.