### PR TITLE
Set `VIRTUAL_ENV` env var before docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/nginx.gpg] http://packages.nginx.or
       netcat-openbsd \
       python3-cachecontrol \
       python3-pip \
+      python3.10-venv \
       tzdata \
       unit \
       unit-python3.10 \
@@ -24,6 +25,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/nginx.gpg] http://packages.nginx.or
  && usermod --lock rdwatch \
  && usermod --append --groups rdwatch unit
 RUN python3 -m pip install poetry==1.4.2
+RUN python3 -m venv /poetry/venvs/rdwatch
+ENV PATH="/poetry/venvs/rdwatch/bin:$PATH"
+ENV VIRTUAL_ENV=/poetry/venvs/rdwatch
 WORKDIR /app
 EXPOSE 80
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
@@ -48,7 +52,6 @@ RUN apt-get update \
       nodejs \
       npm \
       python3-dev \
-      python3.10-venv \
  && rm -rf /var/lib/apt/lists/* \
  && poetry config installer.parallel true
 
@@ -59,9 +62,6 @@ RUN npm ci
 
 FROM builder AS django-builder
 WORKDIR /app/django
-RUN python3 -m venv /poetry/venvs/rdwatch
-ENV PATH="/poetry/venvs/rdwatch/bin:$PATH"
-ENV VIRTUAL_ENV=/poetry/venvs/rdwatch
 COPY django/pyproject.toml django/poetry.lock /app/django/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \
@@ -74,9 +74,6 @@ RUN mkdir /app/django/src \
 # For use in a development environment.
 FROM builder AS dev
 WORKDIR /app/django
-RUN python3 -m venv /poetry/venvs/rdwatch
-ENV PATH="/poetry/venvs/rdwatch/bin:$PATH"
-ENV VIRTUAL_ENV=/poetry/venvs/rdwatch
 COPY django/pyproject.toml django/poetry.lock /app/django/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \


### PR DESCRIPTION
This env var needs to be set before the `docker-entrypoint.sh` script is run, since that script runs `poetry` commands.