### PR TITLE
Add root path of Django app to `nginx.json`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/nginx.gpg] http://packages.nginx.or
  && usermod --lock rdwatch \
  && usermod --append --groups rdwatch unit
 RUN python3 -m pip install poetry==1.4.2
-RUN poetry config virtualenvs.in-project true
 WORKDIR /app
 EXPOSE 80
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/docker/nginx.json
+++ b/docker/nginx.json
@@ -34,6 +34,7 @@
       "type": "python 3.10",
       "user": "rdwatch",
       "group": "rdwatch",
+      "path": "/app/django/",
       "home": "/poetry/venvs/rdwatch/",
       "module": "rdwatch.server",
       "threads": 25,


### PR DESCRIPTION
Sets the `path` attribute for nginx unit - see https://unit.nginx.org/howto/django/#interface-wsgi