### PR TITLE
Remove observation searching for geometry  in model-run endpoint

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -174,7 +174,6 @@ def get_queryset():
         .order_by('-groundtruth', '-id')
         .alias(
             region_id=F('evaluations__region_id'),
-            observation_count=Count('evaluations__observations'),
             evaluation_configuration=F('evaluations__configuration'),
             proposal_val=F('proposal'),
         )
@@ -230,17 +229,7 @@ def get_queryset():
                     min=ExtractEpoch(Min('evaluations__start_date')),
                     max=ExtractEpoch(Max('evaluations__end_date')),
                 ),
-                bbox=Case(
-                    # If there are no site observations associated with this
-                    # site evaluation, return the bbox of the site polygon.
-                    # Otherwise, return the bounding box of all observation
-                    # polygons.
-                    When(
-                        observation_count=0,
-                        then=BoundingBoxGeoJSON('evaluations__geom'),
-                    ),
-                    default=BoundingBoxGeoJSON('evaluations__observations__geom'),
-                ),
+                bbox=BoundingBoxGeoJSON('evaluations__geom'),
                 proposal='proposal_val',
                 adjudicated=Case(
                     When(

--- a/scripts/loadModelRun.py
+++ b/scripts/loadModelRun.py
@@ -99,7 +99,7 @@ def upload_to_rgd(
             post_model_data["evaluation"] = eval_num
         if eval_run_num is not None:
             post_model_data["evaluation_run"] = eval_run_num
-        if proposal is not None:
+        if proposal is True:
             post_model_data["proposal"] = True
         if title == "Ground Truth":
             post_model_data["parameters"] = {"ground_truth": True}

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -489,7 +489,7 @@ export class ApiService {
   public static startModelRunDownload(id: number): CancelablePromise<string> {
     return __request(OpenAPI, {
       method: 'POST',
-      url: "/api/model-runs/{id}/download",
+      url: "/api/model-runs/{id}/download/",
       path: {
         id: id,
       },


### PR DESCRIPTION
I made a sample set by reloading the Dubai region multiple times to get a sense of where the performance issues were. 

I had a hunch that it was searching into each observation.  I had removed most observation searches by moving the date/time range up into the Evaluation area.

I decided to remove the bbox case of looking at observation geometries and focus more on the evaluation geometry.  I also could remove the observation count by removing this.  Now a model run doesn't have to look into each site observation (of which there could be hundreds per site evaluation) to calculate geometry, it will grab it from the higher level.

There could be an argument for the future that the model-run list doesn't need geometry at all and it could be removed in the future so that when a user clicks on a model-run it then grabs the geometry for that specific run.

Take like 3 seconds to get the info for 64 copies of the AE_R001 region
![image](https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/e6c6abad-3597-4026-a8ac-7f29988badec)
