### PR TITLE
Refactor backend + frontend to reference `Regions` by string name instead of numerical ID

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -401,12 +401,7 @@ def get_region(hyper_parameters_id: int):
         .annotate(
             json=JSONObject(
                 region=Subquery(  # prevents including "region" in slow GROUP BY
-                    Region.objects.filter(pk=OuterRef('region_id')).values(
-                        json=JSONObject(
-                            id='id',
-                            name='name',
-                        )
-                    ),
+                    Region.objects.filter(pk=OuterRef('region_id')).values('name')[:1],
                     output_field=JSONField(),
                 ),
             ),

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -46,7 +46,6 @@ from rdwatch.schemas import RegionModel, SiteModel
 from rdwatch.schemas.common import TimeRangeSchema
 from rdwatch.tasks import download_annotations
 from rdwatch.views.performer import PerformerSchema
-from rdwatch.views.region import RegionSchema
 from rdwatch.views.site_observation import get_site_observation_images
 
 router = RouterPaginated()
@@ -97,7 +96,7 @@ class HyperParametersAdjudicated(Schema):
 class HyperParametersDetailSchema(Schema):
     id: int
     title: str
-    region: RegionSchema | None = None
+    region: str | None = None
     performer: PerformerSchema
     parameters: dict
     numsites: int
@@ -112,12 +111,6 @@ class HyperParametersDetailSchema(Schema):
     evaluation_run: int | None = None
     proposal: str = None
     adjudicated: HyperParametersAdjudicated | None = None
-
-
-class EvaluationListSchema(Schema):
-    id: int
-    siteNumber: int
-    region: RegionSchema | None
 
 
 class HyperParametersListSchema(Schema):
@@ -191,13 +184,7 @@ def get_queryset():
                     output_field=JSONField(),
                 ),
                 region=Subquery(  # prevents including "region" in slow GROUP BY
-                    Region.objects.filter(pk=OuterRef('region_id')).values(
-                        json=JSONObject(
-                            id='id',
-                            name='name',
-                        )
-                    ),
-                    output_field=JSONField(),
+                    Region.objects.filter(pk=OuterRef('region_id')).values('name')[:1],
                 ),
                 downloading=Coalesce(
                     Subquery(
@@ -329,14 +316,6 @@ def get_model_run(request: HttpRequest, id: int):
         raise Http404()
 
     model_run = values[0]
-
-    # TODO: use a resolver instead.
-    # Temporary until https://github.com/vitalik/django-ninja/issues/610 is fixed
-    if model_run['region']:
-        model_run['region'] = {
-            'name': RegionSchema.resolve_name(model_run['region']),
-            'id': model_run['region']['id'],
-        }
 
     return 200, model_run
 

--- a/django/src/rdwatch/views/region.py
+++ b/django/src/rdwatch/views/region.py
@@ -1,25 +1,12 @@
-from ninja import Schema
 from ninja.pagination import RouterPaginated
 
 from django.http import HttpRequest
-from django.shortcuts import get_object_or_404
 
 from rdwatch.models import Region
-
-
-class RegionSchema(Schema):
-    id: int
-    name: str
-
 
 router = RouterPaginated()
 
 
-@router.get('/', response=list[RegionSchema])
+@router.get('/', response=list[str])
 def list_regions(request: HttpRequest):
-    return Region.objects.all()
-
-
-@router.get('/{id}/', response=RegionSchema)
-def get_performer(request: HttpRequest, id: int):
-    return get_object_or_404(Region, id=id)
+    return Region.objects.values_list('name', flat=True)

--- a/django/src/rdwatch/views/vector_tile.py
+++ b/django/src/rdwatch/views/vector_tile.py
@@ -111,7 +111,7 @@ def vector_tile(request: HttpRequest, hyper_parameters_id: int, z: int, x: int, 
                 timemin=ExtractEpoch(Min('observations__timestamp')),
                 timemax=ExtractEpoch(Max('observations__timestamp')),
                 performer_id=F('configuration__performer_id'),
-                region_id=F('region_id'),
+                region=F('region__name'),
                 groundtruth=Case(
                     When(
                         Q(configuration__performer__slug='TE') & Q(score=1),
@@ -156,7 +156,7 @@ def vector_tile(request: HttpRequest, hyper_parameters_id: int, z: int, x: int, 
                     ),
                 ),
                 performer_id=F('siteeval__configuration__performer_id'),
-                region_id=F('siteeval__region_id'),
+                region=F('siteeval__region__name'),
                 version=F('siteeval__version'),
                 groundtruth=Case(
                     When(
@@ -178,7 +178,7 @@ def vector_tile(request: HttpRequest, hyper_parameters_id: int, z: int, x: int, 
             .filter(intersects)
             .values()
             .annotate(
-                id=F('pk'),
+                name=F('name'),
                 mvtgeom=mvtgeom,
             )
         )

--- a/vue/src/client/models/Region.ts
+++ b/vue/src/client/models/Region.ts
@@ -1,4 +1,1 @@
-export type Region = {
-  id: number;
-  name: string;
-};
+export type Region = string;

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -157,8 +157,8 @@ export class ApiService {
           }
         });
       }
-      
-  
+
+
       /**
    * @param id
    * @returns boolean
@@ -213,7 +213,7 @@ export class ApiService {
           },
         });
       }
-  
+
   /**
    * @returns ModelRunList
    * @throws ApiError
@@ -243,8 +243,8 @@ export class ApiService {
         },
       });
     }
-  
-    
+
+
 
   /**
    * @param id
@@ -295,21 +295,6 @@ export class ApiService {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/regions",
-    });
-  }
-
-  /**
-   * @param id
-   * @returns Performer
-   * @throws ApiError
-   */
-  public static getRegion(id: number): CancelablePromise<Region> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/api/regions/{id}",
-      path: {
-        id: id,
-      },
     });
   }
 
@@ -408,7 +393,7 @@ export class ApiService {
 
   public static getScoringDetails(
     configurationId: number,
-    regionId: number,
+    region: string,
     siteNumber: number,
     version: string
   ): CancelablePromise<ScoringResults>
@@ -416,30 +401,30 @@ export class ApiService {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/scores/details",
-      query: { configurationId, regionId, siteNumber, version },
+      query: { configurationId, region, siteNumber, version },
     });
   }
 
   public static hasScores(
     configurationId: number,
-    regionId: number,
+    region: string,
   ): CancelablePromise<boolean>
   {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/scores/has-scores",
-      query: { configurationId, regionId },
+      query: { configurationId, region },
     });
   }
   public static getScoreColoring(
     configurationId: number,
-    regionId: number,
+    region: string,
   ): CancelablePromise<Record<string, string>>
   {
     return __request(OpenAPI, {
       method: "GET",
       url: "/api/scores/region-colors",
-      query: { configurationId, regionId },
+      query: { configurationId, region, },
     });
   }
 
@@ -508,4 +493,3 @@ export class ApiService {
 
 
 }
-

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -19,7 +19,6 @@ import { EvaluationImageResults } from "../../types";
 
 export interface QueryArguments {
   performer?: string[];
-  groundtruth?: boolean;
   region?: string;
   page?: number;
   limit?: number;

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -98,7 +98,7 @@ watch([() => state.timestamp, () => state.filters, () => state.satellite, () => 
   const oldFilters = oldVals[1];
 
   // Clear layers on region change
-  if (!isEqual(newFilters.region_id, oldFilters.region_id)) {
+  if (!isEqual(newFilters.regions, oldFilters.regions)) {
     modelRunVectorLayers.clear();
   }
 

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -31,20 +31,20 @@ let loopingInterval: NodeJS.Timeout | null = null;
 
 async function getScoringColoring() {
   if (!useScoring.value) { // inverted value because of the delay
-    const results = await ApiService.getScoreColoring(props.modelRun.id, props.modelRun.region?.id || 0)
+    const results = await ApiService.getScoreColoring(props.modelRun.id, props.modelRun.region || '')
     let tempResults = state.filters.scoringColoring;
     if (!tempResults) {
       tempResults = {};
     }
     if (tempResults !== undefined && tempResults !== null)  {
-      tempResults[`${props.modelRun.id}_${props.modelRun.region?.id || 0}`] = results;
+      tempResults[`${props.modelRun.id}_${props.modelRun.region}`] = results;
     }
     state.filters = { ...state.filters, scoringColoring: tempResults };
   } else {
     let tempResults = state.filters.scoringColoring;
     if (tempResults) {
-      if (Object.keys(tempResults).includes(`${props.modelRun.id}_${props.modelRun.region?.id || 0}`)) {
-        delete tempResults[`${props.modelRun.id}_${props.modelRun.region?.id || 0}`];
+      if (Object.keys(tempResults).includes(`${props.modelRun.id}_${props.modelRun.region}`)) {
+        delete tempResults[`${props.modelRun.id}_${props.modelRun.region}`];
       }
       if (Object.values(tempResults).length === 0) {
         tempResults = null;
@@ -75,7 +75,7 @@ const startDownload = (data: DownloadSettings) => {
   }, 2000)
 }
 
-const cancelDownload = () => { 
+const cancelDownload = () => {
   ApiService.cancelModelRunsImageTask(props.modelRun.id);
 }
 
@@ -156,7 +156,7 @@ const determineDownload = () => {
           region:
         </div>
         <div>
-          {{ modelRun.region?.name || "(none)" }}
+          {{ modelRun.region || "(none)" }}
         </div>
       </v-row>
       <v-row dense>

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -46,7 +46,6 @@ async function loadMore() {
     request.cancel();
   }
   const { performer } = props.filters; // unwrap performer array
-  console.log(performer);
   request = ApiService.getModelRuns({
     limit,
     ...props.filters,
@@ -87,7 +86,7 @@ async function loadMore() {
           getSatelliteTimestamps(modelRunList)
       }
       state.bbox = bbox;
-    } else if (!state.filters.region_id?.length) {
+    } else if (!state.filters.regions?.length) {
       const bbox = {
         xmin: -180,
         ymin: -90,
@@ -128,8 +127,8 @@ function updateCameraBounds(filtered = true) {
   }
   if (
     !state.settings.autoZoom &&
-    state.filters.region_id &&
-    state.filters.region_id?.length > 0
+    state.filters.regions &&
+    state.filters.regions?.length > 0
   ) {
     return;
   }
@@ -222,19 +221,19 @@ function handleToggle(modelRun: KeyedModelRun) {
     // Only move camera if we're *not* currently filtering by region
     updateCameraBounds();
     const configurationIds: Set<number> = new Set();
-    const regionIds: Set<number> = new Set();
+    const regions: Set<string> = new Set();
     state.modelRuns
       .filter((modelRun) => state.openedModelRuns.has(modelRun.key))
       .map((modelRun) => {
         configurationIds.add(modelRun.id);
         if (modelRun.region) {
-          regionIds.add(modelRun.region?.id);
+          regions.add(modelRun.region);
         }
       });
     state.filters = {
       ...state.filters,
       configuration_id: Array.from(configurationIds),
-      region_id: Array.from(regionIds),
+      regions: Array.from(regions),
       scoringColoring: null,
     };
   } else {
@@ -290,7 +289,7 @@ watch([() => props.filters.region, () => props.filters.performer], () => {
         {{ totalModelRuns }} {{ totalModelRuns > 1 ? "Runs" : "Run" }}
       </v-chip>
       <v-chip
-        v-if="!loading && !loadingSatelliteTimestamps && hasSatelliteImages && !state.satellite.satelliteImagesOn && state.filters.region_id?.length"
+        v-if="!loading && !loadingSatelliteTimestamps && hasSatelliteImages && !state.satellite.satelliteImagesOn && state.filters.regions?.length"
         style="font-size: 0.75em"
         label
         density="compact"
@@ -337,7 +336,7 @@ watch([() => props.filters.region, () => props.filters.performer], () => {
       />
     </div>
     <div
-      v-if="!loading && state.filters.region_id?.length && satelliteRegionTooLarge"
+      v-if="!loading && state.filters.regions?.length && satelliteRegionTooLarge"
       class="mt-5"
       style="font-size: 0.75em"
     >
@@ -369,7 +368,7 @@ watch([() => props.filters.region, () => props.filters.performer], () => {
         :open="state.openedModelRuns.has(modelRun.key)"
         :class="{
           outlined: hoveredInfo.region.includes(
-            `${modelRun.id}_${modelRun.region?.id}_${modelRun.performer.id}`
+            `${modelRun.id}_${modelRun.region}_${modelRun.performer.id}`
           ),
         }"
         @toggle="() => handleToggle(modelRun)"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -28,14 +28,14 @@ watch(selectedPerformer, (val) => {
     scoringColoring: null,
   };
 });
-watch (() => state.filters.region_id, () => {
-  if (state.filters.region_id?.length) {
-    selectedRegion.value = {id:state.filters.region_id[0], name: state.regionMap[state.filters.region_id[0]]}
+watch (() => state.filters.regions, () => {
+  if (state.filters.regions?.length) {
+    selectedRegion.value = state.filters.regions[0];
   }
 });
 
 const updateRegion = (val?: Region) => {
-  queryFilters.value = { ...queryFilters.value, region: val?.name, page: 1 };
+  queryFilters.value = { ...queryFilters.value, region: val, page: 1 };
   if (selectedRegion.value === undefined) {
     state.satellite.satelliteImagesOn = false;
     state.enabledSiteObservations = [];
@@ -43,7 +43,7 @@ const updateRegion = (val?: Region) => {
   }
   state.filters = {
     ...state.filters,
-    region_id: val?.id === undefined ? undefined : [val.id],
+    regions: val === undefined ? undefined : [val],
     scoringColoring: null,
   };
 };
@@ -125,7 +125,7 @@ onMounted(() => {
             'animate-flicker': state.satellite.loadingSatelliteImages,
           }"
           :color="imagesOn ? 'rgb(37, 99, 235)' : 'black'"
-          :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)" 
+          :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
           icon="mdi-image"
           @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
         />

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -11,17 +11,19 @@ import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
-const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
+
+const page = ref<number>(1);
+
+const queryFilters = computed<QueryArguments>(() => ({
+  page: page.value,
+  performer: selectedPerformer.value.map((item) => item.short_code),
+  region: selectedRegion.value,
+}));
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 const showSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
-  queryFilters.value = {
-    ...queryFilters.value,
-    performer: val.map((item) => item.short_code),
-    page: 1,
-  };
   state.filters = {
     ...state.filters,
     performer_ids: !val.length ? undefined : val.map((item) => item.id),
@@ -35,7 +37,7 @@ watch (() => state.filters.regions, () => {
 });
 
 const updateRegion = (val?: Region) => {
-  queryFilters.value = { ...queryFilters.value, region: val, page: 1 };
+  page.value = 1;
   if (selectedRegion.value === undefined) {
     state.satellite.satelliteImagesOn = false;
     state.enabledSiteObservations = [];
@@ -63,10 +65,7 @@ const imagesOn = computed({
 
 
 function nextPage() {
-  queryFilters.value = {
-    ...queryFilters.value,
-    page: (queryFilters.value.page || 0) + 1,
-  };
+  page.value += 1;
 }
 
 onMounted(() => {

--- a/vue/src/components/annotationViewer/ModelRunSiteEvalList.vue
+++ b/vue/src/components/annotationViewer/ModelRunSiteEvalList.vue
@@ -36,7 +36,7 @@ const statusMap: Record<SiteModelStatus, { name: string, color: string }> = {
   'PROPOSAL': { name: 'Proposed', color: 'orange'},
   'REJECTED': { name: 'Rejected', color: 'error'},
   'APPROVED': { name: 'Approved', color: 'success'},
-  
+
 }
 
 const getSiteEvalIds = async () => {
@@ -57,7 +57,7 @@ const modifiedList = computed(() => {
   const modList: ModelRunEvaluationDisplay[] = []
   let newNumbers = 0;
   if (evaluationsList.value?.evaluations) {
-    const regionName = evaluationsList.value.region.name;
+    const regionName: string = evaluationsList.value.region;
     evaluationsList.value.evaluations.forEach((item) => {
       const newNum = item.number.toString().padStart(4, '0')
       if (newNum === '9999') {
@@ -115,7 +115,7 @@ const download = (id: number) => {
       </div>
       <div v-else>
         <h3>Site Models:</h3>
-        <v-card 
+        <v-card
           v-for="item in modifiedList"
           :key="`${item.name}_${item.id}_${item.selected}`"
           class="modelRunCard"

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -27,14 +27,14 @@ watch(selectedPerformer, (val) => {
     scoringColoring: null,
   };
 });
-watch (() => state.filters.region_id, () => {
-  if (state.filters.region_id?.length) {
-    selectedRegion.value = {id:state.filters.region_id[0], name: state.regionMap[state.filters.region_id[0]]}
+watch (() => state.filters.regions, () => {
+  if (state.filters.regions?.length) {
+    selectedRegion.value = state.filters.regions[0];
   }
 });
 
 const updateRegion = (val?: Region) => {
-  queryFilters.value = { ...queryFilters.value, region: val?.name, page: 1 };
+  queryFilters.value = { ...queryFilters.value, region: val, page: 1 };
   if (selectedRegion.value === undefined) {
     state.satellite.satelliteImagesOn = false;
     state.enabledSiteObservations = [];
@@ -42,7 +42,7 @@ const updateRegion = (val?: Region) => {
   }
   state.filters = {
     ...state.filters,
-    region_id: val?.id === undefined ? undefined : [val.id],
+    regions: val === undefined ? undefined : [val],
     scoringColoring: null,
   };
 };

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -4,23 +4,25 @@ import TimeSlider from "../TimeSlider.vue";
 import PerformerFilter from "../filters/PerformerFilter.vue";
 import RegionFilter from "../filters/RegionFilter.vue";
 import { state } from "../../store";
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import type { Performer, QueryArguments, Region } from "../../client";
 import type { Ref } from "vue";
 import { changeTime } from "../../interactions/timeStepper";
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
-const queryFilters: Ref<QueryArguments> = ref({ page: 1 });
+
+const page = ref<number>(1);
+
+const queryFilters = computed<QueryArguments>(() => ({
+  page: page.value,
+  performer: selectedPerformer.value.map((item) => item.short_code),
+  region: selectedRegion.value,
+}));
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 const showSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
-  queryFilters.value = {
-    ...queryFilters.value,
-    performer: val.map((item) => item.short_code),
-    page: 1,
-  };
   state.filters = {
     ...state.filters,
     performer_ids: !val.length ? undefined : val.map((item) => item.id),
@@ -34,7 +36,7 @@ watch (() => state.filters.regions, () => {
 });
 
 const updateRegion = (val?: Region) => {
-  queryFilters.value = { ...queryFilters.value, region: val, page: 1 };
+  page.value = 1;
   if (selectedRegion.value === undefined) {
     state.satellite.satelliteImagesOn = false;
     state.enabledSiteObservations = [];
@@ -51,10 +53,7 @@ watch(showSiteOutline, (val) => {
 });
 
 function nextPage() {
-  queryFilters.value = {
-    ...queryFilters.value,
-    page: (queryFilters.value.page || 0) + 1,
-  };
+  page.value += 1;
 }
 
 onMounted(() => {

--- a/vue/src/components/filters/RegionFilter.vue
+++ b/vue/src/components/filters/RegionFilter.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { state } from "../../store";
 import { ref, watch, watchEffect } from "vue";
 import { ApiService } from "../../client";
 import type { Ref } from "vue";
 import type { Region } from "../../client";
-import { useRouter,  } from 'vue-router';
+import { useRouter, } from 'vue-router';
 
 const router = useRouter();
 
@@ -18,42 +17,31 @@ const emit = defineEmits<{
 }>();
 
 const regions: Ref<Region[]> = ref([]);
-const selectedRegion: Ref<number | undefined> = ref(props.modelValue?.id);
-const regionItems: Ref<{title: string; value: number}[]> = ref([]);
+const selectedRegion: Ref<string | undefined> = ref(props.modelValue);
 watchEffect(async () => {
   const regionList = await ApiService.getRegions();
   const regionResults = regionList.items;
-  regionResults.sort((a, b) => (a.name > b.name ? 1 : -1));
+  regionResults.sort((a, b) => (a > b ? 1 : -1));
   regions.value = regionResults;
-  regionItems.value = regionResults.map((item) => ({title: item.name, value: item.id}));
-  const generatedMap: Record<Region['id'], Region['name']> = {}
-    regionResults.forEach((item) => {
-      generatedMap[item.id] = item.name;
-  })
-  state.regionMap = generatedMap;
 });
 
 watch(() => props.modelValue, () => {
   if (props.modelValue) {
-    selectedRegion.value = props.modelValue.id;
+    selectedRegion.value = props.modelValue;
   }
 });
 
 watch(selectedRegion, (val) => {
   let prepend = '/'
   if (router.currentRoute.value.fullPath.includes('proposals')) {
-    prepend='/proposals/'
+    prepend = '/proposals/'
   }
-  if (val !== undefined) {
-    const found = regions.value.find((item) => item.id === val);
-
-    if (found) {
-      router.push(`${prepend}${found.name}`)
-      emit("update:modelValue", found);
-      return;
-    }
+  if (val) {
+    router.push(`${prepend}${val}`)
+    emit("update:modelValue", val);
+    return;
   }
-  router.push({path: prepend});
+  router.push({ path: prepend });
   emit("update:modelValue", undefined);
 });
 </script>
@@ -67,13 +55,13 @@ watch(selectedRegion, (val) => {
     variant="outlined"
     :label="`Region (${regions.length})`"
     :placeholder="`Region (${regions.length})`"
-    :items="regionItems"
+    :items="regions"
     single-line
     class="dropdown"
   />
 </template>
 <style scoped>
 .dropdown {
-  max-width:180px;
+  max-width: 180px;
 }
 </style>

--- a/vue/src/components/siteObservations/EvaluationDisplay.vue
+++ b/vue/src/components/siteObservations/EvaluationDisplay.vue
@@ -45,7 +45,7 @@ const currentClosestTimestamp = computed(() => {
         next = false;
       }
       return {
-        time: `${new Date(closest * 1000).toLocaleDateString()}`, 
+        time: `${new Date(closest * 1000).toLocaleDateString()}`,
         type: observation.images[rootIndex].source,
         prev,
         next,
@@ -110,7 +110,7 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
       >
         <v-col v-if="siteObservation.scoringBase">
           <span class="model-title">
-            {{ `${state.regionMap[siteObservation.scoringBase.regionId]}_${siteObservation.scoringBase.siteNumber.toString().padStart(4, '0')}` }}
+            {{ `${siteObservation.scoringBase.region}_${siteObservation.scoringBase.siteNumber.toString().padStart(4, '0')}` }}
           </span>
         </v-col>
         <v-col cols="1">
@@ -127,7 +127,7 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
         </v-col>
         <v-spacer />
         <v-col class="pl-4">
-          <v-icon 
+          <v-icon
             size="large"
             color="rgb(37, 99, 235)"
             class="mr-2"
@@ -172,7 +172,7 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
-      
+
       <v-row
         dense
         justify="center"
@@ -182,7 +182,7 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
           score:
         </div>
         <div>
-          {{ siteObservation.score.min.toFixed(2) }} to {{ siteObservation.score.max.toFixed(2) }} 
+          {{ siteObservation.score.min.toFixed(2) }} to {{ siteObservation.score.max.toFixed(2) }}
         </div>
         <v-spacer />
       </v-row>

--- a/vue/src/components/siteObservations/EvaluationScoring.vue
+++ b/vue/src/components/siteObservations/EvaluationScoring.vue
@@ -22,7 +22,7 @@ const retrieveScoring = async () => {
       return;
     }
     try {
-    const scoringRequest = await ApiService.getScoringDetails(scoreData.configurationId, scoreData.regionId, scoreData.siteNumber, scoreData.version);
+    const scoringRequest = await ApiService.getScoringDetails(scoreData.configurationId, scoreData.region, scoreData.siteNumber, scoreData.version);
     unionArea.value = scoringRequest.unionArea;
     temporalIOU.value = scoringRequest.temporalIOU;
     statusAnnotated.value = scoringRequest.statusAnnotated;
@@ -67,7 +67,7 @@ onMounted(() => retrieveScoring())
       <v-col v-if="statusAnnotated">
         <b> Status:</b>
         <span> {{ statusAnnotated }}</span>
-      </v-col>      
+      </v-col>
     </v-row>
     <v-row
       v-if="color"
@@ -98,7 +98,7 @@ onMounted(() => retrieveScoring())
         <v-col v-if="temporalIOU.site_preparation">
           <span> Site Prep: </span>
           <span> {{ parseFloat(temporalIOU.site_preparation).toFixed(6) }}</span>
-        </v-col>      
+        </v-col>
       </v-row>
       <v-row
         v-if="temporalIOU"
@@ -109,7 +109,7 @@ onMounted(() => retrieveScoring())
         <v-col v-if="temporalIOU.active_construction">
           <span> Active: </span>
           <span> {{ parseFloat(temporalIOU.active_construction).toFixed(6) }}</span>
-        </v-col>      
+        </v-col>
       </v-row>
       <v-row
         v-if="temporalIOU"
@@ -120,9 +120,9 @@ onMounted(() => retrieveScoring())
         <v-col v-if="temporalIOU.post_construction">
           <span> Post: </span>
           <span> {{ parseFloat(temporalIOU.post_construction).toFixed(6) }}</span>
-        </v-col>      
+        </v-col>
       </v-row>
     </v-container>
-    
+
   </span>
 </template>

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -50,11 +50,11 @@ const drawPopup = async (e: MapLayerMouseEvent) => {
       ) => {
         if (item.properties && item.properties.id) {
           const id = item.properties.site_number;
-          const regionName = state.regionMap[item.properties.region_id]
+          const region: string = item.properties.region;
           const score = item.properties.score;
           const siteId = item.properties.siteeval_id;
           hoveredInfo.value.region.push(
-            `${item.properties.configuration_id}_${item.properties.region_id}_${item.properties.performer_id}`
+            `${item.properties.configuration_id}_${region}_${item.properties.performer_id}`
           );
           hoveredInfo.value.siteId.push(siteId);
           if (!htmlMap[id]) {
@@ -66,7 +66,7 @@ const drawPopup = async (e: MapLayerMouseEvent) => {
                 }
                 const area = Math.round(item.properties.area).toLocaleString('en-US');
                 popupData.push({
-                  siteId: `${regionName}_${String(id).padStart(4, '0')}`,
+                  siteId: `${region}_${String(id).padStart(4, '0')}`,
                   score,
                   groundTruth: item.properties.groundtruth,
                   siteColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
@@ -105,7 +105,7 @@ const clickObservation = async (e: MapLayerMouseEvent) => {
     if (feature.properties) {
       const siteId = feature.properties.siteeval_id;
       const scoringBase = {
-        regionId: feature.properties.region_id as number,
+        region: feature.properties.region as string,
         configurationId: feature.properties.configuration_id as number,
         siteNumber: feature.properties.site_number as number,
         version: feature.properties.version,

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -134,7 +134,7 @@ const getAnnotationColor = (filters: MapFilters) => {
                 if (splits.length === 4) {
                     result.push(['all',
                         ['==', ['get', 'configuration_id'], splits[0]],
-                        ['==', ['get', 'region_id'], splits[1]],
+                        ['==', ['get', 'region'], splits[1]],
                         ['==', ['get', 'performer_id'], splits[2]],
                         ['==', ['get', 'site_number'], splits[3]],
                     ]);

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -69,8 +69,8 @@ export const buildObservationFilter = (
     ],
     [
       "in",
-      ["get", "region_id"],
-      ["literal", filters.region_id?.length ? filters.region_id : [""]],
+      ["get", "region"],
+      ["literal", filters.regions?.length ? filters.regions : [""]],
     ],
     [
       "any",

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -5,7 +5,7 @@ import { ApiService, ModelRun, Region } from "./client";
 export interface MapFilters {
   configuration_id?: number[];
   performer_ids?: number[];
-  region_id?: number[];
+  regions?: Region[];
   showSiteOutline?: boolean;
   groundTruthPattern?: boolean;
   otherPattern?: boolean;
@@ -52,7 +52,7 @@ export interface SiteObservationImage {
 }
 
 export interface ScoringBase {
-  regionId: number;
+  region: string;
   configurationId: number;
   siteNumber: number;
   version: string;
@@ -139,7 +139,6 @@ export const state = reactive<{
     patternThickness: number;
     patternOpacity: number;
   };
-  regionMap: Record<Region["id"], Region["name"]>
   selectedObservations: SiteObservation[];
   enabledSiteObservations: EnabledSiteObservations[],
   siteObsSatSettings: siteObsSatSettings,
@@ -180,7 +179,6 @@ export const state = reactive<{
     patternThickness: 8,
     patternOpacity: 255,
   },
-  regionMap: {},
   selectedObservations: [],
   enabledSiteObservations: [],
   siteObsSatSettings: {
@@ -250,24 +248,24 @@ export const getSiteObservationDetails = async (siteId: string, scoringBase?: Sc
   const numId = parseInt(siteId, 10)
   const foundIndex = state.selectedObservations.findIndex((item) => item.id === numId);
   const obsData =  {
-  id: numId,
-  scoringBase,
-  timerange: data.timerange,
-  imagesLoaded: false,
-  imagesActive: false,
-  imageCounts: {
-    L8,
-    S2,
-    WV,
-  },
-  score: {
-    min: minScore,
-    max: maxScore,
-    average: avgScore,
-  },
-  job: data.job,
-  bbox: data.bbox,
-};
+    id: numId,
+    scoringBase,
+    timerange: data.timerange,
+    imagesLoaded: false,
+    imagesActive: false,
+    imageCounts: {
+      L8,
+      S2,
+      WV,
+    },
+    score: {
+      min: minScore,
+      max: maxScore,
+      average: avgScore,
+    },
+    job: data.job,
+    bbox: data.bbox,
+  };
   if (foundIndex === -1 && select) {
     state.selectedObservations.push(obsData)
   } else {
@@ -326,6 +324,6 @@ export const loadAndToggleSatelliteImages = async (siteId: string) => {
   const data = await getSiteObservationDetails(siteId, undefined, false);
   toggleSatelliteImages(data);
   }
-  
+
 
 }

--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -4,11 +4,11 @@ import ImageViewer from "../components/imageViewer/ImageViewer.vue"
 import MapLibre from "../components/MapLibre.vue";
 import ModelRunSiteEvalList from "../components/annotationViewer/ModelRunSiteEvalList.vue"
 import { ModelRunEvaluationDisplay } from "../components/annotationViewer/ModelRunSiteEvalList.vue"
-import { Ref, computed, ref, watch } from "vue";
+import { Ref, computed, onMounted, ref, watch } from "vue";
 import { state } from "../store";
 
 interface Props {
-  region?: number | string;
+  region?: string;
   selected?: number[] | string;
 }
 const props = withDefaults(defineProps<Props>(), {
@@ -25,18 +25,15 @@ const selectedModelRun = computed(() => {
     return null;
 });
 
-watch(() => state.regionMap, () => {
-  if (state.regionMap && props.region) {
-    const found = Object.entries(state.regionMap).find(([, key]) => key === props.region);
-    if (found) {
-      state.filters = {
-    ...state.filters,
-    region_id: [parseInt(found[0], 10)],
-    scoringColoring: null,
-  };
-    }
+onMounted(() => {
+  if (props.region) {
+    state.filters = {
+      ...state.filters,
+      regions: [props.region],
+      scoringColoring: null,
+    };
   }
-})
+});
 
 const selectedEval: Ref<number | null> = ref(null);
 const selectedName: Ref<string | null> = ref(null);

--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -2,30 +2,27 @@
 import SideBar from "../components/SideBar.vue"
 import MapLibre from "../components/MapLibre.vue";
 import RightBar from "../components/RightBar.vue"
-import { watch } from "vue";
+import { onMounted } from "vue";
 import { state } from "../store";
 
 interface Props {
-  region?: number | string;
+  region?: string;
   selected?: number[] | string;
 }
 const props = withDefaults(defineProps<Props>(), {
   region: undefined,
-  selected:undefined,
+  selected: undefined,
 });
 
-watch(() => state.regionMap, () => {
-  if (state.regionMap && props.region) {
-    const found = Object.entries(state.regionMap).find(([, key]) => key === props.region);
-    if (found) {
-      state.filters = {
-    ...state.filters,
-    region_id: [parseInt(found[0], 10)],
-    scoringColoring: null,
-  };
-    }
+onMounted(() => {
+  if (props.region) {
+    state.filters = {
+      ...state.filters,
+      regions: [props.region],
+      scoringColoring: null,
+    };
   }
-})
+});
 
 
 </script>


### PR DESCRIPTION
This PR removes any notion of region "IDs" from the external-facing API. Regions are now referenced entirely by their string, just as in the T&E database.