### PR TITLE
Build docker images in parallel

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+      - parallelize-builds
 concurrency:
   # Only run the latest workflow.
   # If a build is already happening, cancel it to avoid a race
@@ -11,8 +12,14 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    name: Build [rdwatch]
+    name: Build [rdwatch] (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -33,14 +40,64 @@ jobs:
           result-encoding: string
           script: return 'ghcr.io/${{ github.repository }}'.toLowerCase()
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        id: build
+        uses: docker/build-push-action@v4
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.repo-slug.outputs.result }}/rdwatch:latest
+          outputs: type=image,name=${{ steps.repo-slug.outputs.result }}/rdwatch,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Sanitize repo slug
+        uses: actions/github-script@v6
+        id: repo-slug
+        with:
+          result-encoding: string
+          script: return 'ghcr.io/${{ github.repository }}'.toLowerCase()
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.repo-slug.outputs.result }}/rdwatch
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ steps.repo-slug.outputs.result }}/rdwatch@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ steps.repo-slug.outputs.result }}/rdwatch:${{ steps.meta.outputs.version }}
+
   publish-cli:
     name: Build [rdwatch-cli]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should help speed up builds, or at least prevent the amd64 image build from getting held up by the arm64 one.

See https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners