### PR TITLE
Various Fixes

### DIFF
--- a/django/src/rdwatch/views/site_observation.py
+++ b/django/src/rdwatch/views/site_observation.py
@@ -138,7 +138,9 @@ def get_site_observation_images(request: HttpRequest, pk: int):
             fetching_task.save()
         else:
             fetching_task = SatelliteFetching.objects.create(
-                siteeval=siteeval, timestamp=datetime.now()
+                siteeval=siteeval,
+                timestamp=datetime.now(),
+                status=SatelliteFetching.Status.RUNNING,
             )
         get_siteobservations_images.delay(pk, constellation)
     return Response(status=202)

--- a/vue/src/components/siteObservations/EvaluationDisplay.vue
+++ b/vue/src/components/siteObservations/EvaluationDisplay.vue
@@ -347,7 +347,7 @@ const isRunning = computed(() => {
           Cloud: {{ currentClosestTimestamp.cloudCover }}%
         </div>
         <div
-          v-if="currentClosestTimestamp && currentClosestTimestamp.percentBlack !== undefined"
+          v-if="currentClosestTimestamp && currentClosestTimestamp.percentBlack !== undefined && currentClosestTimestamp.percentBlack !== null"
           class="col-span-1 text-xs font-light justify-self-end"
         >
           NoData: {{ currentClosestTimestamp.percentBlack.toFixed(0) }}%

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -179,9 +179,9 @@ export const getSiteObservationDetails = async (siteId: string) => {
   const data = await ApiService.getSiteObservations(siteId);
   const { results } = data;
   const { images } = data;
-  const worldViewList = images.results.filter((item) => item.source === 'WV')
+  const worldViewList = images.results.filter((item) => item.source === 'WV' && item.image !== null)
     .sort((a, b) => (a.timestamp - b.timestamp));
-  const S2List = images.results.filter((item) => item.source === 'S2').sort((a, b) => (a.timestamp - b.timestamp));
+  const S2List = images.results.filter((item) => item.source === 'S2' && item.image !== null).sort((a, b) => (a.timestamp - b.timestamp));
 
   const L8 = { 
     total: results.filter((item) => item.constellation === 'L8').length,


### PR DESCRIPTION
- The Status wasn't included when initializing a sitefetching table
- Added some error handling for a URLError I saw during some testing
- Somehow empty images were getting created with null image and percent_black being null.  While they can initially have this it shouldn't be something that exists.  I added a check in the task logic to skip over images that return None and on the client side it will filter any existing data which has null.
- 