### PR TITLE
Update performer filter to allow multi-select

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -53,9 +53,17 @@ router = RouterPaginated()
 
 
 class ModelRunFilterSchema(FilterSchema):
-    performer: str | None = Field(q='performer_slug')
+    performer: list[str] | None = Field(q='performer_slug')
     region: str | None
     proposal: str | None = Field(q='proposal', ignore_none=False)
+
+    def filter_performer(self, value: list[str] | None) -> Q:
+        if value is None or not value:
+            return Q()
+        performer_q = Q()
+        for performer_slug in value:
+            performer_q |= Q(performer_slug=performer_slug)
+        return performer_q
 
     def filter_region(self, value: str | None) -> Q:
         if value is None:

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -18,7 +18,7 @@ import { SatelliteTimeStamp } from "../../store";
 import { EvaluationImageResults } from "../../types";
 
 export interface QueryArguments {
-  performer?: string;
+  performer?: string[];
   groundtruth?: boolean;
   region?: string;
   page?: number;

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -26,6 +26,7 @@ const download = () => {
     })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const updateTime = (time: any, date: 'StartDate' | 'EndDate') => {
     if (date === 'StartDate') {
       overrideDates.value[0] = new Date(time as string).toISOString().split('T')[0];

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -45,9 +45,12 @@ async function loadMore() {
   if (request !== undefined) {
     request.cancel();
   }
+  const { performer } = props.filters; // unwrap performer array
+  console.log(performer);
   request = ApiService.getModelRuns({
     limit,
     ...props.filters,
+    performer,
     proposal: props.compact ? 'PROPOSAL' : undefined, // if compact we are doing proposal adjudication
   });
   try {

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -13,18 +13,18 @@ import { changeTime } from "../interactions/timeStepper";
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
 
-const selectedPerformer: Ref<Performer | null> = ref(null);
+const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 const showSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   queryFilters.value = {
     ...queryFilters.value,
-    performer: val?.short_code,
+    performer: val.map((item) => item.short_code),
     page: 1,
   };
   state.filters = {
     ...state.filters,
-    performer_id: val?.id === undefined ? undefined : [val.id],
+    performer_ids: !val.length ? undefined : val.map((item) => item.id),
     scoringColoring: null,
   };
 });

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -12,18 +12,18 @@ import { changeTime } from "../../interactions/timeStepper";
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
 
-const selectedPerformer: Ref<Performer | null> = ref(null);
+const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 const showSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   queryFilters.value = {
     ...queryFilters.value,
-    performer: val?.short_code,
+    performer: val.map((item) => item.short_code),
     page: 1,
   };
   state.filters = {
     ...state.filters,
-    performer_id: val?.id === undefined ? undefined : [val.id],
+    performer_ids: !val.length ? undefined : [val.map((item) => item.id)],
     scoringColoring: null,
   };
 });

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -23,7 +23,7 @@ watch(selectedPerformer, (val) => {
   };
   state.filters = {
     ...state.filters,
-    performer_ids: !val.length ? undefined : [val.map((item) => item.id)],
+    performer_ids: !val.length ? undefined : val.map((item) => item.id),
     scoringColoring: null,
   };
 });

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -4,7 +4,7 @@ import { ApiService, ModelRun, Region } from "./client";
 
 export interface MapFilters {
   configuration_id?: number[];
-  performer_id?: number[];
+  performer_ids?: number[];
   region_id?: number[];
   showSiteOutline?: boolean;
   groundTruthPattern?: boolean;


### PR DESCRIPTION
Per the goals document for the MVP one of the items listed was enabling multiple performers to be selected.

This PR updates the back-end and front-end to allow for multiple selections of performers.  Mostly just changes the 'performer' filter field to an a list of performers instead of a single performer.

The front-end right now increases the height of the box to fit more performers, we may want to revisit this behavior.

