### PR TITLE
Add temporary backwards-compatible endpoints

### DIFF
--- a/django/src/rdwatch/urls.py
+++ b/django/src/rdwatch/urls.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from django.urls import path
 from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.schemas import get_schema_view
@@ -5,8 +7,10 @@ from rest_framework.schemas import get_schema_view
 from rdwatch import views
 from rdwatch.api import api
 
+api_urls = api.urls
+
 urlpatterns = [
-    path('', api.urls),
+    path('', api_urls),
     path(
         'openapi.json',
         get_schema_view(
@@ -50,5 +54,24 @@ urlpatterns = [
     path(
         'observations/<int:pk>/cancel-generate-images',
         views.cancel_site_observation_images,
+    ),
+]
+
+
+def _get_url_callback(url_name: str) -> Callable:
+    return [url for url in (api_urls[0]) if url.name == url_name][0].callback
+
+
+# TODO: Remove these. These are here for backwards compatability with the
+# old endpoint structure (without trailing slash)
+urlpatterns += [
+    path('model-runs', _get_url_callback('create_model_run')),
+    path(
+        'model-runs/<int:hyper_parameters_id>/site-model',
+        _get_url_callback('post_site_model'),
+    ),
+    path(
+        'model-runs/<int:hyper_parameters_id>/region-model',
+        _get_url_callback('post_region_model'),
     ),
 ]


### PR DESCRIPTION
This is a temporary feature that will help consumers of the API to migrate to the new trailing slash endpoints.