### PR TITLE
Revert Count function and add True Revoke

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -15,6 +15,7 @@ from django.db.models import (
     Case,
     Count,
     F,
+    Func,
     JSONField,
     Max,
     Min,
@@ -181,7 +182,7 @@ def get_queryset():
                             ),
                             status=SatelliteFetching.Status.RUNNING,
                         )
-                        .annotate(count=Count('id'))
+                        .annotate(count=Func(F('id'), function='Count'))
                         .values('count')
                     ),
                     0,  # Default value when evaluations are None
@@ -378,7 +379,7 @@ def cancel_generate_images(request: HttpRequest, hyper_parameters_id: int):
                 if fetching_task.status == SatelliteFetching.Status.RUNNING:
                     if fetching_task.celery_id != '':
                         task = AsyncResult(fetching_task.celery_id)
-                        task.revoke()
+                        task.revoke(terminate=True)
                     fetching_task.status = SatelliteFetching.Status.COMPLETE
                     fetching_task.celery_id = ''
                     fetching_task.save()

--- a/django/src/rdwatch/views/site_observation.py
+++ b/django/src/rdwatch/views/site_observation.py
@@ -182,7 +182,7 @@ def cancel_site_observation_images(request: HttpRequest, pk: int):
             if fetching_task.status == SatelliteFetching.Status.RUNNING:
                 if fetching_task.celery_id != '':
                     task = AsyncResult(fetching_task.celery_id)
-                    task.revoke()
+                    task.revoke(terminate=True)
                 fetching_task.status = SatelliteFetching.Status.COMPLETE
                 fetching_task.celery_id = ''
                 fetching_task.save()


### PR DESCRIPTION
- There is a functional difference between using what I had previously and using `Count('id')`.  This will fix some errors that occur when trying to get status during downloading.
- Also added true revoking to the celery task.  Without the 'terminate' the task would continue executing if it was in process (which meant it could download hundreds of images).  The terminate option makes sure it kills the running task.