### PR TITLE
Update GH action location

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -64,7 +64,7 @@ jobs:
         run: poetry build
         working-directory: cli
       - name: Make package index
-        uses: banesullivan/create-pip-index-action@main
+        uses: girder/create-pip-index-action@main
         with:
           package_directory: cli/dist/
       - name: Deploy to GH Pages


### PR DESCRIPTION
@mvandenburgh  Mind merging this? The GH action now lives at [girder/create-pip-index-action](https://github.com/girder/create-pip-index-action).