### PR TITLE
Limit vector tiles by select model runs

### DIFF
--- a/django/src/rdwatch/api.py
+++ b/django/src/rdwatch/api.py
@@ -3,11 +3,9 @@ from ninja import NinjaAPI
 from .views.model_run import router as model_run_router
 from .views.performer import router as performer_router
 from .views.region import router as region_router
-from .views.vector_tile import router as vector_tile_router
 
 api = NinjaAPI()
 
 api.add_router('/performers/', performer_router)
 api.add_router('/regions/', region_router)
 api.add_router('/model-runs/', model_run_router)
-api.add_router('/vector-tile/', vector_tile_router)

--- a/vue/src/client/models/ModelRun.ts
+++ b/vue/src/client/models/ModelRun.ts
@@ -17,4 +17,6 @@ export type ModelRun = {
   } | null;
   bbox: GeoJSON.Polygon | null;
   hasScores?: boolean;
+  created: string;
+  expiration_time: string;
 };

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -76,8 +76,8 @@ const throttledSetSatelliteTimeStamp = throttle(setSatelliteTimeStamp, 300);
 
 
 watch([() => state.timestamp, () => state.filters, () => state.satellite, () => state.filters.scoringColoring,
-  () => state.satellite.satelliteSources, () => state.enabledSiteObservations, () => state.filters.hoverSiteId,
-  () => state.modelRuns, () => state.openedModelRuns], () => {
+() => state.satellite.satelliteSources, () => state.enabledSiteObservations, () => state.filters.hoverSiteId,
+() => state.modelRuns, () => state.openedModelRuns], () => {
 
   if (state.satellite.satelliteImagesOn) {
     throttledSetSatelliteTimeStamp(state, filteredSatelliteTimeList.value);

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -97,7 +97,7 @@ watch([() => state.timestamp, () => state.filters, () => state.satellite, () => 
     setFilter(`observations-text-${modelRun.id}`, observationFilter);
   })
 
-
+  popupLogic(map);
 });
 
 watch(

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -13,7 +13,7 @@ import { popupLogic } from "../interactions/mouseEvents";
 import { satelliteLoading } from "../interactions/satelliteLoading";
 import { setReference } from "../interactions/fillPatterns";
 import { setSatelliteTimeStamp } from "../mapstyle/satellite-image";
-import { throttle } from 'lodash';
+import { isEqual, throttle } from 'lodash';
 
 const mapContainer: ShallowRef<null | HTMLElement> = shallowRef(null);
 const map: ShallowRef<null | Map> = shallowRef(null);
@@ -77,10 +77,18 @@ const throttledSetSatelliteTimeStamp = throttle(setSatelliteTimeStamp, 300);
 
 watch([() => state.timestamp, () => state.filters, () => state.satellite, () => state.filters.scoringColoring,
 () => state.satellite.satelliteSources, () => state.enabledSiteObservations, () => state.filters.hoverSiteId,
-() => state.modelRuns, () => state.openedModelRuns], () => {
+() => state.modelRuns, () => state.openedModelRuns], (newVals, oldVals) => {
 
   if (state.satellite.satelliteImagesOn) {
     throttledSetSatelliteTimeStamp(state, filteredSatelliteTimeList.value);
+  }
+
+  const newFilters = newVals[1];
+  const oldFilters = oldVals[1];
+
+  // Clear layers on region change
+  if (!isEqual(newFilters.region_id, oldFilters.region_id)) {
+    modelRunVectorLayers.clear();
   }
 
   const openedModelRunIds = state.modelRuns.filter((m) => state.openedModelRuns.has(m.key)).map((m) => m.id);

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -117,7 +117,7 @@ const popupLogic = async (map: ShallowRef<null | Map>) => {
   }
 
   if (map.value) {
-    state.modelRuns.forEach((m) => {
+    for (const m of state.modelRuns) {
       map.value.on("mouseenter", `observations-fill-${m.id}`, function (e) {
         drawPopup(e);
       });
@@ -127,7 +127,7 @@ const popupLogic = async (map: ShallowRef<null | Map>) => {
       map.value.on("click", `observations-fill-${m.id}`, function (e) {
         clickObservation(e);
       });
-    });
+    }
   }
 };
 

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -69,8 +69,8 @@ const popupLogic = async (map: ShallowRef<null | Map>) => {
                     siteColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
                     scoreColor: calculateScoreColor(score),
                     timestamp: item.properties.timestamp,
-                    area,                  
-                })    
+                    area,
+                })
               }
             }
           }
@@ -117,19 +117,16 @@ const popupLogic = async (map: ShallowRef<null | Map>) => {
   }
 
   if (map.value) {
-    map.value.on("mouseenter", "observations-fill", function (e) {
-      drawPopup(e);
-    });
-    map.value.on("mouseleave", "observations-fill", function (e) {
-      drawPopup(e);
-    });
-    // map.value.on("mousemove", "observations-fill", function (e) {
-    //   if (insideObservation) {
-    //     drawPopup(e);
-    //   }
-    // });
-    map.value.on("click", "observations-fill", function (e) {
-      clickObservation(e);
+    state.modelRuns.forEach((m) => {
+      map.value.on("mouseenter", `observations-fill-${m.id}`, function (e) {
+        drawPopup(e);
+      });
+      map.value.on("mouseleave", `observations-fill-${m.id}`, function (e) {
+        drawPopup(e);
+      });
+      map.value.on("click", `observations-fill-${m.id}`, function (e) {
+        clickObservation(e);
+      });
     });
   }
 };

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -7,15 +7,15 @@ import {
   sources as openmaptilesSources,
 } from "./openmaptiles";
 import {
-  layers as rdwatchtilesLayers,
-  sources as rdwatchtilesSources,
+  buildSourceFilter as buildRdwatchtilesSources,
+  buildLayerFilter as rdwatchtilesLayers,
 } from "./rdwatchtiles";
 import {
   buildSourceFilter as buildSatelliteSourceFilter,
   layers as satelliteLayers,
 } from "./satellite-image";
 import type { StyleSpecification } from "maplibre-gl";
-import { EnabledSiteObservations, MapFilters, SatelliteData, siteObsSatSettings } from "../store";
+import { EnabledSiteObservations, KeyedModelRun, MapFilters, SatelliteData, siteObsSatSettings } from "../store";
 import { buildImageLayerFilter, buildImageSourceFilter } from "./images";
 
 const tileServerURL =
@@ -26,6 +26,7 @@ export const style = (
   satellite: SatelliteData,
   enabledSiteObservations: EnabledSiteObservations[],
   settings: siteObsSatSettings,
+  modelRuns: KeyedModelRun[],
 ): StyleSpecification => ({
   version: 8,
   sources: {
@@ -33,7 +34,7 @@ export const style = (
     ...openmaptilesSources,
     ...buildSatelliteSourceFilter(timestamp, satellite),
     ...buildImageSourceFilter(timestamp, enabledSiteObservations, settings),
-    ...rdwatchtilesSources,
+    ...buildRdwatchtilesSources(modelRuns),
   },
   sprite: `${tileServerURL}/sprites/osm-liberty`,
   glyphs: `${tileServerURL}/fonts/{fontstack}/{range}.pbf`,
@@ -47,6 +48,6 @@ export const style = (
     ...openmaptilesLayers,
     ...satelliteLayers(timestamp, satellite),
     ...buildImageLayerFilter(timestamp, enabledSiteObservations, settings),
-    ...rdwatchtilesLayers(timestamp, filters),
+    ...rdwatchtilesLayers(timestamp, filters, modelRuns),
   ],
 });

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -26,7 +26,7 @@ export const style = (
   satellite: SatelliteData,
   enabledSiteObservations: EnabledSiteObservations[],
   settings: siteObsSatSettings,
-  modelRuns: KeyedModelRun[],
+  modelRunIds: number[],
 ): StyleSpecification => ({
   version: 8,
   sources: {
@@ -34,7 +34,7 @@ export const style = (
     ...openmaptilesSources,
     ...buildSatelliteSourceFilter(timestamp, satellite),
     ...buildImageSourceFilter(timestamp, enabledSiteObservations, settings),
-    ...buildRdwatchtilesSources(modelRuns),
+    ...buildRdwatchtilesSources(modelRunIds),
   },
   sprite: `${tileServerURL}/sprites/osm-liberty`,
   glyphs: `${tileServerURL}/fonts/{fontstack}/{range}.pbf`,
@@ -48,6 +48,6 @@ export const style = (
     ...openmaptilesLayers,
     ...satelliteLayers(timestamp, satellite),
     ...buildImageLayerFilter(timestamp, enabledSiteObservations, settings),
-    ...rdwatchtilesLayers(timestamp, filters, modelRuns),
+    ...rdwatchtilesLayers(timestamp, filters, modelRunIds),
   ],
 });

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -10,7 +10,11 @@ import type {
 } from "maplibre-gl";
 import type { MapFilters } from "../store";
 
-import { annotationColors, observationText, siteText } from "./annotationStyles";
+import {
+  annotationColors,
+  observationText,
+  siteText,
+} from "./annotationStyles";
 
 // function buildSearchFilters(filters: MapFilters) {
 //   const filter: FilterSpecification = ["all"];
@@ -37,14 +41,17 @@ import { annotationColors, observationText, siteText } from "./annotationStyles"
 //   return filter;
 // }
 
-const buildTextOffset = (type: 'site' | 'observation', filters: MapFilters): [number, number] => {
-  if (filters.showSiteOutline && type === 'site') {
+const buildTextOffset = (
+  type: "site" | "observation",
+  filters: MapFilters
+): [number, number] => {
+  if (filters.showSiteOutline && type === "site") {
     return [0, 0.5];
-  } else if (filters.showSiteOutline && type === 'observation') {
+  } else if (filters.showSiteOutline && type === "observation") {
     return [0, -0.5];
   }
   return [0, 0];
-}
+};
 
 export const buildObservationFilter = (
   timestamp: number,
@@ -117,30 +124,31 @@ export const buildSiteFilter = (
   return filter;
 };
 
-export const buildRegionFilter = (
-  filters: MapFilters
-): FilterSpecification => {
-  const filter: FilterSpecification = [
-    "literal", !!filters.showRegionPolygon,
-  ];
+export const buildRegionFilter = (filters: MapFilters): FilterSpecification => {
+  const filter: FilterSpecification = ["literal", !!filters.showRegionPolygon];
 
   return filter;
 };
 
 const urlRoot = `${location.protocol}//${location.host}`;
 
-
-const buildObservationThick = (filters: MapFilters): DataDrivenPropertyValueSpecification<number>  => {
+const buildObservationThick = (
+  filters: MapFilters
+): DataDrivenPropertyValueSpecification<number> => {
   // If this observation is a grouth truth, make the width 4. Otherwise, make it 2.
- return[ "case",
- ["==", ["get", "siteeval_id"],
- filters.hoverSiteId ? filters.hoverSiteId : ''],
- 6,
-  ["get", "groundtruth"],
-  4,
-  2,
-];
-}
+  return [
+    "case",
+    [
+      "==",
+      ["get", "siteeval_id"],
+      filters.hoverSiteId ? filters.hoverSiteId : "",
+    ],
+    6,
+    ["get", "groundtruth"],
+    4,
+    2,
+  ];
+};
 
 const buildObservationFill = (
   timestamp: number,
@@ -170,94 +178,98 @@ export const buildSourceFilter = (modelRunIds: number[]) => {
   return results;
 };
 
-export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRunIds: number[]): LayerSpecification[] => {
+export const buildLayerFilter = (
+  timestamp: number,
+  filters: MapFilters,
+  modelRunIds: number[]
+): LayerSpecification[] => {
   let results: LayerSpecification[] = [];
   modelRunIds.forEach((id) => {
-      results = results.concat([
-        {
-          id: `observations-fill-${id}`,
-          type: "fill",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `observations-${id}`,
-          paint: {
-            "fill-color": annotationColors(filters),
-            "fill-opacity": 1,
-            "fill-pattern": buildObservationFill(timestamp, filters),
-          },
-          filter: buildObservationFilter(timestamp, filters),
+    results = results.concat([
+      {
+        id: `observations-fill-${id}`,
+        type: "fill",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `observations-${id}`,
+        paint: {
+          "fill-color": annotationColors(filters),
+          "fill-opacity": 1,
+          "fill-pattern": buildObservationFill(timestamp, filters),
         },
-        {
-          id: `observations-outline-${id}`,
-          type: "line",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `observations-${id}`,
-          paint: {
-            "line-color": annotationColors(filters),
-            "line-width": buildObservationThick(filters),
-          },
-          filter: buildObservationFilter(timestamp, filters),
+        filter: buildObservationFilter(timestamp, filters),
+      },
+      {
+        id: `observations-outline-${id}`,
+        type: "line",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `observations-${id}`,
+        paint: {
+          "line-color": annotationColors(filters),
+          "line-width": buildObservationThick(filters),
         },
-        {
-          id: `observations-text-${id}`,
-          type: "symbol",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `observations-${id}`,
-          layout: {
-            "text-anchor": "center",
-            "text-font": ["Roboto Regular"],
-            "text-max-width": 5,
-            "text-size": 12,
-            "text-allow-overlap": true,
-            "text-offset": buildTextOffset('observation', filters),
-            "text-field": observationText,
-          },
-          paint: {
-            "text-color": annotationColors(filters),
-          },
-          filter: buildObservationFilter(timestamp, filters),
+        filter: buildObservationFilter(timestamp, filters),
+      },
+      {
+        id: `observations-text-${id}`,
+        type: "symbol",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `observations-${id}`,
+        layout: {
+          "text-anchor": "center",
+          "text-font": ["Roboto Regular"],
+          "text-max-width": 5,
+          "text-size": 12,
+          "text-allow-overlap": true,
+          "text-offset": buildTextOffset("observation", filters),
+          "text-field": observationText,
         },
-        {
-          id: `regions-outline-${id}`,
-          type: "line",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `regions-${id}`,
-          paint: {
-            "line-color": annotationColors(filters),
-            "line-width": 2,
-          },
-          filter: buildRegionFilter(filters),
+        paint: {
+          "text-color": annotationColors(filters),
         },
-        {
-          id: `sites-outline-${id}`,
-          type: "line",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `sites-${id}`,
-          paint: {
-            "line-color": annotationColors(filters),
-            "line-width": 2,
-          },
-          filter: buildSiteFilter(timestamp, filters),
+        filter: buildObservationFilter(timestamp, filters),
+      },
+      {
+        id: `regions-outline-${id}`,
+        type: "line",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `regions-${id}`,
+        paint: {
+          "line-color": annotationColors(filters),
+          "line-width": 2,
         },
-        {
-          id: `sites-text-${id}`,
-          type: "symbol",
-          source: `vectorTileSource_${id}`,
-          "source-layer": `sites-${id}`,
-          layout: {
-            "text-anchor": "center",
-            "text-font": ["Roboto Regular"],
-            "text-max-width": 5,
-            "text-size": 12,
-            "text-allow-overlap": true,
-            "text-offset": buildTextOffset('site', filters),
-            "text-field": siteText,
-          },
-          paint: {
-            "text-color": annotationColors(filters),
-          },
-          filter: buildSiteFilter(timestamp, filters),
+        filter: buildRegionFilter(filters),
+      },
+      {
+        id: `sites-outline-${id}`,
+        type: "line",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `sites-${id}`,
+        paint: {
+          "line-color": annotationColors(filters),
+          "line-width": 2,
         },
-      ])
+        filter: buildSiteFilter(timestamp, filters),
+      },
+      {
+        id: `sites-text-${id}`,
+        type: "symbol",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `sites-${id}`,
+        layout: {
+          "text-anchor": "center",
+          "text-font": ["Roboto Regular"],
+          "text-max-width": 5,
+          "text-size": 12,
+          "text-allow-overlap": true,
+          "text-offset": buildTextOffset("site", filters),
+          "text-field": siteText,
+        },
+        paint: {
+          "text-color": annotationColors(filters),
+        },
+        filter: buildSiteFilter(timestamp, filters),
+      },
+    ]);
   });
   return results;
-}
+};

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -8,7 +8,7 @@ import type {
   LayerSpecification,
   SourceSpecification,
 } from "maplibre-gl";
-import type { KeyedModelRun, MapFilters } from "../store";
+import type { MapFilters } from "../store";
 
 import { annotationColors, observationText, siteText } from "./annotationStyles";
 
@@ -156,13 +156,13 @@ const buildObservationFill = (
   ];
 };
 
-export const buildSourceFilter = (modelRuns: KeyedModelRun[]) => {
+export const buildSourceFilter = (modelRunIds: number[]) => {
   const results: Record<string, SourceSpecification> = {};
-  modelRuns.forEach((item) => {
-    const source = `vectorTileSource_${item.id}`;
+  modelRunIds.forEach((id) => {
+    const source = `vectorTileSource_${id}`;
     results[source] = {
       type: "vector",
-      tiles: [`${urlRoot}/api/model-runs/${item.id}/vector-tile/{z}/{x}/{y}.pbf/`],
+      tiles: [`${urlRoot}/api/model-runs/${id}/vector-tile/{z}/{x}/{y}.pbf/`],
       minzoom: 0,
       maxzoom: 14,
     };
@@ -170,15 +170,15 @@ export const buildSourceFilter = (modelRuns: KeyedModelRun[]) => {
   return results;
 };
 
-export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRuns: KeyedModelRun[]): LayerSpecification[] => {
+export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRunIds: number[]): LayerSpecification[] => {
   let results: LayerSpecification[] = [];
-  modelRuns.forEach((item) => {
+  modelRunIds.forEach((id) => {
       results = results.concat([
         {
-          id: `observations-fill-${item.id}`,
+          id: `observations-fill-${id}`,
           type: "fill",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `observations-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `observations-${id}`,
           paint: {
             "fill-color": annotationColors(filters),
             "fill-opacity": 1,
@@ -187,10 +187,10 @@ export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRu
           filter: buildObservationFilter(timestamp, filters),
         },
         {
-          id: `observations-outline-${item.id}`,
+          id: `observations-outline-${id}`,
           type: "line",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `observations-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `observations-${id}`,
           paint: {
             "line-color": annotationColors(filters),
             "line-width": buildObservationThick(filters),
@@ -198,10 +198,10 @@ export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRu
           filter: buildObservationFilter(timestamp, filters),
         },
         {
-          id: `observations-text-${item.id}`,
+          id: `observations-text-${id}`,
           type: "symbol",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `observations-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `observations-${id}`,
           layout: {
             "text-anchor": "center",
             "text-font": ["Roboto Regular"],
@@ -217,10 +217,10 @@ export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRu
           filter: buildObservationFilter(timestamp, filters),
         },
         {
-          id: `regions-outline-${item.id}`,
+          id: `regions-outline-${id}`,
           type: "line",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `regions-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `regions-${id}`,
           paint: {
             "line-color": annotationColors(filters),
             "line-width": 2,
@@ -228,10 +228,10 @@ export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRu
           filter: buildRegionFilter(filters),
         },
         {
-          id: `sites-outline-${item.id}`,
+          id: `sites-outline-${id}`,
           type: "line",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `sites-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `sites-${id}`,
           paint: {
             "line-color": annotationColors(filters),
             "line-width": 2,
@@ -239,10 +239,10 @@ export const buildLayerFilter = (timestamp: number, filters: MapFilters, modelRu
           filter: buildSiteFilter(timestamp, filters),
         },
         {
-          id: `sites-text-${item.id}`,
+          id: `sites-text-${id}`,
           type: "symbol",
-          source: `vectorTileSource_${item.id}`,
-          "source-layer": `sites-${item.id}`,
+          source: `vectorTileSource_${id}`,
+          "source-layer": `sites-${id}`,
           layout: {
             "text-anchor": "center",
             "text-font": ["Roboto Regular"],

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -1,6 +1,6 @@
 import { computed, reactive } from "vue";
 
-import { ApiService, Region } from "./client";
+import { ApiService, ModelRun, Region } from "./client";
 
 export interface MapFilters {
   configuration_id?: number[];
@@ -120,6 +120,10 @@ export interface siteObsSatSettings {
   imageOpacity: number;
 }
 
+export interface KeyedModelRun extends ModelRun {
+  key: string;
+}
+
 export const state = reactive<{
   timestamp: number;
   timeMin: number;
@@ -140,6 +144,8 @@ export const state = reactive<{
   siteObsSatSettings: siteObsSatSettings,
   loopingInterval: NodeJS.Timeout | null,
   loopingId: number | null,
+  modelRuns: KeyedModelRun[],
+  openedModelRuns: Set<KeyedModelRun["key"]>
 }>({
   timestamp: Math.floor(Date.now() / 1000),
   timeMin: new Date(0).valueOf(),
@@ -183,6 +189,8 @@ export const state = reactive<{
   },
   loopingInterval: null,
   loopingId: null,
+  modelRuns: [],
+  openedModelRuns: new Set<KeyedModelRun["key"]>(),
 });
 
 export const filteredSatelliteTimeList = computed(() => {
@@ -208,7 +216,7 @@ export const getSiteObservationDetails = async (siteId: string, scoringBase: Sco
     .sort((a, b) => (a.timestamp - b.timestamp));
   const S2List = images.results.filter((item) => item.source === 'S2' && item.image !== null).sort((a, b) => (a.timestamp - b.timestamp));
 
-  const L8 = { 
+  const L8 = {
     total: results.filter((item) => item.constellation === 'L8').length,
     loaded:images.results.filter((item) => item.source === 'L8').length,
     unmatched: null,
@@ -220,7 +228,7 @@ export const getSiteObservationDetails = async (siteId: string, scoringBase: Sco
     images: S2List,
     unmatched: null,
   };
-  const WV = { 
+  const WV = {
     total: results.filter((item) => item.constellation === 'WV').length,
     loaded:worldViewList.length,
     images: worldViewList,


### PR DESCRIPTION
Backend changes:
- Move the vector tiles endpoint underneath the `model-runs` prefix (i.e. the endpoint is now `/api/model-runs/<id>/vector-tile/z/x/y.pbf`) and require a model run ID to filter by. The vector tiles are then generated based on the evaluation/observation/region polygons associated with that model run, as opposed to every polygon in the database that intersects with the given coordinates.

Frontend changes:
- Move model runs / opened model runs into the global state
- Refactor the `rdwatchtiles` to create a new vector tiles layer for every selected model run. This means that vector tiles will only be fetched for the currently selected model runs.