### PR TITLE
Add caching to CI linting job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,11 @@ jobs:
           python-version: "3.10"
       - name: Install pre-commit
         run: pip install pre-commit
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-cache|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit checks
         run: pre-commit run --all-files
   lint-node:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
         args: [--config, django/pyproject.toml]
@@ -36,13 +36,13 @@ repos:
         args: [--py310-plus]
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.12.0
+    rev: 1.13.0
     hooks:
     -   id: django-upgrade
         args: [--target-version, "4.1"]
 
   - repo: https://github.com/PyCQA/autoflake
-    rev: v1.4
+    rev: v2.0.2
     hooks:
       - id: autoflake
         args:


### PR DESCRIPTION
This will speed up reporting of linting errors by caching the install of the pre-commit hooks.