### PR TITLE
Auto-deletion of model runs

### DIFF
--- a/django/src/rdwatch/migrations/0009_hyperparameters_created_and_more.py
+++ b/django/src/rdwatch/migrations/0009_hyperparameters_created_and_more.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import django_extensions.db.fields
+
+from django.db import migrations, models
+from django.db.models import Count, F, OuterRef, Subquery
+
+if TYPE_CHECKING:
+    from django.contrib.gis.db.backends.postgis.schema import PostGISSchemaEditor
+    from django.db.migrations.state import StateApps
+
+
+def migrate_creation_dates(apps: StateApps, schema_editor: PostGISSchemaEditor):
+    HyperParameters = apps.get_model('rdwatch', 'HyperParameters')  # noqa: N806
+    SiteEvaluation = apps.get_model('rdwatch', 'SiteEvaluation')  # noqa: N806
+
+    # Approximate the "created" time of a model run via the oldest timestamp
+    # in its evaluations
+    qs = HyperParameters.objects.filter(created__isnull=True).annotate(
+        created_timestamp=Subquery(
+            SiteEvaluation.objects.filter(configuration_id=OuterRef('id'))
+            .order_by('timestamp')
+            .values('timestamp')[:1]
+        )
+    )
+
+    # Delete any model runs with zero evaluations
+    qs.alias(evaluation_count=Count('evaluations')).filter(evaluation_count=0).delete()
+
+    # Set the "created" times of all remaining model runs
+    qs.update(created=F('created_timestamp'))
+
+
+def reverse_migrate_creation_dates(apps: StateApps, schema_editor: PostGISSchemaEditor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('rdwatch', '0008_satellitefetching_celery_id'),
+    ]
+
+    operations = [
+        # Create "created" column, allowing it to be nullable temporarily
+        # while we estimate the creation dates
+        migrations.AddField(
+            model_name='hyperparameters',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(
+                auto_now_add=True,
+                default=None,
+                null=True,
+            ),
+            preserve_default=False,
+        ),
+        # Fill in the creation dates for existing model runs
+        migrations.RunPython(
+            migrate_creation_dates,
+            reverse_migrate_creation_dates,
+        ),
+        # Set "created" to non-nullable now that all model runs have one
+        migrations.AlterField(
+            model_name='hyperparameters',
+            name='created',
+            field=django_extensions.db.fields.CreationDateTimeField(
+                auto_now_add=True,
+                default=None,
+                null=False,
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='hyperparameters',
+            name='expiration_time',
+            field=models.DurationField(
+                blank=True,
+                help_text='Time relative to creation that this model run '
+                'should be deleted.',
+                null=True,
+            ),
+        ),
+    ]

--- a/django/src/rdwatch/models/hyper_parameters.py
+++ b/django/src/rdwatch/models/hyper_parameters.py
@@ -1,7 +1,10 @@
+from django_extensions.db.models import CreationDateTimeField
+
 from django.db import models
 
 
 class HyperParameters(models.Model):
+    created = CreationDateTimeField()
     title = models.CharField(max_length=1000)
     performer = models.ForeignKey(
         to='Performer',
@@ -12,6 +15,11 @@ class HyperParameters(models.Model):
     parameters = models.JSONField(
         help_text='The hyper parameters for an ML task',
         db_index=True,
+    )
+    expiration_time = models.DurationField(
+        null=True,
+        blank=True,
+        help_text='Time relative to creation that this model run should be deleted.',
     )
 
     def __str__(self):

--- a/django/src/rdwatch/serializers/hyper_parameters.py
+++ b/django/src/rdwatch/serializers/hyper_parameters.py
@@ -10,6 +10,9 @@ class HyperParametersWriteSerializer(serializers.Serializer):
     performer = serializers.CharField()
     title = serializers.CharField(max_length=1000)
     parameters = serializers.JSONField(default=dict)
+    expiration_time = serializers.IntegerField(
+        min_value=0, max_value=24 * 365, required=False
+    )
 
     def validate_performer(self, value: str) -> lookups.Performer:
         try:

--- a/django/src/rdwatch/serializers/hyper_parameters.py
+++ b/django/src/rdwatch/serializers/hyper_parameters.py
@@ -39,6 +39,8 @@ class HyperParametersDetailSerializer(serializers.Serializer):
     timestamp = serializers.IntegerField(allow_null=True)
     timerange = TimeRangeSerializer(allow_null=True)
     bbox = serializers.JSONField(allow_null=True)
+    created = serializers.DateTimeField()
+    expiration_time = serializers.CharField(allow_null=True)
 
 
 class HyperParametersListSerializer(serializers.Serializer):

--- a/django/src/rdwatch/serializers/hyper_parameters.py
+++ b/django/src/rdwatch/serializers/hyper_parameters.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from rest_framework import serializers
 
 from rdwatch.models import lookups
@@ -19,6 +21,11 @@ class HyperParametersWriteSerializer(serializers.Serializer):
             return lookups.Performer.objects.get(slug=value.upper())
         except lookups.Performer.DoesNotExist:
             raise serializers.ValidationError(f"Invalid performer '{value}'")
+
+    def validate_expiration_time(self, value: int | None) -> timedelta | None:
+        if value is not None:
+            return timedelta(hours=value)
+        return value
 
 
 class HyperParametersDetailSerializer(serializers.Serializer):

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -6,9 +6,18 @@ from celery import shared_task
 from pyproj import Transformer
 
 from django.core.files import File
+from django.db import transaction
+from django.db.models import DateTimeField, ExpressionWrapper, F
+from django.utils import timezone
 
 from rdwatch.celery import app
-from rdwatch.models import SatelliteFetching, SiteImage, SiteObservation
+from rdwatch.models import (
+    HyperParameters,
+    SatelliteFetching,
+    SiteEvaluation,
+    SiteImage,
+    SiteObservation,
+)
 from rdwatch.utils.images import (
     fetch_boundbox_image,
     get_max_bbox,
@@ -206,5 +215,15 @@ def get_siteobservations_images(
 @shared_task
 def delete_temp_model_runs_task() -> None:
     """Delete all model runs that are due to be deleted."""
-    print('Test')
-    # TODO: implement this
+    model_runs_to_delete = HyperParameters.objects.alias(
+        delete_at=ExpressionWrapper(
+            F('created') + F('expiration_time'), output_field=DateTimeField()
+        )
+    ).filter(delete_at__lte=timezone.now())
+
+    with transaction.atomic():
+        SiteObservation.objects.filter(
+            siteeval__configuration__in=model_runs_to_delete
+        ).delete()
+        SiteEvaluation.objects.filter(configuration__in=model_runs_to_delete).delete()
+        model_runs_to_delete.delete()

--- a/django/src/rdwatch/tests/test_model_runs.py
+++ b/django/src/rdwatch/tests/test_model_runs.py
@@ -19,15 +19,23 @@ def test_model_run_auto_delete() -> None:
             performer=lookups.Performer.objects.all().first(),
             expiration_time=timedelta(hours=1),
         )
-    model_run_to_not_delete = HyperParameters.objects.create(
+    not_expired_model_run = HyperParameters.objects.create(
         title='test2',
         parameters={},
         performer=lookups.Performer.objects.all().first(),
         expiration_time=timedelta(hours=2),
     )
-    assert HyperParameters.objects.count() == 2
+    model_run_with_no_expiration = HyperParameters.objects.create(
+        title='test3',
+        parameters={},
+        performer=lookups.Performer.objects.all().first(),
+    )
+    assert HyperParameters.objects.count() == 3
 
     delete_temp_model_runs_task()
 
-    assert HyperParameters.objects.count() == 1
-    assert HyperParameters.objects.first() == model_run_to_not_delete
+    assert HyperParameters.objects.count() == 2
+    assert list(HyperParameters.objects.all()) == [
+        not_expired_model_run,
+        model_run_with_no_expiration,
+    ]

--- a/django/src/rdwatch/tests/test_model_runs.py
+++ b/django/src/rdwatch/tests/test_model_runs.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from django.utils import timezone
+
+from rdwatch.models import HyperParameters, lookups
+from rdwatch.tasks import delete_temp_model_runs_task
+
+
+@pytest.mark.django_db
+def test_model_run_auto_delete() -> None:
+    # Create a model run with expiration time of an hour ago
+    with freeze_time(timezone.now() - timedelta(hours=2)):
+        HyperParameters.objects.create(
+            title='test1',
+            parameters={},
+            performer=lookups.Performer.objects.all().first(),
+            expiration_time=timedelta(hours=1),
+        )
+    model_run_to_not_delete = HyperParameters.objects.create(
+        title='test2',
+        parameters={},
+        performer=lookups.Performer.objects.all().first(),
+        expiration_time=timedelta(hours=2),
+    )
+    assert HyperParameters.objects.count() == 2
+
+    delete_temp_model_runs_task()
+
+    assert HyperParameters.objects.count() == 1
+    assert HyperParameters.objects.first() == model_run_to_not_delete

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import django_filters
 import iso3166
 
@@ -164,12 +162,7 @@ class ModelRunViewSet(viewsets.ViewSet):
         write_serializer = HyperParametersWriteSerializer(data=request.data)
         write_serializer.is_valid(raise_exception=True)
         hyper_parameters = HyperParameters.objects.create(
-            title=write_serializer.validated_data['title'],
-            performer=write_serializer.validated_data['performer'],
-            parameters=write_serializer.validated_data['parameters'],
-            expiration_time=timedelta(
-                hours=write_serializer.validated_data['expiration_time']
-            ),
+            **write_serializer.validated_data
         )
         detail_serializer = HyperParametersDetailSerializer(
             {

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import django_filters
 import iso3166
 
@@ -165,6 +167,9 @@ class ModelRunViewSet(viewsets.ViewSet):
             title=write_serializer.validated_data['title'],
             performer=write_serializer.validated_data['performer'],
             parameters=write_serializer.validated_data['parameters'],
+            expiration_time=timedelta(
+                hours=write_serializer.validated_data['expiration_time']
+            ),
         )
         detail_serializer = HyperParametersDetailSerializer(
             {

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -112,6 +112,8 @@ def get_queryset():
             json=JSONObject(
                 id='pk',
                 title='title',
+                created='created',
+                expiration_time='expiration_time',
                 performer=Subquery(  # prevents including "performer" in slow GROUP BY
                     lookups.Performer.objects.filter(
                         pk=OuterRef('performer_id')
@@ -175,6 +177,8 @@ class ModelRunViewSet(viewsets.ViewSet):
                 },
                 'parameters': hyper_parameters.parameters,
                 'numsites': 0,
+                'created': hyper_parameters.created,
+                'expiration_time': hyper_parameters.expiration_time,
             }
         )
         return Response(data=detail_serializer.data, status=200)

--- a/django/tox.ini
+++ b/django/tox.ini
@@ -19,6 +19,7 @@ passenv =
     RDWATCH_SMART_STAC_URL
     RDWATCH_SMART_STAC_KEY
 deps =
+    freezegun
     pytest
     pytest-django
 commands =


### PR DESCRIPTION
This PR adds `created` and `expiration_time` fields to the HyperParameters model. The `expiration_time` is set by the user at model run creation time, and is measured in hours. An hourly celery beat task checks for any "expired" model runs and deletes them + all of their evaluations and observations.