### PR TITLE
Fixes Tooltips and NavBars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN apt-get update \
       nodejs \
       npm \
       python3-dev \
+      python3.10-venv \
  && rm -rf /var/lib/apt/lists/* \
- && poetry config installer.parallel true \
- && poetry config virtualenvs.in-project true
+ && poetry config installer.parallel true 
 
 FROM builder as vue-builder
 WORKDIR /app/vue
@@ -60,6 +60,9 @@ RUN npm ci
 
 FROM builder AS django-builder
 WORKDIR /app/django
+RUN python3 -m venv /poetry/venvs/rdwatch
+ENV PATH="/poetry/venvs/rdwatch/bin:$PATH" 
+ENV VIRTUAL_ENV=/poetry/venvs/rdwatch
 COPY django/pyproject.toml django/poetry.lock /app/django/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \
@@ -72,6 +75,9 @@ RUN mkdir /app/django/src \
 # For use in a development environment.
 FROM builder AS dev
 WORKDIR /app/django
+RUN python3 -m venv /poetry/venvs/rdwatch
+ENV PATH="/poetry/venvs/rdwatch/bin:$PATH" 
+ENV VIRTUAL_ENV=/poetry/venvs/rdwatch
 COPY django/pyproject.toml django/poetry.lock /app/django/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \

--- a/docker/nginx.json
+++ b/docker/nginx.json
@@ -34,7 +34,7 @@
       "type": "python 3.10",
       "user": "rdwatch",
       "group": "rdwatch",
-      "home": "/app/django/.venv",
+      "home": "/poetry/venvs/",
       "module": "rdwatch.server",
       "threads": 25,
       "limits": {

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -12,6 +12,7 @@ import EvaluationsSideBar from "./components/siteObservations/EvaluationsSideBar
       width="400"
       sticky
       style="max-height:100vh;"
+      permanent
     >
       <SideBar />
     </v-navigation-drawer>
@@ -22,6 +23,7 @@ import EvaluationsSideBar from "./components/siteObservations/EvaluationsSideBar
       location="right"
       width="400"
       sticky
+      permanent
     >
       <EvaluationsSideBar />
     </v-navigation-drawer>

--- a/vue/src/components/PopUpComponent.vue
+++ b/vue/src/components/PopUpComponent.vue
@@ -1,20 +1,18 @@
-<script setup lang="ts">
-interface PopUpData {
-  siteId: string;
-  siteColor: string;
-  score: number;
-  groundTruth: boolean;
-  scoreColor: string;
-  area: string;
-}
 
-const data: PopUpData[] = [];
+
+<script setup lang="ts">
+import { PopUpData } from '../interactions/popUpType';
+const props = defineProps<{
+  data:PopUpData[]
+}>();
+
 </script>
 
 <template>
   <v-card dense>
+    <div>POPUP</div>
     <v-row
-      v-for="item in data"
+      v-for="item in props.data"
       :key="item.siteId"
       dense
       align="center"

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -1,28 +1,11 @@
-import { App, Ref, createApp, defineComponent, nextTick, ref } from "vue";
+import { App, Ref,   nextTick, ref } from "vue";
 import { Color, Map, MapLayerMouseEvent, Popup } from "maplibre-gl";
 import { ShallowRef } from "vue";
 import { getSiteObservationDetails, selectedObservationList, state } from "../store";
-import PopUpComponent from '../components/PopUpComponent.vue'
+import  createPopup from '../main';
+import { PopUpData } from '../interactions/popUpType';
 
-import 'vuetify/styles'
-import { createVuetify } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
-import '@mdi/font/css/materialdesignicons.css' // Ensure you are using css-loader
 
-const vuetify = createVuetify({
-  components,
-  directives,
-})
-
-interface PopUpData {
-  siteId: string;
-  siteColor: string;
-  score: number;
-  groundTruth: boolean;
-  scoreColor: string;
-  area: string;
-}
 
   const hoveredInfo: Ref<{region: string[], siteId: number[]}> = ref({region: [], siteId:[]});
 
@@ -96,21 +79,14 @@ const popupLogic = (map: ShallowRef<null | Map>) => {
         }
       );
       popup.setLngLat(coordinates).setHTML('<div id="popup-content"></div>').addTo(map.value);
-      const MyNewPopup = defineComponent({
-        extends: PopUpComponent,
-        setup() {
-          return { data: popupData }
-        },
-      })
       nextTick(() => {
-        if (app !== null) {
+        if (app != null) {
           app.unmount();
           app = null;
         }
-        app = createApp(MyNewPopup).use(vuetify)
+        app = createPopup(popupData);
         app.mount('#popup-content');
-      })
-      
+      });
     } else if (map.value) {
       hoveredInfo.value.region = [];
       hoveredInfo.value.siteId = [];

--- a/vue/src/interactions/popUpType.ts
+++ b/vue/src/interactions/popUpType.ts
@@ -1,0 +1,8 @@
+export interface PopUpData {
+    siteId: string;
+    siteColor: string;
+    score: number;
+    groundTruth: boolean;
+    scoreColor: string;
+    area: string;
+  }  

--- a/vue/src/main.ts
+++ b/vue/src/main.ts
@@ -1,7 +1,8 @@
 import { createApp } from "vue";
 import "./index.css";
 import App from "./App.vue";
-
+import PopupComponent from "./components/PopUpComponent.vue";
+import { PopUpData } from './interactions/popUpType';
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
@@ -14,3 +15,10 @@ const vuetify = createVuetify({
 })
 
 createApp(App).use(vuetify).mount('#app')
+
+
+const createPopup = (data: PopUpData[]) =>  {
+return createApp(PopupComponent, {data}).use(vuetify);
+}
+
+export default createPopup;


### PR DESCRIPTION
The Tooltips weren't working before in the ./dist version of the code because of some mounting issues that weren't the same when running a local vite server.

To duplicate the issue first:

- build the web web app `cd ./vue` && `yarn build`
- install something like `yarn global add http-server`, then run `http-server -P http://localhost:8000 ./dist` to start the server
- With the main branch you'll notice the system doesn't display the tooltip.
- Try the same process again with the updated code and you should see the tooltip.

I also did the DockerFile and nginx.json modifications so I could build this version.  Just confirm this will work properly.

Finally, I added a `permanent` directive to the `v-navigation-bar`s to prevent collapsing.  In the future, we can look into having a small and wide version of the navigation bars.