### PR TITLE
Configure concurrency for deployment workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - "main"
+concurrency:
+  # Only run the latest workflow.
+  # If a build is already happening, cancel it to avoid a race
+  # condition where an older image overwrites a newer one.
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This prevents a race condition where two PRs are merged almost at the same time. In a case like that, it's possible the older PR's docker image build will complete *after* the newer PR's build, which would cause it to overwrite the new image on GHCR.

https://docs.github.com/en/actions/using-jobs/using-concurrency