### PR TITLE
Add `django-debug-toolbar` as a dev dependency

### DIFF
--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -556,6 +556,21 @@ search = ["dj-search-url"]
 testing = ["dj-database-url", "dj-email-url", "dj-search-url", "django-cache-url (>=1.0.0)"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "4.2.0"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_debug_toolbar-4.2.0-py3-none-any.whl", hash = "sha256:af99128c06e8e794479e65ab62cc6c7d1e74e1c19beb44dcbf9bad7a9c017327"},
+    {file = "django_debug_toolbar-4.2.0.tar.gz", hash = "sha256:bc7fdaafafcdedefcc67a4a5ad9dac96efd6e41db15bc74d402a54a2ba4854dc"},
+]
+
+[package.dependencies]
+django = ">=3.2.4"
+sqlparse = ">=0.2"
+
+[[package]]
 name = "django-extensions"
 version = "3.2.1"
 description = "Extensions for Django"
@@ -2199,4 +2214,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "76a8f81659af0b7ae48b24bd47644fb7dd9763dc1c1920c3d0afb260f4562915"
+content-hash = "1d4e1aee4f78c50148fac729711ef11961007edf8b74b516295703de14549033"

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -54,6 +54,7 @@ pre-commit = "^3.3.1"
 tox = "^4.5.1"
 django-minio-storage = "^0.5.2"
 werkzeug = "^2.3.7"
+django-debug-toolbar = "^4.2.0"
 
 [tool.taskipy.tasks]
 "build:openapi" = "DJANGO_SETTINGS_MODULE=rdwatch.server.settings django-admin generateschema --format openapi-json --file openapi.json"

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -171,6 +171,20 @@ class DevelopmentConfiguration(BaseConfiguration):
     MINIO_STORAGE_MEDIA_USE_PRESIGNED = True
     MINIO_STORAGE_MEDIA_URL = 'http://127.0.0.1:9000/rdwatch'
 
+    # Install django-debug-toolbar in development
+    @property
+    def INSTALLED_APPS(self) -> list[str]:
+        return super().INSTALLED_APPS + ['debug_toolbar']
+
+    @property
+    def MIDDLEWARE(self) -> list[str]:
+        return super().MIDDLEWARE + ['debug_toolbar.middleware.DebugToolbarMiddleware']
+
+    # This is needed for django-debug-toolbar
+    @property
+    def INTERNAL_IPS(self) -> list[str]:
+        return super().INTERNAL_IPS + ['127.0.0.1']
+
 
 class ProductionConfiguration(BaseConfiguration):
     SECRET_KEY = values.Value(environ_required=True, environ_prefix=_ENVIRON_PREFIX)

--- a/django/src/rdwatch/server/urls.py
+++ b/django/src/rdwatch/server/urls.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
@@ -6,6 +7,17 @@ urlpatterns = [
     path('api/', include('rdwatch.urls')),
     path('admin/', admin.site.urls),
 ]
+
 # Conditionally add the scoring URLs if the scoring app is installed
 if 'rdwatch_scoring' in apps.app_configs.keys():
     urlpatterns.append(path('api/', include('rdwatch_scoring.urls')))
+
+if settings.DEBUG:
+    try:
+        import debug_toolbar
+
+        urlpatterns = [path('__debug__/', include(debug_toolbar.urls))] + urlpatterns
+    except ModuleNotFoundError:
+        # If DEBUG mode is enabled in production, django-debug-toolbar is
+        # likely not installed. If this happens, just ignore the error.
+        pass


### PR DESCRIPTION
Installs [`django-debug-toolbar`](https://github.com/jazzband/django-debug-toolbar) as a dev dependency and enables it in `DevelopmentConfiguration`. In particular, this will make it more convenient to profile SQL queries.