### PR TITLE
Support missing `score` for site observation

### DIFF
--- a/django/src/rdwatch/models/site_evaluation.py
+++ b/django/src/rdwatch/models/site_evaluation.py
@@ -63,9 +63,6 @@ class SiteEvaluation(models.Model):
             label = lookups.ObservationLabel.objects.get(
                 slug=site_feature.properties.status
             )
-            # A missing score indicates a score of 1.0.
-            # https://smartgitlab.com/TE/standards/-/wikis/Site-Model-Specification#score-float-optional
-            score = site_feature.properties.score or 1.0
 
             site_eval = cls.objects.create(
                 configuration=configuration,
@@ -74,7 +71,7 @@ class SiteEvaluation(models.Model):
                 timestamp=datetime.now(),
                 geom=site_feature.geometry,
                 label=label,
-                score=score,
+                score=site_feature.properties.score,
             )
 
             SiteObservation.bulk_create_from_site_evaluation(site_eval, site_model)
@@ -110,10 +107,6 @@ class SiteEvaluation(models.Model):
                 if isinstance(geometry, MultiPolygon):
                     geometry = geometry.convex_hull
 
-                # A missing score indicates a score of 1.0.
-                # https://smartgitlab.com/TE/standards/-/wikis/Region-Model-Specification#score-float-optional
-                score = feature.properties.score or 1.0
-
                 site_eval = cls(
                     configuration=configuration,
                     region=region,
@@ -121,7 +114,7 @@ class SiteEvaluation(models.Model):
                     timestamp=datetime.now(),
                     geom=geometry,
                     label=label_map[feature.properties.status],
-                    score=score,
+                    score=feature.properties.score,
                 )
                 site_evals.append(site_eval)
 

--- a/django/src/rdwatch/models/site_observation.py
+++ b/django/src/rdwatch/models/site_observation.py
@@ -89,9 +89,6 @@ class SiteObservation(models.Model):
         for feature in site_model.observation_features:
             assert isinstance(feature.properties, ObservationFeature)
 
-            if not feature.properties.observation_date:
-                continue
-
             constellation = constellation_map.get(feature.properties.sensor_name, None)
 
             assert isinstance(feature.geometry, MultiPolygon)

--- a/django/src/rdwatch/schemas/region_model.py
+++ b/django/src/rdwatch/schemas/region_model.py
@@ -92,6 +92,16 @@ class SiteSummaryFeature(Schema):
             return v
         return datetime.strptime(v, '%Y-%m-%d')
 
+    @validator('score', pre=True, always=True)
+    def parse_score(cls, v: float | None) -> float:
+        """
+        Score is an optional field, and defaults to 1.0 if one isn't provided
+        https://smartgitlab.com/TE/standards/-/wikis/Region-Model-Specification#score-float-optional
+        """
+        if v is None:
+            return 1.0
+        return v
+
     @property
     def site_number(self) -> int:
         return int(self.site_id[8:])

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -81,7 +81,7 @@ class SiteFeature(Schema):
 
 class ObservationFeature(Schema):
     type: Literal['observation']
-    observation_date: datetime | None
+    observation_date: datetime
     source: str | None
     sensor_name: Literal['Landsat 8', 'Sentinel-2', 'WorldView', 'Planet'] | None
     current_phase: list[
@@ -123,9 +123,7 @@ class ObservationFeature(Schema):
         return val.split(', ')
 
     @validator('observation_date', pre=True)
-    def parse_dates(cls, v: str | None) -> datetime | None:
-        if v is None:
-            return v
+    def parse_dates(cls, v: str) -> datetime:
         return datetime.strptime(v, '%Y-%m-%d')
 
     @root_validator

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -145,6 +145,16 @@ class ObservationFeature(Schema):
     score: float | None
     misc_info: dict[Any, Any] | None
 
+    @validator('score', pre=True, always=True)
+    def parse_score(cls, v: float | None) -> float:
+        """
+        Score is an optional field, and defaults to 1.0 if one isn't provided
+        https://smartgitlab.com/TE/standards/-/wikis/Site-Model-Specification#score-float-optional-1
+        """
+        if v is None:
+            return 1.0
+        return v
+
 
 class Feature(Schema):
     class Config:

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -64,6 +64,16 @@ class SiteFeature(Schema):
             return v
         return datetime.strptime(v, '%Y-%m-%d')
 
+    @validator('score', pre=True, always=True)
+    def parse_score(cls, v: float | None) -> float:
+        """
+        Score is an optional field, and defaults to 1.0 if one isn't provided
+        https://smartgitlab.com/TE/standards/-/wikis/Site-Model-Specification#score-float-optional
+        """
+        if v is None:
+            return 1.0
+        return v
+
     @property
     def site_number(self) -> int:
         return int(self.site_id[8:])


### PR DESCRIPTION
#191 fixed this for site evaluations, but not site observations; this PR fixes that.