### PR TITLE
Enable Django admin

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,14 +10,15 @@ This is the simplest configuration for developers to start with.
 3. Run `docker compose up` to start the Django development server and Celery worker, plus all backing services
    like PostGIS, Redis, RabbitMQ, etc.
 4. Optionally, populate your database with test data by running `docker compose run --rm django poetry run django-admin loaddata testdata`
-5. Start the client development server:
+5. Optionally, create an account for the Django admin (http://localhost:8000/admin) by running `docker compose run --rm django poetry --directory django run django-admin createsuperuser`
+6. Start the client development server:
    ```sh
    cd vue
    npm install
    npm run dev
    ```
-6. Access the site, starting at http://localhost:8080/
-7. When finished, use `Ctrl+C`
+7. Access the site, starting at http://localhost:8080/
+8. When finished, use `Ctrl+C`
 
 ## Develop Natively (advanced)
 This configuration still uses Docker to run attached services in the background,
@@ -34,6 +35,7 @@ but allows developers to run Python code on their native system.
 7. Run `poetry --directory django install`
 8. Run the following command to configure your environment: `source ./dev/export-env.sh dev/.env.docker-compose-native ./dev/export-env.sh .env`
 9. Optionally, populate your database with test data by running `poetry --directory django run django-admin loaddata testdata`
+10. Optionally, create an account for the Django admin (http://localhost:8000/admin) by running `poetry --directory django run django-admin createsuperuser`
 
 ### Run Application
 1. Ensure `docker compose -f ./docker-compose.yaml up -d` is still active

--- a/django/src/rdwatch/admin.py
+++ b/django/src/rdwatch/admin.py
@@ -1,0 +1,129 @@
+from django.contrib import admin
+
+from rdwatch.models import (
+    HyperParameters,
+    Region,
+    SatelliteFetching,
+    SiteEvaluation,
+    SiteImage,
+    SiteObservation,
+    lookups,
+)
+
+
+@admin.register(lookups.CommonBand)
+class CommonBandAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description', 'spectrum')
+    search_fields = ('slug',)
+
+
+@admin.register(lookups.Constellation)
+class ConstellationAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description')
+    search_fields = ('slug',)
+
+
+@admin.register(lookups.ObservationLabel)
+class ObservationLabelAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description')
+    search_fields = ('slug',)
+
+
+@admin.register(lookups.Performer)
+class PerformerAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description')
+    search_fields = ('slug',)
+
+
+@admin.register(lookups.ProcessingLevel)
+class ProcessingLevelAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description')
+    search_fields = ('slug',)
+
+
+@admin.register(lookups.RegionClassification)
+class RegionClassificationAdmin(admin.ModelAdmin):
+    list_display = ('id', 'slug', 'description')
+    search_fields = ('slug',)
+
+
+@admin.register(HyperParameters)
+class HyperParametersAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'created',
+        'title',
+        'performer',
+        'parameters',
+        'evaluation',
+        'evaluation_run',
+        'expiration_time',
+    )
+    list_filter = ('created', 'performer')
+
+
+@admin.register(Region)
+class RegionAdmin(admin.ModelAdmin):
+    list_display = ('id', 'country', 'classification', 'number', 'geom')
+    raw_id_fields = ('classification',)
+
+
+@admin.register(SatelliteFetching)
+class SatelliteFetchingAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'siteeval',
+        'timestamp',
+        'status',
+        'celery_id',
+        'error',
+    )
+    list_filter = ('siteeval', 'timestamp')
+
+
+@admin.register(SiteEvaluation)
+class SiteEvaluationAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'configuration',
+        'region',
+        'number',
+        'timestamp',
+        'geom',
+        'label',
+        'score',
+        'version',
+    )
+    list_filter = ('timestamp',)
+    raw_id_fields = ('configuration', 'region', 'label')
+
+
+@admin.register(SiteImage)
+class SiteImageAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'siteeval',
+        'siteobs',
+        'timestamp',
+        'image',
+        'cloudcover',
+        'percent_black',
+        'source',
+    )
+    list_filter = ('siteeval', 'siteobs', 'timestamp')
+
+
+@admin.register(SiteObservation)
+class SiteObservationAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'siteeval',
+        'label',
+        'score',
+        'geom',
+        'constellation',
+        'spectrum',
+        'timestamp',
+    )
+    list_filter = ('timestamp',)
+    raw_id_fields = ('siteeval', 'label', 'constellation', 'spectrum')

--- a/django/src/rdwatch/models/hyper_parameters.py
+++ b/django/src/rdwatch/models/hyper_parameters.py
@@ -24,5 +24,5 @@ class HyperParameters(models.Model):
         help_text='Time relative to creation that this model run should be deleted.',
     )
 
-    def __str__(self):
-        return self.pk
+    def __str__(self) -> str:
+        return str(self.pk)

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from configurations import Configuration, values
 
-_environ_prefix = 'RDWATCH'
+_ENVIRON_PREFIX = 'RDWATCH'
 
 
 # With the default "late_binding=False", and "environ_name" is
@@ -20,7 +20,7 @@ class BaseConfiguration(Configuration):
     USE_X_FORWARDED_HOST = True
     WSGI_APPLICATION = 'rdwatch.server.application'
     ALLOWED_HOSTS = ['*']
-    DEBUG = values.BooleanValue(False, _environ_prefix='RDWATCH_DJANGO')
+    DEBUG = values.BooleanValue(False, environ_prefix='RDWATCH_DJANGO')
     # Django's docs suggest that STATIC_URL should be a relative path,
     # for convenience serving a site on a subpath.
     STATIC_URL = 'static/'
@@ -78,7 +78,7 @@ class BaseConfiguration(Configuration):
         DB_val = values.DatabaseURLValue(
             alias='default',
             environ_name='POSTGRESQL_URI',
-            environ_prefix=_environ_prefix,
+            environ_prefix=_ENVIRON_PREFIX,
             environ_required=True,
             # Additional kwargs to DatabaseURLValue are passed to dj-database-url
             engine='django.contrib.gis.db.backends.postgis',
@@ -88,7 +88,7 @@ class BaseConfiguration(Configuration):
             scoring_val = values.DatabaseURLValue(
                 alias='scoringdb',
                 environ_name='POSTGRESQL_SCORING_URI',
-                environ_prefix=_environ_prefix,
+                environ_prefix=_ENVIRON_PREFIX,
                 environ_required=True,
                 # Additional kwargs to DatabaseURLValue are passed to dj-database-url
                 engine='django.contrib.gis.db.backends.postgis',
@@ -118,7 +118,7 @@ class BaseConfiguration(Configuration):
 
     CELERY_BROKER_URL = values.Value(
         environ_required=True,
-        environ_prefix=_environ_prefix,
+        environ_prefix=_ENVIRON_PREFIX,
     )
 
     # Set to same value allowed by NGINX Unit server in `settings.http.max_body_size`
@@ -126,14 +126,14 @@ class BaseConfiguration(Configuration):
     DATA_UPLOAD_MAX_MEMORY_SIZE = 134217728
 
     ACCENTURE_VERSION = values.Value(
-        environ_required=True, environ_prefix=_environ_prefix
+        environ_required=True, environ_prefix=_ENVIRON_PREFIX
     )
 
     SMART_STAC_URL = values.URLValue(
-        environ_required=True, environ_prefix=_environ_prefix
+        environ_required=True, environ_prefix=_ENVIRON_PREFIX
     )
     SMART_STAC_KEY = values.SecretValue(
-        environ_required=True, environ_prefix=_environ_prefix
+        environ_required=True, environ_prefix=_ENVIRON_PREFIX
     )
 
     # django-celery-results configuration
@@ -162,13 +162,13 @@ class DevelopmentConfiguration(BaseConfiguration):
 
     DEFAULT_FILE_STORAGE = 'minio_storage.storage.MinioMediaStorage'
     MINIO_STORAGE_ENDPOINT = values.Value(
-        'localhost:9000', environ_prefix=_environ_prefix
+        'localhost:9000', environ_prefix=_ENVIRON_PREFIX
     )
-    MINIO_STORAGE_USE_HTTPS = values.BooleanValue(False, environ_prefix=_environ_prefix)
-    MINIO_STORAGE_ACCESS_KEY = values.SecretValue(environ_prefix=_environ_prefix)
-    MINIO_STORAGE_SECRET_KEY = values.SecretValue(environ_prefix=_environ_prefix)
+    MINIO_STORAGE_USE_HTTPS = values.BooleanValue(False, environ_prefix=_ENVIRON_PREFIX)
+    MINIO_STORAGE_ACCESS_KEY = values.SecretValue(environ_prefix=_ENVIRON_PREFIX)
+    MINIO_STORAGE_SECRET_KEY = values.SecretValue(environ_prefix=_ENVIRON_PREFIX)
     MINIO_STORAGE_MEDIA_BUCKET_NAME = values.Value(
-        environ_prefix=_environ_prefix,
+        environ_prefix=_ENVIRON_PREFIX,
         environ_name='STORAGE_BUCKET_NAME',
         environ_required=True,
     )
@@ -179,12 +179,12 @@ class DevelopmentConfiguration(BaseConfiguration):
 
 
 class ProductionConfiguration(BaseConfiguration):
-    SECRET_KEY = values.Value(environ_required=True, environ_prefix=_environ_prefix)
+    SECRET_KEY = values.Value(environ_required=True, environ_prefix=_ENVIRON_PREFIX)
 
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
     AWS_STORAGE_BUCKET_NAME = values.Value(
-        environ_prefix=_environ_prefix,
+        environ_prefix=_ENVIRON_PREFIX,
         environ_name='STORAGE_BUCKET_NAME',
         environ_required=True,
     )

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -21,12 +21,19 @@ class BaseConfiguration(Configuration):
     WSGI_APPLICATION = 'rdwatch.server.application'
     ALLOWED_HOSTS = ['*']
     DEBUG = values.BooleanValue(False, _environ_prefix='RDWATCH_DJANGO')
+    # Django's docs suggest that STATIC_URL should be a relative path,
+    # for convenience serving a site on a subpath.
+    STATIC_URL = 'static/'
 
     @property
     def INSTALLED_APPS(self):
         base_applications = [
+            'django.contrib.admin',
             'django.contrib.auth',
             'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'django.contrib.messages',
+            'django.contrib.staticfiles',
             'django.contrib.gis',
             'django.contrib.postgres',
             'django_filters',
@@ -38,6 +45,33 @@ class BaseConfiguration(Configuration):
         if 'RDWATCH_POSTGRESQL_SCORING_URI' in os.environ:
             base_applications.append('rdwatch_scoring')
         return base_applications
+
+    MIDDLEWARE = [
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'rdwatch.middleware.Log500ErrorsMiddleware',
+    ]
+
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
 
     @property
     def DATABASES(self):
@@ -62,12 +96,6 @@ class BaseConfiguration(Configuration):
             scoring_dict = scoring_val.value
             db_dict.update(scoring_dict)
         return db_dict
-
-    MIDDLEWARE = [
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'rdwatch.middleware.Log500ErrorsMiddleware',
-    ]
 
     REST_FRAMEWORK = {
         'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],

--- a/django/src/rdwatch/server/urls.py
+++ b/django/src/rdwatch/server/urls.py
@@ -1,8 +1,10 @@
 from django.apps import apps
+from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
     path('api/', include('rdwatch.urls')),
+    path('admin/', admin.site.urls),
 ]
 # Conditionally add the scoring URLs if the scoring app is installed
 if 'rdwatch_scoring' in apps.app_configs.keys():


### PR DESCRIPTION
Adds the needed settings in order to enable the Django admin at `/admin`. I sometimes find this easier to use then `shell_plus` or looking at the database itself.

Settings needed to enable this were taken from
https://github.com/girder/django-composed-configuration