### PR TITLE
Fix migrations not running on deploys

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,11 +21,11 @@ if [ "$1" = "unitd" ]; then
   fi
 fi
 
-# Run migrations if `django-admin` is installed
-if command -v "django-admin"; then
-  cd /app/django
-  poetry run django-admin migrate
-  cd -
-fi
+# Attempt to run migrations (will only work if `django-admin` is installed)
+set +e
+poetry install --directory /app/django --only main
+poetry run --directory /app/django django-admin migrate
+poetry run --directory /app/django django-admin loaddata lookups
+set -e
 
 exec "$@"


### PR DESCRIPTION
Cherry picked out of #192 , these are more urgent fixes than the rest of that PR.

- Runs `poetry install` before migrations. In some situations, the migrations are run _before_ any `poetry install` command happens, which causes an error if there are missing dependencies.
- Ignore failed `migrate` command. This might happen if `django-admin` is not installed in the docker image yet.
- Add lookups fixture loading to docker image. This should be fine, as the operation is idempotent due to the primary keys of each row being specified in the fixture.
