### PR TITLE
Add celery beat

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,11 +44,11 @@ but allows developers to run Python code on their native system.
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
    2. `poetry run --directory django celery --app rdwatch.celery worker --loglevel INFO --without-heartbeat`
-3. Run in another separate terminal:
+4. Run in another separate terminal:
    1. `source ./dev/export-env.sh`
    2. `poetry run --directory django celery --app rdwatch.celery beat --loglevel INFO`
-4. When finished, run `docker compose stop`
-5. To destroy the stack and start fresh, run `docker compose down`
+5. When finished, run `docker compose stop`
+6. To destroy the stack and start fresh, run `docker compose down`
    1. Note: this command does not destroy docker volumes, such as those associated with the postgresql and minio services. To destroy those as well, run `docker compose down -v`.
 
 ### Running DB migrations manually

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,6 +44,9 @@ but allows developers to run Python code on their native system.
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
    2. `poetry run --directory django celery --app rdwatch.celery worker --loglevel INFO --without-heartbeat`
+3. Run in another separate terminal:
+   1. `source ./dev/export-env.sh`
+   2. `poetry run --directory django celery --app rdwatch.celery beat --loglevel INFO`
 4. When finished, run `docker compose stop`
 5. To destroy the stack and start fresh, run `docker compose down`
    1. Note: this command does not destroy docker volumes, such as those associated with the postgresql and minio services. To destroy those as well, run `docker compose down -v`.

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 from configurations import Configuration, values
 
@@ -92,6 +93,13 @@ class BaseConfiguration(Configuration):
     CELERY_CACHE_BACKEND = 'django-cache'
     CELERY_RESULT_EXTENDED = True
     CELERYD_TIME_LIMIT = 1200
+
+    CELERY_BEAT_SCHEDULE = {
+        'delete-temp-model-runs-beat': {
+            'task': 'rdwatch.tasks.delete_temp_model_runs_task',
+            'schedule': timedelta(seconds=60),
+        },
+    }
 
 
 class DevelopmentConfiguration(BaseConfiguration):

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -97,7 +97,7 @@ class BaseConfiguration(Configuration):
     CELERY_BEAT_SCHEDULE = {
         'delete-temp-model-runs-beat': {
             'task': 'rdwatch.tasks.delete_temp_model_runs_task',
-            'schedule': timedelta(seconds=60),
+            'schedule': timedelta(hours=1),
         },
     }
 

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -2,6 +2,7 @@ import io
 import logging
 from datetime import datetime, timedelta
 
+from celery import shared_task
 from pyproj import Transformer
 
 from django.core.files import File
@@ -200,3 +201,10 @@ def get_siteobservations_images(
     fetching_task.status = SatelliteFetching.Status.COMPLETE
     fetching_task.celery_id = ''
     fetching_task.save()
+
+
+@shared_task
+def delete_temp_model_runs_task() -> None:
+    """Delete all model runs that are due to be deleted."""
+    print('Test')
+    # TODO: implement this

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -1,123 +1,26 @@
 import io
 import logging
 from datetime import datetime, timedelta
-from urllib.error import URLError
 
-from PIL import Image
 from pyproj import Transformer
 
 from django.core.files import File
 
 from rdwatch.celery import app
 from rdwatch.models import SatelliteFetching, SiteImage, SiteObservation
+from rdwatch.utils.images import (
+    fetch_boundbox_image,
+    get_max_bbox,
+    get_percent_black_pixels,
+    get_range_captures,
+    scale_bbox,
+)
 from rdwatch.utils.raster_tile import get_raster_bbox
-from rdwatch.utils.satellite_bands import get_bands
 from rdwatch.utils.worldview_processed.raster_tile import (
     get_worldview_processed_visual_bbox,
 )
-from rdwatch.utils.worldview_processed.satellite_captures import (
-    get_captures as get_worldview_captures,
-)
 
 logger = logging.getLogger(__name__)
-
-
-def scale_bbox(bbox: tuple[float, float, float, float], scale_factor: float):
-    xmin, ymin, xmax, ymax = bbox
-    width = xmax - xmin
-    height = ymax - ymin
-    new_width = width * scale_factor
-    new_height = height * scale_factor
-    new_xmin = xmin - ((new_width - width) / 2)
-    new_ymin = ymin - ((new_height - height) / 2)
-    new_xmax = xmax + ((new_width - width) / 2)
-    new_ymax = ymax + ((new_height - height) / 2)
-    scaled_bbox = [new_xmin, new_ymin, new_xmax, new_ymax]
-    return scaled_bbox
-
-
-def get_max_bbox(
-    bbox: tuple[float, float, float, float], maxbbox: tuple[float, float, float, float]
-):
-    newbbox = [
-        min(bbox[0], maxbbox[0]),
-        min(bbox[1], maxbbox[1]),
-        max(bbox[2], maxbbox[3]),
-        max(bbox[2], maxbbox[3]),
-    ]
-    return newbbox
-
-
-def get_percent_black_pixels(bytes: bytes):
-    img = Image.open(io.BytesIO(bytes))
-    # determine the size of the image
-    width, height = img.size
-
-    # get the pixel data of the image
-    pixels = img.load()
-
-    # count the number of black pixels in the image
-    num_black_pixels = 0
-    for x in range(width):
-        for y in range(height):
-            if pixels[x, y] == (0, 0, 0):
-                num_black_pixels += 1
-
-    # calculate the percentage of black pixels in the image
-    percent_black_pixels = (num_black_pixels / (width * height)) * 100
-    return percent_black_pixels
-
-
-def get_range_captures(
-    bbox: tuple[float, float, float, float],
-    timestamp: datetime,
-    constellation: str,
-    timebuffer: timedelta,
-    worldView=False,
-):
-    if worldView:
-        captures = get_worldview_captures(timestamp, bbox, timebuffer)
-    else:
-        captures = list(get_bands(constellation, timestamp, bbox, timebuffer))
-
-        # Filter bands by requested processing level and spectrum
-        tempCaptures = []
-        for band in captures:
-            if band.level.slug == '2A' and band.spectrum.slug == 'visual':
-                tempCaptures.append(band)
-        captures = tempCaptures
-
-    return captures
-
-
-def fetch_boundbox_image(
-    bbox: tuple[float, float, float, float],
-    timestamp: datetime,
-    constellation: str,
-    worldView=False,
-):
-    timebuffer = timedelta(days=1)
-    try:
-        captures = get_range_captures(
-            bbox, timestamp, constellation, timebuffer, worldView
-        )
-    except URLError as e:
-        logger.warning('Failed to get range capture because of URLError')
-        logger.warning(e)
-        return None
-
-    if len(captures) == 0:
-        return None
-    closest_capture = min(captures, key=lambda band: abs(band.timestamp - timestamp))
-    if worldView:
-        bytes = get_worldview_processed_visual_bbox(closest_capture, bbox)
-    else:
-        bytes = get_raster_bbox(closest_capture.uri, bbox)
-    return {
-        'bytes': bytes,
-        'cloudcover': closest_capture.cloudcover,
-        'timestamp': closest_capture.timestamp,
-    }
 
 
 @app.task(bind=True)

--- a/django/src/rdwatch/utils/images.py
+++ b/django/src/rdwatch/utils/images.py
@@ -1,0 +1,115 @@
+import io
+import logging
+from datetime import datetime, timedelta
+from urllib.error import URLError
+
+from PIL import Image
+
+from rdwatch.utils.raster_tile import get_raster_bbox
+from rdwatch.utils.satellite_bands import get_bands
+from rdwatch.utils.worldview_processed.raster_tile import (
+    get_worldview_processed_visual_bbox,
+)
+from rdwatch.utils.worldview_processed.satellite_captures import (
+    get_captures as get_worldview_captures,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def scale_bbox(bbox: tuple[float, float, float, float], scale_factor: float):
+    xmin, ymin, xmax, ymax = bbox
+    width = xmax - xmin
+    height = ymax - ymin
+    new_width = width * scale_factor
+    new_height = height * scale_factor
+    new_xmin = xmin - ((new_width - width) / 2)
+    new_ymin = ymin - ((new_height - height) / 2)
+    new_xmax = xmax + ((new_width - width) / 2)
+    new_ymax = ymax + ((new_height - height) / 2)
+    scaled_bbox = [new_xmin, new_ymin, new_xmax, new_ymax]
+    return scaled_bbox
+
+
+def get_max_bbox(
+    bbox: tuple[float, float, float, float], maxbbox: tuple[float, float, float, float]
+):
+    newbbox = [
+        min(bbox[0], maxbbox[0]),
+        min(bbox[1], maxbbox[1]),
+        max(bbox[2], maxbbox[3]),
+        max(bbox[2], maxbbox[3]),
+    ]
+    return newbbox
+
+
+def get_percent_black_pixels(bytes: bytes):
+    img = Image.open(io.BytesIO(bytes))
+    # determine the size of the image
+    width, height = img.size
+
+    # get the pixel data of the image
+    pixels = img.load()
+
+    # count the number of black pixels in the image
+    num_black_pixels = 0
+    for x in range(width):
+        for y in range(height):
+            if pixels[x, y] == (0, 0, 0):
+                num_black_pixels += 1
+
+    # calculate the percentage of black pixels in the image
+    percent_black_pixels = (num_black_pixels / (width * height)) * 100
+    return percent_black_pixels
+
+
+def get_range_captures(
+    bbox: tuple[float, float, float, float],
+    timestamp: datetime,
+    constellation: str,
+    timebuffer: timedelta,
+    worldView=False,
+):
+    if worldView:
+        captures = get_worldview_captures(timestamp, bbox, timebuffer)
+    else:
+        captures = list(get_bands(constellation, timestamp, bbox, timebuffer))
+
+        # Filter bands by requested processing level and spectrum
+        tempCaptures = []
+        for band in captures:
+            if band.level.slug == '2A' and band.spectrum.slug == 'visual':
+                tempCaptures.append(band)
+        captures = tempCaptures
+
+    return captures
+
+
+def fetch_boundbox_image(
+    bbox: tuple[float, float, float, float],
+    timestamp: datetime,
+    constellation: str,
+    worldView=False,
+):
+    timebuffer = timedelta(days=1)
+    try:
+        captures = get_range_captures(
+            bbox, timestamp, constellation, timebuffer, worldView
+        )
+    except URLError as e:
+        logger.warning('Failed to get range capture because of URLError')
+        logger.warning(e)
+        return None
+
+    if len(captures) == 0:
+        return None
+    closest_capture = min(captures, key=lambda band: abs(band.timestamp - timestamp))
+    if worldView:
+        bytes = get_worldview_processed_visual_bbox(closest_capture, bbox)
+    else:
+        bytes = get_raster_bbox(closest_capture.uri, bbox)
+    return {
+        'bytes': bytes,
+        'cloudcover': closest_capture.cloudcover,
+        'timestamp': closest_capture.timestamp,
+    }

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -32,7 +32,7 @@ services:
       - redis-master
       - minio
 
-  celery:
+  celery_worker:
     build:
       dockerfile: Dockerfile
       target: dev
@@ -65,3 +65,25 @@ services:
         condition: service_started
       django:
         condition: service_healthy
+
+  celery_beat:
+    build:
+      dockerfile: Dockerfile
+      target: dev
+    command: [
+      "poetry", "run",
+      "--directory", "/app/django",
+      "celery",
+      "--app", "rdwatch.celery",
+      "beat",
+      "--loglevel", "INFO",
+    ]
+    env_file:
+      - .env
+      - ./dev/.env.docker-compose
+    environment:
+      RDWATCH_POSTGRESQL_URI: "postgresql://rdwatch:secretkey@postgresql:5432/rdwatch"
+      RDWATCH_REDIS_URI: "redis://:secretkey@redis-master:6379"
+      RDWATCH_CELERY_BROKER_URL: amqp://rdwatch:secretkey@rabbitmq:5672/
+    volumes:
+      - ./django:/app/django


### PR DESCRIPTION
This PR 
- Moves all non-task functions out of `rdwatch.tasks` and into their own module
	- This is the usual practice when it comes to celery tasks AFAIK, and it also makes it easier to see all celery tasks at a glance. @BryonLewis any objections to this?
- Adds a new docker compose service for celery beat and instructions for running it natively.
- Adds a stub task that runs once a minute. I will make a follow up to actually implement the "temporary" model run logic, where this task will be responsible for querying for and deleting model runs that need to be deleted.