### PR TITLE
Fix errors in site model ingest

### DIFF
--- a/django/src/rdwatch/migrations/0005_alter_siteobservation_geom.py
+++ b/django/src/rdwatch/migrations/0005_alter_siteobservation_geom.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import django.contrib.gis.db.models.fields
+from django.contrib.gis.geos import MultiPolygon
+from django.db import migrations
+
+if TYPE_CHECKING:
+    from django.contrib.gis.db.backends.postgis.schema import PostGISSchemaEditor
+    from django.db.migrations.state import StateApps
+
+
+def migrate_observation_geom(apps: StateApps, schema_editor: PostGISSchemaEditor):
+    SiteEvaluation = apps.get_model('rdwatch', 'SiteEvaluation')  # noqa: N806
+    SiteObservation = apps.get_model('rdwatch', 'SiteObservation')  # noqa: N806
+
+    # Set of SiteEvaluation ids that we want to delete
+    evals_to_delete: set[int] = set()
+
+    for observation in SiteObservation.objects.iterator():
+        if len(observation.geom_old) > 1:
+            # If this MultiPolygon contains more than one Polygon, this
+            # site needs to be reingested
+            evals_to_delete.add(observation.siteeval.id)
+            observation.delete()
+        else:
+            # Otherwise, extract the one Polygon from the MultiPolygon
+            observation.geom = list(observation.geom_old)[0]
+            observation.save(update_fields=['geom'])
+
+    SiteEvaluation.objects.filter(id__in=evals_to_delete).delete()
+
+
+def reverse_migrate_observation_geom(
+    apps: StateApps, schema_editor: PostGISSchemaEditor
+):
+    SiteObservation = apps.get_model('rdwatch', 'SiteObservation')  # noqa: N806
+
+    for observation in SiteObservation.objects.iterator():
+        observation.geom_old = MultiPolygon([observation.geom])
+        observation.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('rdwatch', '0004_alter_region_geom'),
+    ]
+
+    operations = [
+        # Rename current geom column so we can create the new one
+        migrations.RenameField('siteobservation', old_name='geom', new_name='geom_old'),
+        # Make the old geom column nullable
+        migrations.AlterField(
+            model_name='siteobservation',
+            name='geom_old',
+            field=django.contrib.gis.db.models.fields.MultiPolygonField(
+                help_text='Footprint of site observation',
+                srid=3857,
+                null=True,
+            ),
+        ),
+        # Create the new geom column
+        migrations.AddField(
+            model_name='siteobservation',
+            name='geom',
+            field=django.contrib.gis.db.models.fields.PolygonField(
+                help_text='Footprint of site observation',
+                srid=3857,
+                null=True,
+            ),
+        ),
+        # Perform the data migration from the old column to the new one
+        migrations.RunPython(
+            migrate_observation_geom,
+            reverse_migrate_observation_geom,
+        ),
+        # Now that the data migration is complete, set the new column to be non-nullable
+        migrations.AlterField(
+            model_name='siteobservation',
+            name='geom',
+            field=django.contrib.gis.db.models.fields.PolygonField(
+                help_text='Footprint of site observation',
+                srid=3857,
+                null=False,
+            ),
+        ),
+        # Finally, remove the old column
+        migrations.RemoveField(
+            model_name='siteobservation',
+            name='geom_old',
+            field=django.contrib.gis.db.models.fields.MultiPolygonField(
+                help_text='Footprint of site observation',
+                srid=3857,
+            ),
+        ),
+    ]

--- a/django/src/rdwatch/schemas/region_model.py
+++ b/django/src/rdwatch/schemas/region_model.py
@@ -1,9 +1,9 @@
 # flake8: noqa: F722
 import json
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from ninja import Schema
+from ninja import Field, Schema
 from pydantic import constr, validator
 
 from django.contrib.gis.gdal import GDALException
@@ -102,7 +102,10 @@ class Feature(Schema):
         arbitrary_types_allowed = True
 
     type: Literal['Feature']
-    properties: RegionFeature | SiteSummaryFeature
+    properties: Annotated[
+        RegionFeature | SiteSummaryFeature,
+        Field(discriminator='type'),
+    ]
     geometry: Polygon
 
     @validator('geometry', pre=True)

--- a/django/src/rdwatch/schemas/region_model.py
+++ b/django/src/rdwatch/schemas/region_model.py
@@ -123,10 +123,6 @@ class RegionModel(Schema):
     type: Literal['FeatureCollection']
     features: list[Feature]
 
-    @validator('features', pre=True)
-    def preprocess_features(cls, v: list):
-        return _preprocess_features(v)
-
     @validator('features')
     def ensure_one_region_feature(cls, v: list[Feature]):
         region_features = [
@@ -151,21 +147,3 @@ class RegionModel(Schema):
             for feature in self.features
             if isinstance(feature.properties, SiteSummaryFeature)
         ]
-
-
-def _preprocess_features(features: list) -> list:
-    for feature in features:
-        if (
-            feature['properties']['type'] == 'site_summary'
-            and 'region_id' in feature['properties']
-        ):
-            del feature['properties']['region_id']
-
-        for key, value in feature['properties'].items():
-            if isinstance(value, str):
-                feature['properties'][key] = value.strip()
-
-        if 'model_cont' in feature['properties']:
-            feature['properties']['model_content'] = feature['properties']['model_cont']
-            del feature['properties']['model_cont']
-    return features

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -82,7 +82,7 @@ class ObservationFeature(Schema):
             'Post Construction',
             'Unknown',
         ]
-    ]
+    ] | None
     is_occluded: list[bool] | None
     is_site_boundary: list[bool] | None
 
@@ -125,7 +125,7 @@ class ObservationFeature(Schema):
             for field in ('current_phase', 'is_occluded', 'is_site_boundary')
             if values.get(field) is not None
         ]
-        if len({len(l) for l in lists}) != 1:
+        if len(lists) and len({len(l) for l in lists}) != 1:
             raise ValueError(
                 'current_phase/is_occluded/is_site_boundary lists must be the same length!'
             )

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -1,9 +1,9 @@
 # flake8: noqa: F722
 import json
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from ninja import Schema
+from ninja import Field, Schema
 from pydantic import constr, root_validator, validator
 
 from django.contrib.gis.gdal import GDALException
@@ -112,7 +112,10 @@ class Feature(Schema):
         arbitrary_types_allowed = True
 
     type: Literal['Feature']
-    properties: SiteFeature | ObservationFeature
+    properties: Annotated[
+        SiteFeature | ObservationFeature,
+        Field(discriminator='type'),
+    ]
     geometry: GEOSGeometry
 
     @validator('geometry', pre=True)

--- a/django/src/rdwatch/tests/conftest.py
+++ b/django/src/rdwatch/tests/conftest.py
@@ -21,7 +21,7 @@ def django_db_setup(django_db_setup, django_db_blocker: _DatabaseBlocker) -> Non
         call_command('loaddata', 'lookups')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def test_client() -> TestClient:
     return TestClient(router_or_app=api)
 

--- a/django/src/rdwatch/tests/test_ingest.py
+++ b/django/src/rdwatch/tests/test_ingest.py
@@ -1,7 +1,87 @@
 import pytest
 from ninja.testing import TestClient
 
-from rdwatch.models import HyperParameters
+from rdwatch.models import HyperParameters, SiteEvaluation
+
+
+@pytest.mark.django_db
+def test_site_model_ingest(
+    test_client: TestClient,
+    hyper_parameters: HyperParameters,
+) -> None:
+    site_model = {
+        'features': [
+            {
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [
+                        [
+                            [55.505, 24.47],
+                            [55.13, 24.97],
+                            [55.596, 24.326],
+                            [55.901, 24.222],
+                            [55.505, 24.47],
+                        ]
+                    ],
+                },
+                'properties': {
+                    'mgrs': '40RBN',
+                    'model_content': 'proposed',
+                    'originator': 'kit',
+                    'region_id': 'US_R000',
+                    'score': 0.85,
+                    'site_id': 'US_R000_0000',
+                    'status': 'system_confirmed',
+                    'type': 'site',
+                    'version': '0.0.0',
+                },
+                'type': 'Feature',
+            },
+            {
+                'geometry': {
+                    'coordinates': [
+                        [
+                            [
+                                [55.413, 24.8625],
+                                [55.5505, 24.863],
+                                [55.4901, 24.864],
+                                [55.3596, 24.863],
+                                [55.413, 24.8625],
+                            ]
+                        ],
+                        [
+                            [
+                                [55.413, 24.8625],
+                                [55.5505, 24.863],
+                                [55.4901, 24.864],
+                                [55.3596, 24.863],
+                                [55.413, 24.8625],
+                            ]
+                        ],
+                    ],
+                    'type': 'MultiPolygon',
+                },
+                'properties': {
+                    'current_phase': 'Site Preparation, Site Preparation',
+                    'is_occluded': 'False, False',
+                    'is_site_boundary': 'True, True',
+                    'score': 0.67,
+                    'sensor_name': 'WorldView',
+                    'type': 'observation',
+                },
+                'type': 'Feature',
+            },
+        ],
+        'type': 'FeatureCollection',
+    }
+    res = test_client.post(
+        f'/model-runs/{hyper_parameters.id}/site-model',
+        json=site_model,
+    )
+
+    assert SiteEvaluation.objects.count() == 1
+    assert res.status_code == 201
+    assert res.json() == SiteEvaluation.objects.first().id, res.json()
 
 
 @pytest.mark.django_db

--- a/django/src/rdwatch/views/site_model.py
+++ b/django/src/rdwatch/views/site_model.py
@@ -9,23 +9,33 @@ from rdwatch.schemas import RegionModel, SiteModel
 router = Router()
 
 
-@router.post('/{hyper_parameters_id}/site-model')
+@router.post(
+    '/{hyper_parameters_id}/site-model',
+    response={201: int},
+)
 def post_site_model(
     request: HttpRequest,
     hyper_parameters_id: int,
     site_model: SiteModel,
 ):
     hyper_parameters = get_object_or_404(HyperParameters, pk=hyper_parameters_id)
-    SiteEvaluation.bulk_create_from_site_model(site_model, hyper_parameters)
-    return 201
+    site_evaluation = SiteEvaluation.bulk_create_from_site_model(
+        site_model, hyper_parameters
+    )
+    return 201, site_evaluation.id
 
 
-@router.post('/{hyper_parameters_id}/region-model')
+@router.post(
+    '/{hyper_parameters_id}/region-model',
+    response={201: list[int]},
+)
 def post_region_model(
     request: HttpRequest,
     hyper_parameters_id: int,
     region_model: RegionModel,
 ):
     hyper_parameters = get_object_or_404(HyperParameters, pk=hyper_parameters_id)
-    SiteEvaluation.bulk_create_from_from_region_model(region_model, hyper_parameters)
-    return 201
+    site_evaluations = SiteEvaluation.bulk_create_from_from_region_model(
+        region_model, hyper_parameters
+    )
+    return 201, [eval.id for eval in site_evaluations]


### PR DESCRIPTION
This PR:

- Fixes some incorrect usage of Pydantic validation that was resulting in some 500 errors in the ingest endpoints (https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/afaeb292b830356261b4c05be89def7c85f8a0fc)
- Improves the error messages returned when a user attempts to ingest an invalid site/region model json (https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/aed6702733ab29ddc854195189cd26f6695f7518)
- Makes the parsing of comma-separated lists during site model ingest cleaner by casting them to a list of strings at the start of ingestion (https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/08ae93cbb84defb8d78f05cbbe46f0ac3dac6e9c)
- Removes support for comma-separated list for region models (these are not supported by the spec) https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/eec82ca18df4dbabfe5d7a8a4e6df692e82dcfcf
- Adds a new test for site model ingest, and cleans up some minor issues exposed by it (https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/0a77b2ac84b0af0871424c5b61127988f2c966b4, https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/40248e9dd8b1d9b8c3880f4babdb0b4ae132cca5, https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/cbd67def8eafb3b0dc2d8341b08e01161dccf2de)

- Refactors the site model ingest to be in line with what the spec expects https://github.com/ResonantGeoData/RD-WATCH/pull/165/commits/f75de8139f087c0c529b2dac8d254abdd38cdbe4
	- This part is particularly important, since I discovered that we have been making some incorrect assumptions about site models in both the ingest routine and in our data model since the beginning. Until now, we were storing each `observation` in a site model as a separate `SiteObservation` in the database, each with its own `MultiPolygon` geometry. However, this is incorrect - a single `observation` object in a site model actually maps to several `SiteObservations`. The `current_phase` field can contain multiple phases (in the form of a comma-separated list), each of which represents a different observation; and the nth phase in this list maps to the nth `Polygon` within the `MultiPolygon` for this `observation`. 
- To fix this, I
	- Changed the `SiteObservation` `geom` column to be a `PolygonField` instead of a `MultiPolygonField`.
	- Changed the site model ingest code to be in line with the facts above.
	- Wrote a custom database migration that will convert all the existing `SiteObservation` `geom` columns to a `Polygon`. This comes with some slight complications:
    	- `SiteObservations` whose `MultiPolygon` contained only a single `Polygon` are straightforward to convert. Practically, the vast majority of the `SiteObservations` fit into this category.
    	- `SiteObservations` whose `MultiPolygons` contained multiple `Polygons` are more difficult to convert. We _could_ have an even more complicated migration that handles this case; but considering that there's only a handful of these in the system, I think it's easier to just delete them and manually re-ingest later. 