### PR TITLE
Explicitly copy venv dir in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/nginx.gpg] http://packages.nginx.or
  && usermod --lock rdwatch \
  && usermod --append --groups rdwatch unit
 RUN python3 -m pip install poetry==1.4.2
+RUN poetry config virtualenvs.in-project false \
+ && poetry config virtualenvs.path /poetry/venvs
 WORKDIR /app
 EXPOSE 80
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
@@ -102,6 +104,10 @@ RUN chmod -R u=rX,g=rX,o= .
 
 # Final image
 FROM base
+COPY --from=django-builder \
+     --chown=rdwatch:rdwatch \
+     /poetry/venvs \
+     /poetry/venvs
 COPY --from=django-dist \
      --chown=rdwatch:rdwatch \
      /app/django \


### PR DESCRIPTION
Since we relocated the venv directory to `/poetry/venvs` instead of `/app/django`, we now need to explicitly copy it in the final build stage. Deploys are currently failing with an error due to this issue.