### PR TITLE
Fix KeyError in WV imagery function

### DIFF
--- a/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
+++ b/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
@@ -66,7 +66,8 @@ def get_captures(
             pan_feature = next(
                 feat
                 for feat in features
-                if feat['properties'].get('nitf:image_representation', False) == 'MONO'
+                if 'B01' in feat['assets']
+                and feat['properties'].get('nitf:image_representation', False) == 'MONO'
                 and datetime.fromisoformat(feat['properties']['datetime'].rstrip('Z'))
                 == cap.timestamp
             )


### PR DESCRIPTION
To reproduce this bug, go to the following URL in any RGD deployment:
`/api/satellite-image/visual-timestamps?start_timestamp=2014-01-01T00:00:00&end_timestamp=2022-12-01T00:00:00&bbox=25.5370616,-33.791286441000004,25.5477044,-33.785965041000004`

It seems there are some worldview STAC assets that don't contain the expected `B01` field. I don't know what that field is, or why it would or would not be present in a STAC asset, but to my untrained eye it looks like the particular entry that is missing the  `B01` field is some sort of image _metadata_ and not an actual image. While most (maybe all?) of the other assets returned from the STAC server for WorldView appear to be TIFs, this particular asset is a IMD file, with the description `"IMD Metadata carried over from source data"`. Checking for the presence of the `B01` field fixes the issue and results in the above URL returning a series of timestamps as expected.