### PR TITLE
Refactor Site Observation Image Fetching

### DIFF
--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -219,7 +219,7 @@ def get_siteobservations_images(
                 timestamp=capture.timestamp,
                 source=baseConstellation,
             )
-            if found.count() > 0:
+            if found.exists():
                 existing = found.first()
                 existing.image.delete()
                 existing.cloudcover = cloudcover

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -1,6 +1,5 @@
 import io
 import logging
-import os
 from datetime import datetime, timedelta
 
 from celery import shared_task
@@ -68,33 +67,6 @@ def get_percent_black_pixels(bytes: bytes):
     return percent_black_pixels
 
 
-def get_closest_capture(
-    bbox: tuple[float, float, float, float],
-    timestamp: datetime,
-    constellation: str,
-    worldView=False,
-):
-    timebuffer = timedelta(days=1)
-    captures = None
-    if worldView:
-        captures = get_worldview_captures(timestamp, bbox, timebuffer)
-    else:
-        captures = list(get_bands(constellation, timestamp, bbox, timebuffer))
-
-        # Filter bands by requested processing level and spectrum
-        tempCaptures = []
-        for band in captures:
-            if band.level.slug == '2A' and band.spectrum.slug == 'visual':
-                tempCaptures.append(band)
-        captures = tempCaptures
-    # logger.warning(f'Captures: {len(captures)}')
-    if not captures:
-        return None
-    closest_capture = min(captures, key=lambda band: abs(band.timestamp - timestamp))
-
-    return closest_capture
-
-
 def get_range_captures(
     bbox: tuple[float, float, float, float],
     timestamp: datetime,
@@ -102,7 +74,6 @@ def get_range_captures(
     timebuffer: timedelta,
     worldView=False,
 ):
-    captures = None
     if worldView:
         captures = get_worldview_captures(timestamp, bbox, timebuffer)
     else:
@@ -114,9 +85,6 @@ def get_range_captures(
             if band.level.slug == '2A' and band.spectrum.slug == 'visual':
                 tempCaptures.append(band)
         captures = tempCaptures
-    # logger.warning(f'Captures: {len(captures)}')
-    if not captures:
-        return None
 
     return captures
 
@@ -127,19 +95,19 @@ def fetch_boundbox_image(
     constellation: str,
     worldView=False,
 ):
-    capture = get_closest_capture(bbox, timestamp, constellation, worldView)
-    # logger.warning(f'Closest Capture is: {capture}')
-    if capture is None:
+    timebuffer = timedelta(days=1)
+    captures = get_range_captures(bbox, timestamp, constellation, timebuffer, worldView)
+    if len(captures) == 0:
         return None
-    bytes = None
+    closest_capture = min(captures, key=lambda band: abs(band.timestamp - timestamp))
     if worldView:
-        bytes = get_worldview_processed_visual_bbox(capture, bbox)
+        bytes = get_worldview_processed_visual_bbox(closest_capture, bbox)
     else:
-        bytes = get_raster_bbox(capture.uri, bbox)
+        bytes = get_raster_bbox(closest_capture.uri, bbox)
     return {
         'bytes': bytes,
-        'cloudcover': capture.cloudcover,
-        'timestamp': capture.timestamp,
+        'cloudcover': closest_capture.cloudcover,
+        'timestamp': closest_capture.timestamp,
     }
 
 
@@ -156,7 +124,7 @@ def get_siteobservations_images(
     matchConstellation = ''
     baseSiteEval = None
     # First we gather all images that match observations
-    for observation in site_observations:
+    for observation in site_observations.iterator():
         min_time = min(min_time, observation.timestamp)
         max_time = max(max_time, observation.timestamp)
         mercator: tuple[float, float, float, float] = observation.geom.extent
@@ -196,26 +164,22 @@ def get_siteobservations_images(
             found_timestamps[found_timestamp] = True
             # logger.warning(f'Retrieved Image with timestamp: {timestamp}')
             output = f'tile_image_{observation.id}.jpg'
-            with open(output, 'wb') as f:
-                f.write(bytes)
-            with open(output, 'rb') as imageFile:
-                image = File(imageFile, output)
-                if found.count() > 0:
-                    existing = found.first()
-                    existing.image.delete()  # remove previous image if new one found
-                    existing.cloudcover = cloudcover
-                    existing.image = image
-                    existing.save()
-                else:
-                    SiteImage.objects.create(
-                        siteeval=observation.siteeval,
-                        siteobs=observation,
-                        timestamp=observation.timestamp,
-                        image=image,
-                        cloudcover=cloudcover,
-                        source=baseConstellation,
-                    )
-            os.remove(output)
+            image = File(io.BytesIO(bytes), name=output)
+            if found.count() > 0:
+                existing = found.first()
+                existing.image.delete()  # remove previous image if new one found
+                existing.cloudcover = cloudcover
+                existing.image = image
+                existing.save()
+            else:
+                SiteImage.objects.create(
+                    siteeval=observation.siteeval,
+                    siteobs=observation,
+                    timestamp=observation.timestamp,
+                    image=image,
+                    cloudcover=cloudcover,
+                    source=baseConstellation,
+                )
 
     # Now we need to go through and find all other images
     # that exist in the start/end range of the siteEval
@@ -249,27 +213,23 @@ def get_siteobservations_images(
             cloudcover = capture.cloudcover
             count += 1
             output = f'tile_image_{observation.siteeval}_nonobs_{count}.jpg'
-            with open(output, 'wb') as f:
-                f.write(bytes)
-            with open(output, 'rb') as imageFile:
-                image = File(imageFile, output)
-                found = SiteImage.objects.filter(
+            image = File(io.BytesIO(bytes), name=output)
+            found = SiteImage.objects.filter(
+                siteeval=baseSiteEval,
+                timestamp=capture.timestamp,
+                source=baseConstellation,
+            )
+            if found.count() > 0:
+                existing = found.first()
+                existing.image.delete()
+                existing.cloudcover = cloudcover
+                existing.image = image
+                existing.save()
+            else:
+                SiteImage.objects.create(
                     siteeval=baseSiteEval,
                     timestamp=capture.timestamp,
+                    image=image,
+                    cloudcover=cloudcover,
                     source=baseConstellation,
                 )
-                if found.count() > 0:
-                    existing = found.first()
-                    existing.image.delete()
-                    existing.cloudcover = cloudcover
-                    existing.image = image
-                    existing.save()
-                else:
-                    SiteImage.objects.create(
-                        siteeval=baseSiteEval,
-                        timestamp=capture.timestamp,
-                        image=image,
-                        cloudcover=cloudcover,
-                        source=baseConstellation,
-                    )
-            os.remove(output)

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -165,7 +165,7 @@ def get_siteobservations_images(
             # logger.warning(f'Retrieved Image with timestamp: {timestamp}')
             output = f'tile_image_{observation.id}.jpg'
             image = File(io.BytesIO(bytes), name=output)
-            if found.count() > 0:
+            if found.exists():
                 existing = found.first()
                 existing.image.delete()  # remove previous image if new one found
                 existing.cloudcover = cloudcover

--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
         name='satellite-visual-tiles',
     ),
     path(
-        'observations/<int:pk>/get-images',
+        'observations/<int:pk>/generate-images',
         views.get_site_observation_images,
     ),
 ]

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -78,7 +78,7 @@ export class ApiService {
       ): CancelablePromise<boolean> {
         return __request(OpenAPI, {
           method: "POST",
-          url: "/api/observations/{id}/get-images",
+          url: "/api/observations/{id}/generate-images",
           path: {
             id: id,
           },

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -2,7 +2,6 @@ import { Ref, ref } from "vue";
 import { Color, Map, MapLayerMouseEvent, Popup } from "maplibre-gl";
 import { ShallowRef } from "vue";
 import { getSiteObservationDetails, selectedObservationList, state } from "../store";
-import { ApiService } from "../client";
 
 const checkBadge =
   '<svg style="display:inline;" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="replacementColor" aria-hidden="true"><path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0112 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 013.498 1.307 4.491 4.491 0 011.307 3.497A4.49 4.49 0 0121.75 12a4.49 4.49 0 01-1.549 3.397 4.491 4.491 0 01-1.307 3.497 4.491 4.491 0 01-3.497 1.307A4.49 4.49 0 0112 21.75a4.49 4.49 0 01-3.397-1.549 4.49 4.49 0 01-3.498-1.306 4.491 4.491 0 01-1.307-3.498A4.49 4.49 0 012.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 011.307-3.497 4.49 4.49 0 013.497-1.307zm7.007 6.387a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z" clip-rule="evenodd"></path></svg>';
@@ -83,10 +82,6 @@ const popupLogic = (map: ShallowRef<null | Map>) => {
                       `rgba(0,0,0,0)`
                     );
                   }
-                  if (area){
-                    const areaDiv = `<div class='badge'>${area.toFixed(0)}m<sup>2</sup></div>`;
-                  }
-
                   const scoreStyle = `style="background-color:${calculateScoreColor(
                     score.toFixed(2)
                   )};color: black; font-weight:bolder; opacity: 1.0 !important;"`;


### PR DESCRIPTION
Based on the comments on the previous PR I've refactored and improved a couple things.

- Only one function `get_range_captures` where closest capture just specifies a timebuffer of 1 day and then filters for the closest capture
- The Temporary File writing is eliminated, I could write the bytes directly into a Django File object instead of requiring any temporary file.
- changed from `get-images` to `generate-images` in frontend/backend
- Cleaned up some dangling stuff for area calculations in the client.