### PR TITLE
Parallelize model run upload scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-files: ^(django|cli)/
+files: ^(django|cli|scripts)/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/scripts/loadGroundTruth.py
+++ b/scripts/loadGroundTruth.py
@@ -1,19 +1,21 @@
-import json
+from __future__ import annotations
+from collections import defaultdict
+
+import os
 import argparse
 import sys
 from pathlib import Path
+from multiprocessing import Pool
 
 import requests
 
 rgd_endpoint = "http://localhost:8000"
 
-existing_model_runs = {}
-
 
 def main():
     parser = argparse.ArgumentParser(description="Upload ground truth to server")
     parser.add_argument(
-        "baseDir",
+        "base_dir",
         type=str,
         help="Base Annotation Directory with subdirectories of site_models\
           || site-model || region_models || region-model",
@@ -31,57 +33,96 @@ def main():
     parser.add_argument(
         "--expiration_time", default=None, type=int, help="expiration time in hours"
     )
+    parser.add_argument(
+        '--parallelism',
+        default=os.cpu_count(),
+        type=int,
+        help='max number of uploads to perform at once',
+    )
 
     upload_to_rgd(**vars(parser.parse_args()))
 
 
-def upload_to_rgd(baseDir, skip_regions, rgd_auth_cookie, expiration_time):
+def _upload_model_run(
+    region: str,
+    endpoint: str,
+    model_runs: dict[str, list[Path]],
+    cookies: dict[str, str],
+    expiration_time: int | None,
+) -> None:
+    # Create model run
+    print(f"Creating model run for {region}")
+    post_model_data = {
+        "performer": "TE",
+        "title": "Ground Truth",
+        "parameters": {},
+    }
+    if expiration_time is not None:
+        post_model_data["expiration_time"] = str(expiration_time)
+
+    res = requests.post(
+        f"{rgd_endpoint}/api/model-runs/",
+        json=post_model_data,
+        headers={"Content-Type": "application/json"},
+        cookies=cookies,
+    )
+    res.raise_for_status()
+
+    model_run_id = res.json()["id"]
+
+    for file in model_runs[region]:
+        print(f"Uploading {file}")
+        res = requests.post(
+            f"{rgd_endpoint}/api/model-runs/{model_run_id}/{endpoint}/",
+            data=file.read_text(),
+            headers={"Content-Type": "application/json"},
+            cookies=cookies,
+        )
+        if res.status_code >= 400:
+            print(res.status_code, res.text)
+            continue
+
+
+def upload_to_rgd(
+    base_dir: Path,
+    skip_regions: bool,
+    rgd_auth_cookie: str | None,
+    expiration_time: str,
+    parallelism: int,
+):
     check_vals = [("site_models", "site-model")]
-    cookies = None
+    cookies: dict[str, str] = {}
     if not skip_regions:
         check_vals.append(("region_models", "region-model"))
-    if rgd_auth_cookie:
-        cookies = {"AWSELBAuthSessionCookie-0": rgd_auth_cookie}
+    if rgd_auth_cookie or "RGD_AUTH_COOKIE" in os.environ:
+        cookies = {"token": os.environ.get("RGD_AUTH_COOKIE", rgd_auth_cookie)}
+
+    model_runs: defaultdict[str, list[Path]] = defaultdict(list)
+
     for dir, endpoint in check_vals:
-        geojson_dir_path = Path(baseDir) / dir
-        for file in sorted(list(geojson_dir_path.iterdir())):
+        geojson_dir_path = Path(base_dir) / dir
+        geojson_files = sorted(list(geojson_dir_path.iterdir()))
+
+        for file in geojson_files:
             if file.is_dir() or not file.suffix == ".geojson":
                 print(f"Skipping {file}")
                 continue
 
-            model_run_name = "_".join(file.name.split("_")[:2])
-            if model_run_name not in existing_model_runs:
-                # Create model run if it doesn't exist
-                print(f"Creating model run {model_run_name}")
-                post_model_data = {
-                    "performer": "TE",
-                    "title": "Ground Truth",
-                    "parameters": {},
-                }
-                if expiration_time is not None:
-                    post_model_data["expiration_time"] = expiration_time
+            region = "_".join(file.name.split("_")[:2])
+            model_runs[region].append(file)
 
-                res = requests.post(
-                    f"{rgd_endpoint}/api/model-runs/",
-                    json=post_model_data,
-                    headers={"Content-Type": "application/json"},
-                    cookies=cookies,
-                )
-                res.raise_for_status()
-                existing_model_runs[model_run_name] = res.json()["id"]
-
-            model_run_id = existing_model_runs[model_run_name]
-
-            print(f"  Posting {file}...")
-            res = requests.post(
-                f"{rgd_endpoint}/api/model-runs/{model_run_id}/{endpoint}/",
-                data=file.read_text(),
-                headers={"Content-Type": "application/json"},
-                cookies=cookies,
+        with Pool(processes=parallelism) as pool:
+            pool.starmap(
+                _upload_model_run,
+                zip(
+                    model_runs.keys(),
+                    [endpoint] * len(model_runs),
+                    [model_runs] * len(model_runs),
+                    [cookies] * len(model_runs),
+                    [expiration_time] * len(model_runs),
+                    strict=True,
+                ),
             )
-            if res.status_code >= 400:
-                print(res.status_code, res.text)
-                continue
 
 
 if __name__ == "__main__":

--- a/scripts/loadModelRun.py
+++ b/scripts/loadModelRun.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
-import json
 import traceback
 from glob import glob
 from multiprocessing import Pool
@@ -11,42 +11,47 @@ from multiprocessing import Pool
 import requests
 
 # TODO: Parameterize
-rgd_endpoint = "http://localhost:8000"
+rgd_endpoint = 'http://localhost:8000'
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Upload sites to RGD")
+    parser = argparse.ArgumentParser(description='Upload sites to RGD')
 
-    parser.add_argument("region_id", type=str, help="Region ID")
+    parser.add_argument('region_id', type=str, help='Region ID')
     parser.add_argument(
-        "site_models_glob", type=str, help="Glob string for sites to upload"
+        'site_models_glob', type=str, help='Glob string for sites to upload'
     )
     parser.add_argument(
-        "--rgd-auth-cookie",
+        '--rgd-auth-cookie',
         required=False,
         type=str,
-        help="RGD Authentication cookie, e.g.: "
-        "AWSELBAuthSessionCookie-0=<LONG BASE64 STRING>",
+        help='RGD Authentication cookie, e.g.: '
+        'AWSELBAuthSessionCookie-0=<LONG BASE64 STRING>',
     )
     parser.add_argument(
-        "--title",
-        default="Ground Truth",
+        '--title',
+        default='Ground Truth',
         type=str,
-        help="Title of the model run " '(default: "Ground Truth")',
+        help='Title of the model run ' '(default: "Ground Truth")',
     )
     parser.add_argument(
-        "--performer_shortcode",
+        '--performer_shortcode',
         type=str,
-        default="TE",
+        default='TE',
         help='Performer shortcode (default: "TE")',
     )
-    parser.add_argument("--proposal", default=False, action=argparse.BooleanOptionalAction, help="Marks all siteModels as proposals")
-    parser.add_argument("--eval_num", default=None, type=int, help="Evaluation Number")
     parser.add_argument(
-        "--eval_run_num", default=None, type=int, help="Evaluation  Run Number"
+        '--proposal',
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help='Marks all siteModels as proposals',
+    )
+    parser.add_argument('--eval_num', default=None, type=int, help='Evaluation Number')
+    parser.add_argument(
+        '--eval_run_num', default=None, type=int, help='Evaluation  Run Number'
     )
     parser.add_argument(
-        "--expiration_time", default=None, type=int, help="expiration time in hours"
+        '--expiration_time', default=None, type=int, help='expiration time in hours'
     )
     parser.add_argument(
         '--parallelism',
@@ -70,60 +75,60 @@ def upload_to_rgd(
     expiration_time: int | None = None,
 ):
     # Check that our run doesn't already exist
-    model_run_results_url = f"{rgd_endpoint}/api/model-runs/"
+    model_run_results_url = f'{rgd_endpoint}/api/model-runs/'
     cookies = None
     if rgd_auth_cookie:
-        cookies = {"AWSELBAuthSessionCookie-0": rgd_auth_cookie}
+        cookies = {'AWSELBAuthSessionCookie-0': rgd_auth_cookie}
     model_runs_result = requests.get(
         model_run_results_url,
-        params={"limit": "0"},
-        headers={"Content-Type": "application/json"},
+        params={'limit': '0'},
+        headers={'Content-Type': 'application/json'},
         cookies=cookies,
     )
 
     existing_model_run = None
-    for model_run in model_runs_result.json().get("results", ()):
+    for model_run in model_runs_result.json().get('results', ()):
         if (
-            model_run["title"] == title
-            and model_run["performer"]["short_code"] == performer_shortcode
-            and "region" in model_run
-            and model_run["region"] is not None
-            and model_run["region"].get("name") == region_id
+            model_run['title'] == title
+            and model_run['performer']['short_code'] == performer_shortcode
+            and 'region' in model_run
+            and model_run['region'] is not None
+            and model_run['region'].get('name') == region_id
         ):  # noqa
             existing_model_run = model_run
             break
 
     if existing_model_run is not None:
-        model_run_id = model_run["id"]
+        model_run_id = model_run['id']
     else:
-        post_model_url = f"{rgd_endpoint}/api/model-runs/"
+        post_model_url = f'{rgd_endpoint}/api/model-runs/'
 
         post_model_data = {
-            "performer": performer_shortcode,
-            "title": title,
-            "region": {"name": region_id},
-            "parameters": {},
+            'performer': performer_shortcode,
+            'title': title,
+            'region': {'name': region_id},
+            'parameters': {},
         }
         if expiration_time is not None:
-            post_model_data["expiration_time"] = expiration_time
+            post_model_data['expiration_time'] = expiration_time
         if eval_num is not None:
-            post_model_data["evaluation"] = eval_num
+            post_model_data['evaluation'] = eval_num
         if eval_run_num is not None:
-            post_model_data["evaluation_run"] = eval_run_num
+            post_model_data['evaluation_run'] = eval_run_num
         if proposal is True:
-            post_model_data["proposal"] = True
-        if title == "Ground Truth":
-            post_model_data["parameters"] = {"ground_truth": True}
+            post_model_data['proposal'] = True
+        if title == 'Ground Truth':
+            post_model_data['parameters'] = {'ground_truth': True}
 
         post_model_result = requests.post(
             post_model_url,
             json=post_model_data,
-            headers={"Content-Type": "application/json"},
+            headers={'Content-Type': 'application/json'},
             cookies=cookies,
         )
-        model_run_id = post_model_result.json()["id"]
+        model_run_id = post_model_result.json()['id']
 
-    post_site_url = f"{rgd_endpoint}/api/model-runs/{model_run_id}/site-model/"
+    post_site_url = f'{rgd_endpoint}/api/model-runs/{model_run_id}/site-model/'
     print(site_models_glob)
     site_files = glob(site_models_glob)
     with Pool(processes=parallelism) as pool:
@@ -133,33 +138,34 @@ def upload_to_rgd(
                 [post_site_url] * len(site_files),
                 site_files,
                 [rgd_auth_cookie] * len(site_files),
-                strict=True
-            )
+                strict=True,
+            ),
         )
 
+
 def post_site(post_site_url, site_filepath, rgd_auth_cookie):
-    print("Uploading '{}' ..".format(site_filepath))
-    with open(site_filepath, "r") as f:
+    print(f"Uploading '{site_filepath}' ..")
+    with open(site_filepath) as f:
         cookie = None
         if rgd_auth_cookie:
-            cookie = {"AWSELBAuthSessionCookie-0": rgd_auth_cookie}
+            cookie = {'AWSELBAuthSessionCookie-0': rgd_auth_cookie}
         try:
             response = requests.post(
                 post_site_url,
                 json=json.load(f),
-                headers={"Content-Type": "application/json"},
+                headers={'Content-Type': 'application/json'},
                 cookies=cookie,
             )
         except Exception:
-            print("Exception occurred (printed below)")
+            print('Exception occurred (printed below)')
             traceback.print_exception(*sys.exc_info())
 
     print(response)
     if response.status_code != 201:
-        print(f"Error uploading site, status " f"code: [{response.status_code}]")
+        print(f'Error uploading site, status ' f'code: [{response.status_code}]')
 
     return response
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
I made some improvements to the upload scripts to make things faster, namely, using the `multiprocessing` model to do uploads in parallel. A new CLI argument, `--parallelism`, allows the user to specify the number of concurrent uploads to do at once. It defaults to the value returned by `os.cpu_count()`. This significantly speeds up upload when you're trying to get a large number of model runs loaded into your system quickly.

I also added the `scripts/` subdirectory to the pre-commit config.