### PR TITLE
Update site model ingest routine to latest spec

### DIFF
--- a/django/src/rdwatch/models/site_observation.py
+++ b/django/src/rdwatch/models/site_observation.py
@@ -1,7 +1,7 @@
 from typing_extensions import Self
 
 from django.contrib.gis.db.models import PolygonField
-from django.contrib.gis.geos import MultiPolygon
+from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.contrib.postgres.indexes import GistIndex
 from django.db import models
 
@@ -91,9 +91,15 @@ class SiteObservation(models.Model):
 
             constellation = constellation_map.get(feature.properties.sensor_name, None)
 
-            assert isinstance(feature.geometry, MultiPolygon)
+            assert isinstance(feature.geometry, Polygon | MultiPolygon)
 
-            for i, polygon in enumerate(feature.geometry):
+            geometry = (
+                feature.geometry
+                if isinstance(feature.geometry, MultiPolygon)
+                else MultiPolygon([feature.geometry])
+            )
+
+            for i, polygon in enumerate(geometry):
                 if feature.properties.current_phase:
                     phase = feature.properties.current_phase[i]
                 else:

--- a/django/src/rdwatch/schemas/region_model.py
+++ b/django/src/rdwatch/schemas/region_model.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from ninja import Field, Schema
-from pydantic import constr, validator
+from pydantic import confloat, constr, validator
 
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry, Polygon
@@ -82,7 +82,7 @@ class SiteSummaryFeature(Schema):
 
     # Optional fields
     comments: str | None
-    score: float | None
+    score: confloat(ge=0.0, le=1.0) | None
     validated: Literal['True', 'False'] | None
     annotation_cache: dict[Any, Any] | None
 


### PR DESCRIPTION
The spec for site models has been updated, this PR tweaks our ingest routines to account for these changes. Most notably, site `observations` can now have either `Polygon` or `MultiPolygon` geometries. 