### PR TITLE
Control redis cluster mode with its own env var

### DIFF
--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -7,15 +7,13 @@ SECRET_KEY = environ['RDWATCH_SECRET_KEY']
 ALLOWED_HOSTS = ['*']
 DEBUG = environ['RDWATCH_DJANGO_DEBUG'].lower() in ('1', 'true', 'yes', 'on')
 
-if DEBUG:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-            'KEY_PREFIX': 'rdwatch',
-            'LOCATION': environ['RDWATCH_REDIS_URI'],
-        }
-    }
-else:
+REDIS_CLUSTER_MODE = environ.get('RDWATCH_REDIS_CLUSTER_MODE', '0').lower() in (
+    '1',
+    'true',
+    'yes',
+    'on',
+)
+if REDIS_CLUSTER_MODE:
     CACHES = {
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
@@ -25,6 +23,15 @@ else:
             },
         }
     }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'KEY_PREFIX': 'rdwatch',
+            'LOCATION': environ['RDWATCH_REDIS_URI'],
+        }
+    }
+
 DATABASE_PARSE_RESULT = urlparse(environ['RDWATCH_POSTGRESQL_URI'])
 DATABASES = {
     'default': {

--- a/template.env
+++ b/template.env
@@ -18,6 +18,9 @@ RDWATCH_POSTGRESQL_URI=
 #   redis://rdwatch:$RDWATCH_SECRET_KEY@redis:6379
 RDWATCH_REDIS_URI=
 
+# Set to "1" if your Redis instance is running in cluster mode.
+RDWATCH_REDIS_CLUSTER_MODE=
+
 # URL pointing to the SMART STAC server
 RDWATCH_SMART_STAC_URL=
 


### PR DESCRIPTION
This decouples it from the DEBUG env var, and allows the DEBUG var to be set while also enabling redis cluster mode.

This will require a corresponding change in the rgd_aws_infrastructure repo.