### PR TITLE
Added OSGEO4W path setups and OS agnostic URL joins

### DIFF
--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -5,6 +5,13 @@ from configurations import Configuration, values
 
 _ENVIRON_PREFIX = 'RDWATCH'
 
+if os.name == 'nt':
+    OSGEO4W = r"C:\OSGeo4W"
+    assert os.path.isdir(OSGEO4W), "Directory does not exist: " + OSGEO4W
+    os.environ['OSGEO4W_ROOT'] = OSGEO4W
+    os.environ['GDAL_DATA'] = OSGEO4W + r"\share\gdal"
+    os.environ['PATH'] = OSGEO4W + r"\bin;" + os.environ['PATH']
+
 
 # With the default "late_binding=False", and "environ_name" is
 # specified or "environ=False", even Values from non-included

--- a/django/src/rdwatch/utils/stac_search.py
+++ b/django/src/rdwatch/utils/stac_search.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from os import path
 from typing import Literal, TypedDict
 from urllib.request import Request, urlopen
+import urllib.parse
 
 from django.conf import settings
 
@@ -78,7 +79,7 @@ def stac_search(
 ) -> Results:
     # Use SMART program server instead of public server
     # (https://earth-search.aws.element84.com/v0/search)
-    url = path.join(settings.SMART_STAC_URL, 'search')
+    url = urllib.parse.urljoin(settings.SMART_STAC_URL, 'search')
     params = SearchParams()
     params['bbox'] = bbox
     if timebuffer is not None:

--- a/django/src/rdwatch/utils/worldview/stac_search.py
+++ b/django/src/rdwatch/utils/worldview/stac_search.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from os import path
 from typing import Literal, TypedDict
 from urllib.request import Request, urlopen
+import urllib.parse
 
 from django.conf import settings
 
@@ -74,7 +75,7 @@ def worldview_search(
     timebuffer: timedelta | None = None,
     page: int = 1,
 ) -> Results:
-    url = path.join(settings.SMART_STAC_URL, 'search')
+    url = urllib.parse.urljoin(settings.SMART_STAC_URL, 'search')
     params = SearchParams()
     params['bbox'] = bbox
     if timebuffer is not None:

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from os import path
 from typing import Literal, TypedDict
 from urllib.request import Request, urlopen
+import urllib.parse
 
 from django.conf import settings
 
@@ -67,7 +68,7 @@ def worldview_search(
     timebuffer: timedelta | None = None,
     page: int = 1,
 ) -> Results:
-    url = path.join(settings.SMART_STAC_URL, 'search')
+    url = urllib.parse.urljoin(settings.SMART_STAC_URL, 'search')
     params = SearchParams()
     params['bbox'] = bbox
     if timebuffer is not None:


### PR DESCRIPTION
Added windows compatibility for native deployment/development

Additional notes for setting up on Windows:

# Setting up native development in windows for RD WATCH
1) Install python 3.10 without conda and deactivate conda environments, including base
	- https://www.python.org/downloads/release/python-3100/
2) Set the environment variables in .env.
3) Run `docker compose -f ./docker-compose.yaml up -d`
4) `pip install psycopg2-binary`
5) Install poetry
```pwsh
(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | py -
```
6) Install/create python env with poetry
```
poetry --directory django install
```

You might have to install Visual C++ build tools 14.0+
Just follow the link in the error message and make sure you check off the build tools

7)
Make sure `.py` files are associated with python interpreter. Cannot be conda.

or

Set poetry interpreter in pycharm. This is what I am doing.

8) Set up environment variables
The intent is to just set the variables present in the `.env` and `dev/.env.docker-compose-native` files. Do it any way you see fit, including manually via the windows UI.

The following is a scripted way
```pwsh
get-content .env.docker-compose-native | foreach {
    $name, $value = $_.split('=')
    [Environment]::SetEnvironmentVariable($name, $value, 'User')
}
```

Run this `.ps1` script to set environment variables in windows powershell
```
. .\export-env.ps1  
```

You have to remove empty lines and comments from the `.env` files, or else you will get an error about 0 length variables. 

**Also make sure there are no quotation marks!!**

Also, need to install gdal via this method. Conda will not work
https://trac.osgeo.org/osgeo4w/

Select advanced installation and ensure `gdal` and the `gdal303-runtime` are selected. The dependencies should automatically be installed after.

9) 
```
poetry run --directory django .\django\src\manage.py runserver
```

or

run `manage.py` in pycharm after setting up interpreter. Make sure to restart pycharm if you are using it to update `os.environ` and environment variables.

10)
Run, in a separate terminal,
`poetry run --directory django celery --app rdwatch.celery worker --loglevel INFO --without-heartbeat`

If you get an error about finding some `gdal304.dll`, go to the location and rename it to `gdal304.dll.orig`, and do the same for any other potential environments on the PATH. For me, I found one in the base anaconda environment.

11) 
Run, in a separate terminal,
`poetry run --directory django celery --app rdwatch.celery beat --loglevel INFO`

12) 
Run, in a separate terminal,
`cd vue`
`npm run dev`

to spin up the front end