### PR TITLE
Don't run poetry install in docker entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,7 +21,6 @@ if [ "$1" = "unitd" ]; then
   fi
 fi
 
-poetry install --directory /app/django --only main
 poetry run --directory /app/django /app/django/src/manage.py migrate
 poetry run --directory /app/django /app/django/src/manage.py loaddata lookups
 


### PR DESCRIPTION
This is already done in the Dockerfile and shouldn't need to be repeated. It also seems to be causing a deployment failure when I tried deploying the latest image, logs are here https://us-west-2.console.aws.amazon.com/ecs/v2/clusters/resonantgeodatablue-fargate-cluster/services/resonantgeodatablue-worker-service/tasks/762716d1bb7a43e7a3fdd18d5b23f873/logs?region=us-west-2