### PR TITLE
Refactor Satellite timeStamp requests

### DIFF
--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('evaluations/<int:pk>', views.site_observations),
     path('vector-tile/<int:z>/<int:x>/<int:y>.pbf', views.vector_tile),
     path('satellite-image/timestamps', views.satelliteimage_time_list),
+    path('satellite-image/all-timestamps', views.all_satellite_timestamps),
     path(
         'satellite-image/tile/<int:z>/<int:x>/<int:y>.webp',
         views.satelliteimage_raster_tile,

--- a/django/src/rdwatch/utils/satellite_bands.py
+++ b/django/src/rdwatch/utils/satellite_bands.py
@@ -136,5 +136,5 @@ def get_bands(
                     bbox=stac_bbox,
                     uri=uri,
                     cloudcover=cloudcover,
-                    collection=feature['collection']
+                    collection=feature['collection'],
                 )

--- a/django/src/rdwatch/utils/satellite_bands.py
+++ b/django/src/rdwatch/utils/satellite_bands.py
@@ -18,6 +18,8 @@ class Band:
     timestamp: datetime
     bbox: tuple[float, float, float, float]
     uri: str
+    cloudcover: int
+    collection: str
 
 
 def get_bands(
@@ -79,6 +81,7 @@ def get_bands(
                     logger.warning("Malformed STAC response: no 'bbox'")
                     continue
 
+            cloudcover = 0
             match feature:
                 case {'collection': 'landsat-c2l1' | 'sentinel-s2-l1c'}:
                     level, _ = ProcessingLevel.objects.get_or_create(
@@ -102,6 +105,9 @@ def get_bands(
                 case _:
                     logger.warning("Malformed STAC response: no 'collection'")
                     continue
+            if 'properties' in feature.keys():
+                if 'eo:cloud_cover' in feature['properties'].keys():
+                    cloudcover = feature['properties']['eo:cloud_cover']
 
             for name, asset in feature['assets'].items():
                 if name == 'visual':
@@ -129,4 +135,6 @@ def get_bands(
                     spectrum=spectrum,
                     bbox=stac_bbox,
                     uri=uri,
+                    cloudcover=cloudcover,
+                    collection=feature['collection']
                 )

--- a/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
+++ b/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
@@ -56,7 +56,7 @@ def get_captures(
                 uri=feature['assets']['visual']['href'],
                 panuri=None,
                 cloudcover=cloudcover,
-                collection=feature['collection']
+                collection=feature['collection'],
             )
             captures.append(capture)
 

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -78,5 +78,4 @@ def worldview_search(
         headers={'x-api-key': environ['RDWATCH_SMART_STAC_KEY']},
     )
     with urlopen(request) as resp:
-        data = resp.read()
-        return json.loads(data)
+        return json.loads(resp.read())

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -69,9 +69,7 @@ def worldview_search(
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
     params['datetime'] = time_str
-    params['collections'] = [
-        "ta1-wv-acc-1",
-    ]
+    params['collections'] = ["ta1-wv-acc-2"]
     params['page'] = page
     params['limit'] = 100
     request = Request(

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -69,7 +69,7 @@ def worldview_search(
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
     params['datetime'] = time_str
-    params['collections'] = ["ta1-wv-acc-2"]
+    params['collections'] = ['ta1-wv-acc-2']
     params['page'] = page
     params['limit'] = 100
     request = Request(

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -69,7 +69,9 @@ def worldview_search(
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
     params['datetime'] = time_str
-    params['collections'] = ['ta1-wv-acc-2']
+    params['collections'] = [
+        "ta1-wv-acc-1",
+    ]
     params['page'] = page
     params['limit'] = 100
     request = Request(
@@ -78,4 +80,5 @@ def worldview_search(
         headers={'x-api-key': environ['RDWATCH_SMART_STAC_KEY']},
     )
     with urlopen(request) as resp:
-        return json.loads(resp.read())
+        data = resp.read()
+        return json.loads(data)

--- a/django/src/rdwatch/views/__init__.py
+++ b/django/src/rdwatch/views/__init__.py
@@ -10,6 +10,7 @@ from .tile import (
     satelliteimage_time_list,
     satelliteimage_visual_tile,
     satelliteimage_visual_time_list,
+    all_satellite_timestamps,
     vector_tile,
 )
 
@@ -26,5 +27,6 @@ __all__ = [
     'satelliteimage_time_list',
     'satelliteimage_visual_tile',
     'satelliteimage_visual_time_list',
+    'all_satellite_timestamps',
     'vector_tile',
 ]

--- a/django/src/rdwatch/views/__init__.py
+++ b/django/src/rdwatch/views/__init__.py
@@ -6,11 +6,11 @@ from .site_evaluation import site_evaluations
 from .site_model import post_region_model, post_site_model
 from .site_observation import site_observations
 from .tile import (
+    all_satellite_timestamps,
     satelliteimage_raster_tile,
     satelliteimage_time_list,
     satelliteimage_visual_tile,
     satelliteimage_visual_time_list,
-    all_satellite_timestamps,
     vector_tile,
 )
 

--- a/django/src/rdwatch/views/region.py
+++ b/django/src/rdwatch/views/region.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.pagination import PageNumberPagination
 
 from rdwatch.models import Region
 from rdwatch.serializers import RegionSerializer
@@ -7,3 +8,6 @@ from rdwatch.serializers import RegionSerializer
 class RegionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Region.objects.all().select_related('classification')
     serializer_class = RegionSerializer
+    pagination_class = PageNumberPagination
+    # Set the number of items per page to 1000
+    pagination_class.page_size = 1000

--- a/django/src/rdwatch/views/tile.py
+++ b/django/src/rdwatch/views/tile.py
@@ -381,6 +381,7 @@ def satelliteimage_visual_time_list(request: HttpRequest):
 
     return JsonResponse([capture.timestamp for capture in captures], safe=False)
 
+
 # Additional endpoint that returns worldview and satellite images with data about images
 @cache_page(60 * 60 * 24 * 365)
 def all_satellite_timestamps(request: HttpRequest):
@@ -425,22 +426,26 @@ def all_satellite_timestamps(request: HttpRequest):
     ]
     results = []
     for band in bands:
-        results.append({
-            'timestamp': band.timestamp,
-            'cloudcover': band.cloudcover,
-            'collection': band.collection,
-            'source': 'S2'
-        })
+        results.append(
+            {
+                'timestamp': band.timestamp,
+                'cloudcover': band.cloudcover,
+                'collection': band.collection,
+                'source': 'S2',
+            }
+        )
     timestamps_set = {band.timestamp for band in bands}
     timestamps = [t for t in timestamps_set]
     timestamps.sort()
     captures = get_captures(timestamp, bbox, timebuffer)
     for capture in captures:
-        results.append({
-            'timestamp': capture.timestamp,
-            'cloudcover':capture.cloudcover,
-            'collection': capture.collection,
-            'source': 'WorldView',
-        })
+        results.append(
+            {
+                'timestamp': capture.timestamp,
+                'cloudcover': capture.cloudcover,
+                'collection': capture.collection,
+                'source': 'WorldView',
+            }
+        )
     results.sort(key=lambda d: d['timestamp'])
     return JsonResponse(results, safe=False)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,6 +120,10 @@ services:
   # Run poetry commands
   poetry:
     image: ghcr.io/resonantgeodata/rd-watch/builder:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: builder
     depends_on:
       - django
     entrypoint:

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -14,6 +14,7 @@ import type { Region } from "../models/Region";
 import type { CancelablePromise } from "../core/CancelablePromise";
 import { OpenAPI } from "../core/OpenAPI";
 import { request as __request } from "../core/request";
+import { SatelliteTimeStamp } from "../../store";
 
 export interface QueryArguments {
   performer?: string;
@@ -155,7 +156,7 @@ export class ApiService {
     level="2A",
     startTimestamp=0,
     endTimestamp=0,
-    bbox=[]
+    bbox=[],
   ): CancelablePromise<string[]>
   {
     const startTime = new Date(startTimestamp * 1000).toISOString().substring(0, 10);
@@ -175,17 +176,19 @@ export class ApiService {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/satellite-image/timestamps",
-      query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr
+      query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });
   }
+
   public static getSatelliteVisualTimestamps(
     constellation="S2",
     spectrum="visual",
     level="2A",
     startTimestamp=0,
     endTimestamp=0,
-    bbox=[]
+    bbox=[],
+    cloudcover = 100
   ): CancelablePromise<string[]>
   {
     const startTime = new Date(startTimestamp * 1000).toISOString().substring(0, 10);
@@ -205,7 +208,37 @@ export class ApiService {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/satellite-image/visual-timestamps",
-      query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr
+      query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
+      }
+    });
+  }
+  public static getAllSatelliteTimestamps(
+    constellation="S2",
+    spectrum="visual",
+    level="2A",
+    startTimestamp=0,
+    endTimestamp=0,
+    bbox=[],
+  ): CancelablePromise<SatelliteTimeStamp[]>
+  {
+    const startTime = new Date(startTimestamp * 1000).toISOString().substring(0, 10);
+    const endTime = new Date(endTimestamp * 1000).toISOString().substring(0, 10);
+    // Convert bbox into array of numbers, min/max
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    bbox.forEach((item: [number, number]) => {
+      minX = Math.min(minX, item[1]);
+      minY = Math.min(minY, item[0]);
+      maxX = Math.max(maxX, item[1]);
+      maxY = Math.max(maxY, item[0]);
+    })
+    const bboxstr = `${minY},${minX},${maxY},${maxX}`;
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/satellite-image/all-timestamps",
+      query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });
   }

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -66,7 +66,7 @@ onUnmounted(() => {
 const throttledSetSatelliteTimeStamp = throttle(setSatelliteTimeStamp, 300);
 
 
-watch([() => state.timestamp, () => state.filters, () => state.satellite], () => {
+watch([() => state.timestamp, () => state.filters, () => state.satellite, () => state.satellite.satelliteSources], () => {
   if (state.satellite.satelliteImagesOn) {
     throttledSetSatelliteTimeStamp(state, filteredSatelliteTimeList.value);
   }

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -5,7 +5,7 @@ import {
   buildObservationFilter,
   buildSiteFilter,
 } from "../mapstyle/rdwatchtiles";
-import { state } from "../store";
+import { filteredSatelliteTimeList, state } from "../store";
 import { markRaw, onMounted, onUnmounted, shallowRef, watch } from "vue";
 import type { FilterSpecification } from "maplibre-gl";
 import type { ShallowRef } from "vue";
@@ -68,7 +68,7 @@ const throttledSetSatelliteTimeStamp = throttle(setSatelliteTimeStamp, 300);
 
 watch([() => state.timestamp, () => state.filters, () => state.satellite], () => {
   if (state.satellite.satelliteImagesOn) {
-    throttledSetSatelliteTimeStamp(state);
+    throttledSetSatelliteTimeStamp(state, filteredSatelliteTimeList.value);
   }
   const siteFilter = buildSiteFilter(state.timestamp, state.filters);
   const observationFilter = buildObservationFilter(

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -253,7 +253,7 @@ watch([() => props.filters.region, () => props.filters.performer], () => {
       class="badge-accent badge ml-2"
     >{{ totalModelRuns }} {{ totalModelRuns > 1 ? "Runs" : "Run" }}</span>
     <span
-      v-if="!loading && !loadingSatelliteTimestamps && hasSatelliteImages&& !state.satellite.satelliteImagesOn && state.filters.region_id?.length"
+      v-if="!loading && !loadingSatelliteTimestamps && hasSatelliteImages && !state.satellite.satelliteImagesOn && state.filters.region_id?.length"
       style="font-size: 0.75em"
       class="badge-secondary badge ml-2"
     >{{ hasSatelliteImages }} {{ hasSatelliteImages > 1 ? "Image Timestamps" : "Image Timestamp" }}</span>

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -10,7 +10,7 @@ import {
 import { computed, ref, watch, watchEffect } from "vue";
 import type { Ref } from "vue";
 import { ApiService } from "../client";
-import { state } from "../store";
+import { filteredSatelliteTimeList, state } from "../store";
 import { LngLatBounds } from "maplibre-gl";
 import { hoveredInfo } from "../interactions/popup";
 const limit = 10;
@@ -182,7 +182,7 @@ async function getSatelliteTimestamps(modelRun: ModelRunList, force=false) {
       'S2', 'visual','2A', modelRun.timerange?.min, modelRun.timerange?.max, modelRun.bbox?.coordinates[0] as []);
 
   loadingSatelliteTimestamps.value = false;
-  state.satellite.satelliteTimeList = results.filter((item) => item.source === 'WorldView');
+  state.satellite.satelliteTimeList = results;
   state.satellite.satelliteBounds = modelRun.bbox?.coordinates[0] as [];
 }
 
@@ -233,7 +233,7 @@ async function handleScroll(event: Event) {
   }
 }
 
-const hasSatelliteImages = computed(() => state.satellite.satelliteTimeList.length);
+const hasSatelliteImages = computed(() => filteredSatelliteTimeList.value.length);
 
 watchEffect(loadMore);
 watch([() => props.filters.region, () => props.filters.performer], () => {

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -182,7 +182,7 @@ async function getSatelliteTimestamps(modelRun: ModelRunList, force=false) {
       'S2', 'visual','2A', modelRun.timerange?.min, modelRun.timerange?.max, modelRun.bbox?.coordinates[0] as []);
 
   loadingSatelliteTimestamps.value = false;
-  state.satellite.satelliteTimeList = results; //.filter((item) => item.source === 'WorldView');
+  state.satellite.satelliteTimeList = results.filter((item) => item.source === 'WorldView');
   state.satellite.satelliteBounds = modelRun.bbox?.coordinates[0] as [];
 }
 

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -317,6 +317,7 @@ watch(hiddenCanvas, () => {
       </label>
     </div>
     <div
+      v-if="imagesOn"
       class="form-control"
     >
       <label class="label cursor-pointer">

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -32,6 +32,15 @@ const imageOpacity = computed({
   },
 });
 
+const cloudCover = computed({
+  get() {
+    return state.satellite.cloudCover || 1000;
+  },
+  set(val: number) {
+    state.satellite = { ...state.satellite, cloudCover: val };
+  },
+});
+
 const showSiteOutline = computed({
   get() {
     return state.filters.showSiteOutline || false;
@@ -253,6 +262,22 @@ watch(hiddenCanvas, () => {
           min="0"
           max="1"
           step="0.1"
+          class="chrome-range w-full"
+          type="range"
+        >
+      </label>
+    </div>
+    <div
+      class="form-control"
+    >
+      <label class="label cursor-pointer">
+        <span class="label-text">Cloud Cover:</span>
+        <input
+          v-model.number="cloudCover"
+          :disabled="state.satellite.loadingSatelliteImages"
+          min="0"
+          max="100"
+          step="20"
           class="chrome-range w-full"
           type="range"
         >

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -93,6 +93,35 @@ const patternOpacity = computed({
   },
 });
 
+const S2Imagery = computed({
+  get() {
+    return state.satellite.satelliteSources.includes('S2');
+  },
+  set(val: boolean) {
+    if (!state.satellite.satelliteSources.includes('S2') && val) {
+      state.satellite.satelliteSources.push('S2')
+    } else if (state.satellite.satelliteSources.includes('S2')) {
+      const index = state.satellite.satelliteSources.indexOf('S2');
+      state.satellite.satelliteSources.splice(index, 1);
+    }
+  },
+});
+
+const worldViewImagery = computed({
+  get() {
+    return state.satellite.satelliteSources.includes('WorldView');
+  },
+  set(val: boolean) {
+    if (!state.satellite.satelliteSources.includes('WorldView') && val) {
+      state.satellite.satelliteSources.push('WorldView')
+    } else if (state.satellite.satelliteSources.includes('WorldView')) {
+      const index = state.satellite.satelliteSources.indexOf('WorldView');
+      state.satellite.satelliteSources.splice(index, 1);
+    }
+  },
+});
+
+
 const patternDensity: Ref<number> = ref(1);
 const patternDensityIndex = ref([64, 128, 256, 512, 1024])
 
@@ -267,6 +296,26 @@ watch(hiddenCanvas, () => {
         >
       </label>
     </div>
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">S2 Imagery:</span>
+        <input
+          v-model="S2Imagery"
+          type="checkbox"
+          class="checkbox-primary checkbox"
+        >
+      </label>
+    </div>
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        <span class="label-text">WorldView Imagery:</span>
+        <input
+          v-model="worldViewImagery"
+          type="checkbox"
+          class="checkbox-primary checkbox"
+        >
+      </label>
+    </div>
     <div
       class="form-control"
     >
@@ -281,6 +330,7 @@ watch(hiddenCanvas, () => {
           class="chrome-range w-full"
           type="range"
         >
+        <span class="label-text pl-2">&lt{{ cloudCover }}%</span>
       </label>
     </div>
 
@@ -377,7 +427,7 @@ watch(hiddenCanvas, () => {
     </div>
     <div class="form-control">
       <label class="label cursor-pointer">
-        <span class="label-text">Pattern Desnsity:</span>
+        <span class="label-text">Pattern Density:</span>
         <input
           v-model="patternDensity"
           type="range"

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -330,7 +330,7 @@ watch(hiddenCanvas, () => {
           class="chrome-range w-full"
           type="range"
         >
-        <span class="label-text pl-2">&lt{{ cloudCover }}%</span>
+        <span class="label-text pl-2">&lt;{{ cloudCover }}%</span>
       </label>
     </div>
 

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -5,7 +5,7 @@ import PerformerFilter from "./filters/PerformerFilter.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
 import { Cog6ToothIcon, PhotoIcon } from "@heroicons/vue/24/solid";
 import SettingsPanel from "./SettingsPanel.vue";
-import { state } from "../store";
+import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
 import type { Performer, QueryArguments, Region } from "../client";
 import type { Ref } from "vue";
@@ -107,10 +107,10 @@ onMounted(() => {
             :class="{
               'animate-flicker': state.satellite.loadingSatelliteImages,
               'text-blue-600': imagesOn,
-              'hover': selectedRegion !== null && state.satellite.satelliteTimeList.length !== 0,
-              'text-gray-400': selectedRegion === null || state.satellite.satelliteTimeList.length === 0,
+              'hover': selectedRegion !== null && filteredSatelliteTimeList.length !== 0,
+              'text-gray-400': selectedRegion === null || filteredSatelliteTimeList.length === 0,
             }"
-            @click="imagesOn = selectedRegion !== null && state.satellite.satelliteTimeList.length !== 0 ? !imagesOn : imagesOn"
+            @click="imagesOn = selectedRegion !== null && filteredSatelliteTimeList.length !== 0 ? !imagesOn : imagesOn"
           />
           <span class="h5 grow" />
           <Cog6ToothIcon

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -107,10 +107,10 @@ onMounted(() => {
             :class="{
               'animate-flicker': state.satellite.loadingSatelliteImages,
               'text-blue-600': imagesOn,
-              'hover': selectedRegion !== null && filteredSatelliteTimeList.length !== 0,
-              'text-gray-400': selectedRegion === null || filteredSatelliteTimeList.length === 0,
+              'hover': selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0),
+              'text-gray-400': selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0),
             }"
-            @click="imagesOn = selectedRegion !== null && filteredSatelliteTimeList.length !== 0 ? !imagesOn : imagesOn"
+            @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
           />
           <span class="h5 grow" />
           <Cog6ToothIcon

--- a/vue/src/interactions/satelliteLoading.ts
+++ b/vue/src/interactions/satelliteLoading.ts
@@ -10,29 +10,28 @@ const satelliteLoading = (map: ShallowRef<null | Map>) => {
     watch([() => state.satellite.satelliteTimeStamp, () => state.satellite.satelliteImagesOn], () => {
         state.satellite.loadingSatelliteImages = false;
         Object.keys(satelliteTilesUIDs).forEach((key) => delete satelliteTilesUIDs[key]);
-    })
+    });
     if (map.value) {
         map.value.on("data", function (e: MapDataLoad) {
-        if (e.sourceId === 'satelliteTiles') {
-            if (e?.tile?.uid) {
-            if (satelliteTilesUIDs[e.tile.uid])
-            delete satelliteTilesUIDs[e.tile.uid];
+            if (e.sourceId === 'satelliteTiles') {
+                if (e?.tile?.uid) {
+                if (satelliteTilesUIDs[e.tile.uid])
+                delete satelliteTilesUIDs[e.tile.uid];
+                }
+                if (Object.values(satelliteTilesUIDs).length === 0) {
+                state.satellite.loadingSatelliteImages = false;
+                } else {
+                    state.satellite.loadingSatelliteImages = true;
+                }
             }
-            if (Object.values(satelliteTilesUIDs).length === 0) {
-            state.satellite.loadingSatelliteImages = false;
-            } else {
-                state.satellite.loadingSatelliteImages = true;
-            }
-        }
-
         });
         map.value.on("dataloading", function (e: MapDataLoad) {
-        if (e.sourceId === 'satelliteTiles') {
-            if (e?.tile?.uid) {
-            satelliteTilesUIDs[e.tile.uid] = 'loading';
-            state.satellite.loadingSatelliteImages = true;
+            if (e.sourceId === 'satelliteTiles') {
+                if (e?.tile?.uid) {
+                satelliteTilesUIDs[e.tile.uid] = 'loading';
+                state.satellite.loadingSatelliteImages = true;
+                }
             }
-        }
         });
     }
 };

--- a/vue/src/interactions/timeStepper.ts
+++ b/vue/src/interactions/timeStepper.ts
@@ -5,7 +5,6 @@ function changeTime(direction: -1 | 1) {
     if (state.satellite.satelliteImagesOn) { // Jump to the next timestmap within an hour of the current one
         const currentIndex = filteredSatelliteTimeList.value.findIndex((item) => item.timestamp === state.satellite.satelliteTimeStamp);
         const currentImageTime = new Date(`${state.satellite.satelliteTimeStamp}Z`);
-        console.log(currentIndex);
         // Now we go from the current index and find the Next Day in either direction
         let newTime = null;
         let checkDateIndex = currentIndex + direction * 1

--- a/vue/src/interactions/timeStepper.ts
+++ b/vue/src/interactions/timeStepper.ts
@@ -1,16 +1,16 @@
 // Does time stepping left/right based on satellite timestamps if they exists
-import { state } from '../store';
+import { filteredSatelliteTimeList, state } from '../store';
 
 function changeTime(direction: -1 | 1) {
     if (state.satellite.satelliteImagesOn) { // Jump to the next timestmap within an hour of the current one
-        const currentIndex = state.satellite.satelliteTimeList.findIndex((item) => item.timestamp === state.satellite.satelliteTimeStamp);
+        const currentIndex = filteredSatelliteTimeList.value.findIndex((item) => item.timestamp === state.satellite.satelliteTimeStamp);
         const currentImageTime = new Date(`${state.satellite.satelliteTimeStamp}Z`);
         console.log(currentIndex);
         // Now we go from the current index and find the Next Day in either direction
         let newTime = null;
         let checkDateIndex = currentIndex + direction * 1
         while (newTime === null && currentIndex !== -1 && checkDateIndex >= 0) {
-            const checkTimeString = state.satellite.satelliteTimeList[checkDateIndex].timestamp;
+            const checkTimeString = filteredSatelliteTimeList.value[checkDateIndex].timestamp;
             const checkTime = new Date(`${checkTimeString}Z`);
             const diffTime = Math.abs(checkTime.getTime() - currentImageTime.getTime());
             const diffDays = Math.ceil(diffTime / (60 * 60 * 24));

--- a/vue/src/interactions/timeStepper.ts
+++ b/vue/src/interactions/timeStepper.ts
@@ -3,13 +3,14 @@ import { state } from '../store';
 
 function changeTime(direction: -1 | 1) {
     if (state.satellite.satelliteImagesOn) { // Jump to the next timestmap within an hour of the current one
-        const currentIndex = state.satellite.satelliteTimeList.findIndex((item) => item === state.satellite.satelliteTimeStamp);
+        const currentIndex = state.satellite.satelliteTimeList.findIndex((item) => item.timestamp === state.satellite.satelliteTimeStamp);
         const currentImageTime = new Date(`${state.satellite.satelliteTimeStamp}Z`);
+        console.log(currentIndex);
         // Now we go from the current index and find the Next Day in either direction
         let newTime = null;
         let checkDateIndex = currentIndex + direction * 1
         while (newTime === null && currentIndex !== -1 && checkDateIndex >= 0) {
-            const checkTimeString = state.satellite.satelliteTimeList[checkDateIndex];
+            const checkTimeString = state.satellite.satelliteTimeList[checkDateIndex].timestamp;
             const checkTime = new Date(`${checkTimeString}Z`);
             const diffTime = Math.abs(checkTime.getTime() - currentImageTime.getTime());
             const diffDays = Math.ceil(diffTime / (60 * 60 * 24));
@@ -25,7 +26,6 @@ function changeTime(direction: -1 | 1) {
     } else {
         // satellite Images are on we change by day then
         const newTime = state.timestamp + ((60 * 60 * 24) * direction)
-        console.log('setting Time');
         const currentTime =  (Date.now().valueOf() / 1000.0)
         if (newTime >= state.timeMin && newTime <= currentTime ) {
             state.timestamp = newTime;

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -1,7 +1,6 @@
 import {
   layers as naturalearthLayers,
   sources as naturalearthSources,
-  sources,
 } from "./naturalearth";
 import {
   layers as openmaptilesLayers,

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -37,6 +37,15 @@ import { annotationColors, observationText, siteText } from "./annotationStyles"
 //   return filter;
 // }
 
+const buildTextOffset = (type: 'site' | 'observation', filters: MapFilters): [number, number] => {
+  if (filters.showSiteOutline && type === 'site') {
+    return [0, 0.5];
+  } else if (filters.showSiteOutline && type === 'observation') {
+    return [0, -0.5];
+  }
+  return [0, 0];
+}
+
 export const buildObservationFilter = (
   timestamp: number,
   filters: MapFilters
@@ -187,6 +196,8 @@ export const layers = (
       "text-font": ["Roboto Regular"],
       "text-max-width": 5,
       "text-size": 12,
+      "text-allow-overlap": true,
+      "text-offset": buildTextOffset('observation', filters),
       "text-field": observationText,
     },
     paint: {
@@ -226,6 +237,8 @@ export const layers = (
       "text-font": ["Roboto Regular"],
       "text-max-width": 5,
       "text-size": 12,
+      "text-allow-overlap": true,
+      "text-offset": buildTextOffset('site', filters),
       "text-field": siteText,
     },
     paint: {

--- a/vue/src/mapstyle/satellite-image.ts
+++ b/vue/src/mapstyle/satellite-image.ts
@@ -7,7 +7,7 @@ export const buildSourceFilter = (
     timestamp: number,
     satellite: SatelliteData
 ) => {
-    if (!satellite.satelliteImagesOn) {
+    if (!satellite.satelliteImagesOn || satellite.satelliteSources.length === 0) {
          return undefined;
     }
     const constellation = "S2";
@@ -56,7 +56,7 @@ export const layers = (
     timestamp: number,
     satellite: SatelliteData
   ): LayerSpecification[] => {
-    if (!satellite.satelliteImagesOn) {
+    if (!satellite.satelliteImagesOn || satellite.satelliteSources.length === 0) {
          return [];
     }
     const layers: LayerSpecification[] = [

--- a/vue/src/mapstyle/satellite-image.ts
+++ b/vue/src/mapstyle/satellite-image.ts
@@ -28,10 +28,19 @@ export const buildSourceFilter = (
       console.error(`Filter for current has infinite bounding box`);
     } else {
     const timeStamp = satellite.satelliteTimeStamp;
-      if (timeStamp !== '') {
+    const tileSource = satellite.satelliteTimeSource;
+    let sourceEndpoint = 'tile';
+    if (tileSource === 'WorldView') {
+      sourceEndpoint = 'visual-tile';
+    }
+    if (timeStamp !== '') {
+        let tiles = `${urlRoot}/api/satellite-image/${sourceEndpoint}/{z}/{x}/{y}.webp?timestamp=${timeStamp}`;
+        if ( tileSource === 'S2') {
+          tiles = `${tiles}&constellation=${constellation}&spectrum=${spectrum}&level=2A`
+        }
         const source: SourceSpecification = {
             type: "raster",
-            tiles: [`${urlRoot}/api/satellite-image/tile/{z}/{x}/{y}.webp?constellation=${constellation}&timestamp=${timeStamp}&spectrum=${spectrum}&level=2A`],
+            tiles: [tiles],
             minzoom: 0,
             maxzoom: 14,
             bounds: bbox,
@@ -66,7 +75,7 @@ export const layers = (
 
 export const setSatelliteTimeStamp = (state: { filters: MapFilters, satellite: SatelliteData, timestamp: number}) => {
   if (state.filters && state.satellite.satelliteTimeList && state.satellite.satelliteTimeList.length > 0) {
-    const list = state.satellite.satelliteTimeList.map((item) => new Date(`${item}Z`));
+    const list = state.satellite.satelliteTimeList.map((item) => new Date(`${item.timestamp}Z`));
     const base = new Date(state.timestamp * 1000);
     const filtered = list.filter((item) => item.valueOf() <= base.valueOf());
     let baseList = filtered;
@@ -81,6 +90,8 @@ export const setSatelliteTimeStamp = (state: { filters: MapFilters, satellite: S
     // Lets try to get the closes timestamp that is less than the current time.
     const date = baseList[0];
     const timeStamp = date.toISOString().substring(0,19);
+    const currentIndex = state.satellite.satelliteTimeList.findIndex((item) => item.timestamp === timeStamp);
+    state.satellite.satelliteTimeSource = state.satellite.satelliteTimeList[currentIndex].source;
     state.satellite.satelliteTimeStamp = timeStamp;
 }
 }

--- a/vue/src/mapstyle/satellite-image.ts
+++ b/vue/src/mapstyle/satellite-image.ts
@@ -1,5 +1,5 @@
 import type { LayerSpecification, SourceSpecification } from "maplibre-gl";
-import type { MapFilters, SatelliteData } from "../store";
+import type { MapFilters, SatelliteData, SatelliteTimeStamp } from "../store";
 
 const urlRoot = `${location.protocol}//${location.host}`;
 const satelliteImages = "satelliteTiles";
@@ -73,9 +73,9 @@ export const layers = (
     return layers;
   }
 
-export const setSatelliteTimeStamp = (state: { filters: MapFilters, satellite: SatelliteData, timestamp: number}) => {
-  if (state.filters && state.satellite.satelliteTimeList && state.satellite.satelliteTimeList.length > 0) {
-    const list = state.satellite.satelliteTimeList.map((item) => new Date(`${item.timestamp}Z`));
+export const setSatelliteTimeStamp = (state: { filters: MapFilters, satellite: SatelliteData, timestamp: number}, filteredTimeList: SatelliteTimeStamp[]) => {
+  if (state.filters && filteredTimeList && filteredTimeList.length > 0) {
+    const list = filteredTimeList.map((item) => new Date(`${item.timestamp}Z`));
     const base = new Date(state.timestamp * 1000);
     const filtered = list.filter((item) => item.valueOf() <= base.valueOf());
     let baseList = filtered;

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -1,4 +1,4 @@
-import { reactive } from "vue";
+import { computed, reactive } from "vue";
 
 import type { Region } from "./client";
 
@@ -28,6 +28,7 @@ export interface SatelliteData {
   satelliteBounds:[number,number][];
   loadingSatelliteImages: boolean;
   cloudCover: number;
+  satelliteSources: ('S2' |'WorldView')[];
 }
 
 export const state = reactive<{
@@ -69,6 +70,7 @@ export const state = reactive<{
     loadingSatelliteImages: false,
     satelliteTimeSource: 'S2',
     cloudCover: 100,
+    satelliteSources: ['S2', 'WorldView'],
   },
   patterns: {
     patternThickness: 8,
@@ -76,3 +78,12 @@ export const state = reactive<{
   },
   regionMap: {}
 });
+
+export const filteredSatelliteTimeList = computed(() => {
+  let filtered = state.satellite.satelliteTimeList;
+  if (state.satellite.cloudCover <  100 ) {
+    filtered = filtered.filter((item) => item.cloudcover < state.satellite.cloudCover);
+  }
+  filtered = filtered.filter((item) => state.satellite.satelliteSources.includes(item.source))
+  return filtered;
+})

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -70,7 +70,7 @@ export const state = reactive<{
     loadingSatelliteImages: false,
     satelliteTimeSource: 'S2',
     cloudCover: 100,
-    satelliteSources: ['S2', 'WorldView'],
+    satelliteSources: ['S2'],
   },
   patterns: {
     patternThickness: 8,

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -12,13 +12,22 @@ export interface MapFilters {
   showRegionPolygon?: boolean;
 }
 
+export interface SatelliteTimeStamp {
+  timestamp: string;
+  cloudcover: number;
+  collection: string;
+  source: 'S2' | 'WorldView'
+}
+
 export interface SatelliteData {
   satelliteImagesOn: boolean;
   imageOpacity: number;
-  satelliteTimeList: string[];
+  satelliteTimeList: SatelliteTimeStamp[];
+  satelliteTimeSource: 'S2' | 'WorldView'
   satelliteTimeStamp: string | null,
   satelliteBounds:[number,number][];
   loadingSatelliteImages: boolean;
+  cloudCover: number;
 }
 
 export const state = reactive<{
@@ -58,6 +67,8 @@ export const state = reactive<{
     satelliteBounds: [],
     imageOpacity: 0.75,
     loadingSatelliteImages: false,
+    satelliteTimeSource: 'S2',
+    cloudCover: 100,
   },
   patterns: {
     patternThickness: 8,


### PR DESCRIPTION
Refactors the request for satellite timestamps to do both sentinel and world-view at the same time.

- Instead of returning a flat list of timestamps it returns a list of objects (sorted by timestamp) which indicate each timestamp's source, collection, cloudcover).
- The front end has been modified to use this new data structure for the timestamps.
- There is a cloud cover filter and checkboxes to filter between S3 and WorldView Imagery.

Tips:

- US0005 is a decent sample region to look at to see the images.

Issues:

- Worldview Imagery takes a **LONG** time to download from the server if the region is decently large.  You can watch the console output and see the range requests happening.  I don't know enough about the COGReader and if there is a better way to do this.  I feel like it is trying to download/gather too much data based on the tile for some reason.
- So long in fact that there are 503 errors and some of the tiles just return 404 errors 
