### PR TITLE
Use `pystac-client` to make STAC requests

### DIFF
--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -955,6 +955,25 @@ files = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.17.3"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jsonschema-4.17.3-py3-none-any.whl", hash = "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"},
+    {file = "jsonschema-4.17.3.tar.gz", hash = "sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d"},
+]
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+
+[[package]]
 name = "kombu"
 version = "5.2.4"
 description = "Messaging library for Python."
@@ -1637,23 +1656,84 @@ docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.2.2)", "importlib-metadata (>=6)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "virtualenv (>=20.17.1)", "wheel (>=0.38.4)"]
 
 [[package]]
+name = "pyrsistent"
+version = "0.19.3"
+description = "Persistent/Functional/Immutable data structures"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e42296a09e83028b3476f7073fcb69ffebac0e66dbbfd1bd847d61f74db30f19"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win32.whl", hash = "sha256:64220c429e42a7150f4bfd280f6f4bb2850f95956bde93c6fda1b70507af6ef3"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win_amd64.whl", hash = "sha256:016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4db1bd596fefd66b296a3d5d943c94f4fac5bcd13e99bffe2ba6a759d959a28"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeda827381f5e5d65cced3024126529ddc4289d944f75e090572c77ceb19adbf"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42ac0b2f44607eb92ae88609eda931a4f0dfa03038c44c772e07f43e738bcac9"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win32.whl", hash = "sha256:e8f2b814a3dc6225964fa03d8582c6e0b6650d68a232df41e3cc1b66a5d2f8d1"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9bb60a40a0ab9aba40a59f68214eed5a29c6274c83b2cc206a359c4a89fa41b"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a2471f3f8693101975b1ff85ffd19bb7ca7dd7c38f8a81701f67d6b4f97b87d8"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc5d149f31706762c1f8bda2e8c4f8fead6e80312e3692619a75301d3dbb819a"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3311cb4237a341aa52ab8448c27e3a9931e2ee09561ad150ba94e4cfd3fc888c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win32.whl", hash = "sha256:f0e7c4b2f77593871e918be000b96c8107da48444d57005b6a6bc61fb4331b2c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:c147257a92374fde8498491f53ffa8f4822cd70c0d85037e09028e478cababb7"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b735e538f74ec31378f5a1e3886a26d2ca6351106b4dfde376a26fc32a044edc"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99abb85579e2165bd8522f0c0138864da97847875ecbd45f3e7e2af569bfc6f2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a8cb235fa6d3fd7aae6a4f1429bbb1fec1577d978098da1252f0489937786f3"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win32.whl", hash = "sha256:c74bed51f9b41c48366a286395c67f4e894374306b197e62810e0fdaf2364da2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:878433581fc23e906d947a6814336eee031a00e6defba224234169ae3d3d6a98"},
+    {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
+    {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
+]
+
+[[package]]
 name = "pystac"
-version = "1.7.3"
-description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
+version = "1.8.3"
+description = "Python library for working with the SpatioTemporal Asset Catalog (STAC) specification"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pystac-1.7.3-py3-none-any.whl", hash = "sha256:2b1b5e11b995e443376ca1d195609d95723f690c8d192604bc00091fcdf52e4c"},
-    {file = "pystac-1.7.3.tar.gz", hash = "sha256:6848074fad6665ac631abd62c692bb868de37379615db90f4d913dca37f844ce"},
+    {file = "pystac-1.8.3-py3-none-any.whl", hash = "sha256:91805520b0b5386db84aae5296dc6d4fb6754410c481d0a00a8afedc3b4c75d5"},
+    {file = "pystac-1.8.3.tar.gz", hash = "sha256:3fd0464bfeb7e99893b24c8d683dd3d046c48b2e53ed65d0a8a704f1281f1ed1"},
 ]
 
 [package.dependencies]
+jsonschema = {version = ">=4.0.1,<4.18", optional = true, markers = "extra == \"validation\""}
 python-dateutil = ">=2.7.0"
 
 [package.extras]
+bench = ["asv (>=0.5,<1.0)", "virtualenv (>=20.22,<21.0)"]
+docs = ["Sphinx (>=6.2,<7.0)", "ipython (>=8.12,<9.0)", "jinja2 (<4.0)", "jupyter (>=1.0,<2.0)", "nbsphinx (>=0.9,<1.0)", "pydata-sphinx-theme (>=0.13,<1.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-design (>=0.4,<1.0)", "sphinxcontrib-fulltoc (>=1.2,<2.0)"]
+jinja2 = ["jinja2 (<4.0)"]
 orjson = ["orjson (>=3.5)"]
+test = ["black (>=23.3,<24.0)", "codespell (>=2.2,<3.0)", "coverage (>=7.2,<8.0)", "doc8 (>=1.1,<2.0)", "html5lib (>=1.1,<2.0)", "jinja2 (<4.0)", "jsonschema (>=4.0.1,<4.18)", "mypy (>=1.2,<2.0)", "orjson (>=3.8,<4.0)", "pre-commit (>=3.2,<4.0)", "pytest (>=7.3,<8.0)", "pytest-cov (>=4.0,<5.0)", "pytest-mock (>=3.10,<4.0)", "pytest-recording (>=0.13,<1.0)", "ruff (==0.0.284)", "types-html5lib (>=1.1,<2.0)", "types-orjson (>=3.6,<4.0)", "types-python-dateutil (>=2.8,<3.0)", "types-urllib3 (>=1.26,<2.0)"]
 urllib3 = ["urllib3 (>=1.26)"]
-validation = ["jsonschema (>=4.0.1)"]
+validation = ["jsonschema (>=4.0.1,<4.18)"]
+
+[[package]]
+name = "pystac-client"
+version = "0.7.5"
+description = "Python library for working with SpatioTemporal Asset Catalog (STAC) APIs."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pystac-client-0.7.5.tar.gz", hash = "sha256:4b0ed0f7177dfc6e394aeb3ecf1236364f315b1d38c107afbcbbef17c2f7db8b"},
+    {file = "pystac_client-0.7.5-py3-none-any.whl", hash = "sha256:b07c21f0bfbe7ea19cd23e535406ee08ee604b8ff8d9afcee666c0b1fe017dc4"},
+]
+
+[package.dependencies]
+pystac = {version = ">=1.8.2", extras = ["validation"]}
+python-dateutil = ">=2.8.2"
+requests = ">=2.28.2"
+
+[package.extras]
+dev = ["black (>=23.3,<24.0)", "codespell (>=2.2.4,<2.3.0)", "coverage (>=7.2,<8.0)", "doc8 (>=1.1.1,<1.2.0)", "importlib-metadata (>=6.7,<7.0)", "mypy (>=1.2,<2.0)", "orjson (>=3.8,<4.0)", "pre-commit (>=3.2,<4.0)", "pytest (>=7.4,<8.0)", "pytest-benchmark (>=4.0.0,<4.1.0)", "pytest-console-scripts (>=1.4.0,<1.5.0)", "pytest-cov (>=4.1.0,<4.2.0)", "pytest-recording (>=0.13,<1.0)", "recommonmark (>=0.7.1,<0.8.0)", "requests-mock (>=1.11.0,<1.12.0)", "ruff (==0.0.287)", "tomli (>=2.0,<3.0)", "types-python-dateutil (>=2.8.19,<2.9.0)", "types-requests (>=2.31.0,<2.32.0)", "urllib3 (<2)"]
+docs = ["Sphinx (>=6.2,<7.0)", "boto3 (>=1.26,<2.0)", "cartopy (>=0.21,<1.0)", "geojson (>=3.0.1,<3.1.0)", "geopandas (>=0.13.0,<0.14.0)", "geoviews (>=1.9,<2.0)", "hvplot (>=0.8.3,<0.9.0)", "ipykernel (>=6.22,<7.0)", "ipython (>=8.12,<9.0)", "jinja2 (<4.0)", "matplotlib (>=3.7.1,<3.8.0)", "myst-parser (>=2.0,<3.0)", "nbsphinx (>=0.9,<1.0)", "pydata-sphinx-theme (>=0.13,<1.0)", "pygeoif (>=1.0,<2.0)", "scipy (>=1.10,<2.0)", "sphinxcontrib-fulltoc (>=1.2,<2.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -2199,4 +2279,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "76a8f81659af0b7ae48b24bd47644fb7dd9763dc1c1920c3d0afb260f4562915"
+content-hash = "87d9b782e71165efe5d5311f5948665a9ee4cf4b712a93b9097c2505cd97903b"

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -40,6 +40,7 @@ pillow = "^9.5.0"
 django-configurations = {extras = ["database", "email"], version = "^2.4.1"}
 django-storages = {extras = ["boto3"], version = "^1.13.2"}
 django-celery-results = "^2.5.1"
+pystac-client = "^0.7.5"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/django/src/rdwatch/utils/stac_search.py
+++ b/django/src/rdwatch/utils/stac_search.py
@@ -1,9 +1,8 @@
-import json
 import logging
 from datetime import datetime, timedelta
-from os import path
-from typing import Literal, TypedDict
-from urllib.request import Request, urlopen
+from typing import Literal, TypedDict, cast
+
+from pystac_client import Client
 
 from django.conf import settings
 
@@ -74,29 +73,30 @@ def stac_search(
     timestamp: datetime,
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,
-    page: int = 1,
 ) -> Results:
-    # Use SMART program server instead of public server
-    # (https://earth-search.aws.element84.com/v0/search)
-    url = path.join(settings.SMART_STAC_URL, 'search')
-    params = SearchParams()
-    params['bbox'] = bbox
+    stac_catalog = Client.open(
+        # Use SMART program server instead of public server
+        # (https://earth-search.aws.element84.com/v0/search)
+        settings.SMART_STAC_URL,
+        headers={'x-api-key': settings.SMART_STAC_KEY},
+    )
+
     if timebuffer is not None:
         min_time = timestamp - timebuffer
         max_time = timestamp + timebuffer
         time_str = f'{_fmt_time(min_time)}/{_fmt_time(max_time)}'
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
-    params['datetime'] = time_str
-    params['collections'] = COLLECTIONS[source]
-    params['page'] = page
-    params['limit'] = 100
-    request = Request(
-        url,
-        data=bytes(json.dumps(params), 'utf-8'),
-        headers={'x-api-key': settings.SMART_STAC_KEY},
+
+    results = stac_catalog.search(
+        method='GET',
+        bbox=bbox,
+        datetime=time_str,
+        collections=COLLECTIONS[source],
+        limit=100,
     )
-    logger.warning(request.full_url)
-    logger.warning(params)
-    with urlopen(request) as resp:
-        return json.loads(resp.read())
+
+    # TODO: return `results` directly instead of converting to a dict.
+    # Before that can happen, the callers need to be updated to handle
+    # an `ItemSearch` object.
+    return cast(Results, results.item_collection_as_dict())

--- a/django/src/rdwatch/utils/worldview/satellite_captures.py
+++ b/django/src/rdwatch/utils/worldview/satellite_captures.py
@@ -38,13 +38,6 @@ def get_features(
     results = worldview_search(timestamp, bbox, timebuffer=timebuffer)
     yield from results['features']
 
-    matched = results['context']['matched']
-    limit = results['context']['limit']
-    for i in range(matched // limit):
-        page = i + 2
-        results = worldview_search(timestamp, bbox, timebuffer=timebuffer, page=page)
-        yield from results['features']
-
 
 def get_captures(
     timestamp: datetime,

--- a/django/src/rdwatch/utils/worldview/stac_search.py
+++ b/django/src/rdwatch/utils/worldview/stac_search.py
@@ -1,8 +1,7 @@
-import json
 from datetime import datetime, timedelta
-from os import path
-from typing import Literal, TypedDict
-from urllib.request import Request, urlopen
+from typing import Literal, TypedDict, cast
+
+from pystac_client import Client
 
 from django.conf import settings
 
@@ -72,25 +71,28 @@ def worldview_search(
     timestamp: datetime,
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,
-    page: int = 1,
 ) -> Results:
-    url = path.join(settings.SMART_STAC_URL, 'search')
-    params = SearchParams()
-    params['bbox'] = bbox
+    stac_catalog = Client.open(
+        settings.SMART_STAC_URL,
+        headers={'x-api-key': settings.SMART_STAC_KEY},
+    )
+
     if timebuffer is not None:
         min_time = timestamp - timebuffer
         max_time = timestamp + timebuffer
         time_str = f'{_fmt_time(min_time)}/{_fmt_time(max_time)}'
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
-    params['datetime'] = time_str
-    params['collections'] = ['worldview-nitf']
-    params['page'] = page
-    params['limit'] = 100
-    request = Request(
-        url,
-        data=bytes(json.dumps(params), 'utf-8'),
-        headers={'x-api-key': settings.SMART_STAC_KEY},
+
+    results = stac_catalog.search(
+        method='GET',
+        bbox=bbox,
+        datetime=time_str,
+        collections=['worldview-nitf'],
+        limit=100,
     )
-    with urlopen(request) as resp:
-        return json.loads(resp.read())
+
+    # TODO: return `results` directly instead of converting to a dict.
+    # Before that can happen, the callers need to be updated to handle
+    # an `ItemSearch` object.
+    return cast(Results, results.item_collection_as_dict())

--- a/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
+++ b/django/src/rdwatch/utils/worldview_processed/satellite_captures.py
@@ -23,13 +23,6 @@ def get_features(
     results = worldview_search(timestamp, bbox, timebuffer=timebuffer)
     yield from results['features']
 
-    matched = results['context']['matched']
-    limit = results['context']['limit']
-    for i in range(matched // limit):
-        page = i + 2
-        results = worldview_search(timestamp, bbox, timebuffer=timebuffer, page=page)
-        yield from results['features']
-
 
 def get_captures(
     timestamp: datetime,

--- a/django/src/rdwatch/utils/worldview_processed/stac_search.py
+++ b/django/src/rdwatch/utils/worldview_processed/stac_search.py
@@ -1,8 +1,7 @@
-import json
 from datetime import datetime, timedelta
-from os import path
-from typing import Literal, TypedDict
-from urllib.request import Request, urlopen
+from typing import Literal, TypedDict, cast
+
+from pystac_client import Client
 
 from django.conf import settings
 
@@ -65,25 +64,28 @@ def worldview_search(
     timestamp: datetime,
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,
-    page: int = 1,
 ) -> Results:
-    url = path.join(settings.SMART_STAC_URL, 'search')
-    params = SearchParams()
-    params['bbox'] = bbox
+    stac_catalog = Client.open(
+        settings.SMART_STAC_URL,
+        headers={'x-api-key': settings.SMART_STAC_KEY},
+    )
+
     if timebuffer is not None:
         min_time = timestamp - timebuffer
         max_time = timestamp + timebuffer
         time_str = f'{_fmt_time(min_time)}/{_fmt_time(max_time)}'
     else:
         time_str = f'{_fmt_time(timestamp)}Z'
-    params['datetime'] = time_str
-    params['collections'] = COLLECTIONS
-    params['page'] = page
-    params['limit'] = 100
-    request = Request(
-        url,
-        data=bytes(json.dumps(params), 'utf-8'),
-        headers={'x-api-key': settings.SMART_STAC_KEY},
+
+    results = stac_catalog.search(
+        method='GET',
+        bbox=bbox,
+        datetime=time_str,
+        collections=COLLECTIONS,
+        limit=100,
     )
-    with urlopen(request) as resp:
-        return json.loads(resp.read())
+
+    # TODO: return `results` directly instead of converting to a dict.
+    # Before that can happen, the callers need to be updated to handle
+    # an `ItemSearch` object.
+    return cast(Results, results.item_collection_as_dict())


### PR DESCRIPTION
This PR installs `pystac-client` and uses it to query the STAC API instead of manually crafting HTTP requests. The next step is to remove the code that parses the raw JSON blob from the STAC server, and instead use the pystac-client's built in parsing functionality; I'll include that in a follow up PR. 

One additional thing to note is that the pystac client handles pagination
automatically. So, I've removed the manual pagination handling code as well.