### PR TITLE
Use django-ninja `ValidationError` instead of DRF

### DIFF
--- a/django/src/rdwatch/models/region.py
+++ b/django/src/rdwatch/models/region.py
@@ -1,10 +1,10 @@
 import iso3166
+from ninja.errors import ValidationError
 
 from django.contrib.gis.db.models import PolygonField
 from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
-from rest_framework.exceptions import ValidationError
 
 from rdwatch.models import lookups
 from rdwatch.validators import validate_iso3166


### PR DESCRIPTION
I didn't update this properly when we moved these endpoints from DRF to ninja, which is causing 500 errors to get thrown instead of 400.