### PR TITLE
Denormalize region name into a single column

### DIFF
--- a/django/src/rdwatch/admin.py
+++ b/django/src/rdwatch/admin.py
@@ -41,12 +41,6 @@ class ProcessingLevelAdmin(admin.ModelAdmin):
     search_fields = ('slug',)
 
 
-@admin.register(lookups.RegionClassification)
-class RegionClassificationAdmin(admin.ModelAdmin):
-    list_display = ('id', 'slug', 'description')
-    search_fields = ('slug',)
-
-
 @admin.register(HyperParameters)
 class HyperParametersAdmin(admin.ModelAdmin):
     list_display = (
@@ -64,8 +58,7 @@ class HyperParametersAdmin(admin.ModelAdmin):
 
 @admin.register(Region)
 class RegionAdmin(admin.ModelAdmin):
-    list_display = ('id', 'country', 'classification', 'number', 'geom')
-    raw_id_fields = ('classification',)
+    list_display = ('id', 'name')
 
 
 @admin.register(SatelliteFetching)

--- a/django/src/rdwatch/fixtures/lookups.json
+++ b/django/src/rdwatch/fixtures/lookups.json
@@ -434,29 +434,5 @@
       "slug": "2A",
       "description": "surface reflectance"
     }
-  },
-  {
-    "model": "rdwatch.regionclassification",
-    "pk": 1,
-    "fields": {
-      "slug": "R",
-      "description": "standard region identifier"
-    }
-  },
-  {
-    "model": "rdwatch.regionclassification",
-    "pk": 2,
-    "fields": {
-      "slug": "C",
-      "description": "a proposal by anyone for 'coarse' annotation"
-    }
-  },
-  {
-    "model": "rdwatch.regionclassification",
-    "pk": 3,
-    "fields": {
-      "slug": "S",
-      "description": "a 'super-region', which will contain one or more 'standard' or 'coarse' regions"
-    }
   }
 ]

--- a/django/src/rdwatch/migrations/0014_remove_region_uniq_region_and_more.py
+++ b/django/src/rdwatch/migrations/0014_remove_region_uniq_region_and_more.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import iso3166
+
+from django.db import migrations, models
+
+if TYPE_CHECKING:
+    from django.contrib.gis.db.backends.postgis.schema import PostGISSchemaEditor
+    from django.db.migrations.state import StateApps
+
+
+def migrate_region_name(apps: StateApps, schema_editor: PostGISSchemaEditor):
+    Region = apps.get_model('rdwatch', 'Region')  # noqa: N806
+
+    for region in Region.objects.iterator():
+        country_numeric = str(region.country).zfill(3)
+        country_code = iso3166.countries_by_numeric[country_numeric].alpha2
+        region_number = 'xxx' if region.number is None else str(region.number).zfill(3)
+        region.name = f'{country_code}_{region.classification.slug}{region_number}'
+        region.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('rdwatch', '0013_remove_siteevaluation_unique_siteeval'),
+    ]
+
+    operations = [
+        # Allow column to be NULL initially
+        migrations.AddField(
+            model_name='region',
+            name='name',
+            field=models.CharField(max_length=255, null=True),
+        ),
+        # Populate the `name` column for all existing regions
+        migrations.RunPython(migrate_region_name),
+        # Now that all `names` are populated, don't allow it to be NULL
+        migrations.AlterField(
+            model_name='region',
+            name='name',
+            field=models.CharField(max_length=255, null=False),
+        ),
+        migrations.RemoveConstraint(
+            model_name='region',
+            name='uniq_region',
+        ),
+        migrations.RemoveField(
+            model_name='region',
+            name='classification',
+        ),
+        migrations.RemoveField(
+            model_name='region',
+            name='country',
+        ),
+        migrations.RemoveField(
+            model_name='region',
+            name='number',
+        ),
+        migrations.AddConstraint(
+            model_name='region',
+            constraint=models.UniqueConstraint(
+                fields=('name',),
+                name='uniq_region',
+                violation_error_message='Region already exists.',
+            ),
+        ),
+        migrations.DeleteModel(
+            name='RegionClassification',
+        ),
+    ]

--- a/django/src/rdwatch/models/lookups.py
+++ b/django/src/rdwatch/models/lookups.py
@@ -41,7 +41,3 @@ class Performer(Lookup):
 
 class ProcessingLevel(Lookup):
     ...
-
-
-class RegionClassification(Lookup):
-    ...

--- a/django/src/rdwatch/models/region.py
+++ b/django/src/rdwatch/models/region.py
@@ -1,32 +1,10 @@
-import iso3166
-from ninja.errors import ValidationError
-
 from django.contrib.gis.db.models import PolygonField
 from django.contrib.gis.geos import Polygon
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
-
-from rdwatch.models import lookups
-from rdwatch.validators import validate_iso3166
 
 
 class Region(models.Model):
-    country = models.PositiveSmallIntegerField(
-        help_text='The numeric country identifier as specified by ISO 3166',
-        db_index=True,
-        validators=[validate_iso3166],
-    )
-    classification = models.ForeignKey(
-        to='RegionClassification',
-        on_delete=models.PROTECT,
-        help_text='Region classification code',
-        db_index=True,
-    )
-    number = models.PositiveSmallIntegerField(
-        help_text='The region number',
-        null=True,
-        db_index=True,
-    )
+    name = models.CharField(max_length=255)
     geom = PolygonField(
         help_text='Polygon from the associated Region Feature',
         srid=3857,
@@ -35,21 +13,14 @@ class Region(models.Model):
         blank=True,
     )
 
-    def __str__(self):
-        cty = iso3166.countries_by_numeric[str(self.country).zfill(3)].alpha2
-        rcls = self.classification.slug
-        num = str(self.number).zfill(3)
-        return f'{cty}_{rcls}{num}'
+    def __str__(self) -> str:
+        return self.name
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
                 name='uniq_region',
-                fields=[
-                    'country',
-                    'classification',
-                    'number',
-                ],
+                fields=['name'],
                 violation_error_message='Region already exists.',  # type: ignore
             ),
         ]
@@ -59,19 +30,9 @@ def get_or_create_region(
     region_id: str,
     region_polygon: Polygon | None = None,
 ) -> tuple[Region, bool]:
-    countrystr, numstr = region_id.split('_')
-    contrynum = iso3166.countries_by_alpha2[countrystr].numeric
-
-    try:
-        region_classification = lookups.RegionClassification.objects.get(slug=numstr[0])
-    except ObjectDoesNotExist:
-        raise ValidationError(f'invalid region classification {numstr[0]}')
-
     with transaction.atomic():
         region, created = Region.objects.select_for_update().get_or_create(
-            country=int(contrynum),
-            classification=region_classification,
-            number=None if numstr[1:] == 'xxx' else int(numstr[1:]),
+            name=region_id
         )
         if region.geom is None and region_polygon is not None:
             region.geom = region_polygon

--- a/django/src/rdwatch/utils/tools.py
+++ b/django/src/rdwatch/utils/tools.py
@@ -1,8 +1,0 @@
-import iso3166
-
-
-def getRegion(country: str, number: int, classification: str):
-    country_numeric = str(country).zfill(3)
-    country_code = iso3166.countries_by_numeric[country_numeric].alpha2
-    region_number = 'xxx' if number is None else str(number).zfill(3)
-    return f'{country_code}_{classification}{region_number}'

--- a/django/src/rdwatch/views/region.py
+++ b/django/src/rdwatch/views/region.py
@@ -1,4 +1,3 @@
-import iso3166
 from ninja import Schema
 from ninja.pagination import RouterPaginated
 
@@ -12,32 +11,15 @@ class RegionSchema(Schema):
     id: int
     name: str
 
-    @staticmethod
-    def resolve_name(obj: Region | str) -> str:
-        if isinstance(obj, Region):
-            country = obj.country
-            classification = obj.classification.slug
-            number = obj.number
-        else:
-            country = obj['country']
-            classification = obj['classification']['slug']
-            number = obj['number']
-        country_numeric = str(country).zfill(3)
-        country_code = iso3166.countries_by_numeric[country_numeric].alpha2
-        region_number = 'xxx' if number is None else str(number).zfill(3)
-        return f'{country_code}_{classification}{region_number}'
-
 
 router = RouterPaginated()
 
 
 @router.get('/', response=list[RegionSchema])
 def list_regions(request: HttpRequest):
-    return Region.objects.all().select_related('classification')
+    return Region.objects.all()
 
 
 @router.get('/{id}/', response=RegionSchema)
 def get_performer(request: HttpRequest, id: int):
-    return get_object_or_404(
-        Region.objects.all().select_related('classification'), id=id
-    )
+    return get_object_or_404(Region, id=id)

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -3,7 +3,6 @@ import sys
 import tempfile
 from datetime import datetime
 
-import iso3166
 from ninja import Field, FilterSchema, Query, Router, Schema
 
 from django.conf import settings
@@ -21,7 +20,6 @@ from rdwatch.db.functions import BoundingBox, ExtractEpoch
 from rdwatch.models import SiteEvaluation, SiteEvaluationTracking, lookups
 from rdwatch.schemas import SiteEvaluationRequest
 from rdwatch.schemas.common import BoundingBoxSchema, TimeRangeSchema
-from rdwatch.utils.tools import getRegion
 
 from .performer import PerformerSchema
 
@@ -30,26 +28,13 @@ router = Router()
 
 class SiteEvaluationSchema(Schema):
     id: int
-    site: dict
+    site: str
     configuration: dict
     performer: PerformerSchema
     score: float
     timestamp: int | None
     timerange: TimeRangeSchema | None
     bbox: BoundingBoxSchema
-
-    @staticmethod
-    def resolve_site(obj: dict) -> str:
-        country_numeric = str(obj['region']['country']).zfill(3)
-        country_code = iso3166.countries_by_numeric[country_numeric].alpha2
-        region_class = obj['region']['classification']
-        region_number = (
-            'xxx'
-            if obj['region']['number'] is None
-            else str(obj['region']['number']).zfill(3)
-        )
-        site_number = str(obj['number']).zfill(3)
-        return f'{country_code}_{region_class}{region_number}_{site_number}'
 
 
 class SiteEvaluationListSchema(Schema):
@@ -148,11 +133,7 @@ def list_site_evaluations(
             JSONObject(
                 id='pk',
                 site=JSONObject(
-                    region=JSONObject(
-                        country='region__country',
-                        classification='region__classification__slug',
-                        number='region__number',
-                    ),
+                    region='region__name',
                     number='number',
                 ),
                 configuration='configuration__parameters',
@@ -210,12 +191,6 @@ def patch_site_evaluation(request: HttpRequest, id: int, data: SiteEvaluationReq
     return 200
 
 
-def get_region_name(country, number, classification):
-    # Your implementation of getRegion function here
-    # Replace this with the actual implementation of getRegion function
-    return getRegion(country, number, classification)
-
-
 def get_site_model_feature_JSON(id: int, obsevations=False):
     query = (
         SiteEvaluation.objects.filter(pk=id)
@@ -223,11 +198,7 @@ def get_site_model_feature_JSON(id: int, obsevations=False):
         .annotate(
             json=JSONObject(
                 site=JSONObject(
-                    region=JSONObject(
-                        country='region__country',
-                        classification='region__classification__slug',
-                        number='region__number',
-                    ),
+                    region='region__name',
                     number='number',
                 ),
                 configuration='configuration__parameters',
@@ -252,11 +223,7 @@ def get_site_model_feature_JSON(id: int, obsevations=False):
     if query.exists():
         data = query[0]['json']
 
-        # convert to
-        region = data['site']['region']
-        region_name = getRegion(
-            region['country'], region['number'], region['classification']
-        )
+        region_name = data['site']['region']
         site_id = f'{region_name}_{str(data["site"]["number"]).zfill(3)}'
         version = data['version']
         output = {


### PR DESCRIPTION
Currently in the RGD database, we break region strings up into multiple columns (i.e. for `AE_R001`, we store the country (AE), type (R), and id (0001) in separate columns). The T&E database on the other hand simply stores the region as a single string. This PR brings the RGD db in line with the T&E db.

This is a prerequisite for embedding region names directly in the vector tile metadata (at least, it makes it significantly simpler); I'll make a follow up PR that implements that change.