### PR TITLE
Fix proposal region name

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -401,12 +401,7 @@ def get_region(hyper_parameters_id: int):
         .annotate(
             json=JSONObject(
                 region=Subquery(  # prevents including "region" in slow GROUP BY
-                    Region.objects.filter(pk=OuterRef('region_id')).values(
-                        json=JSONObject(
-                            id='id',
-                            name='name',
-                        )
-                    ),
+                    Region.objects.filter(pk=OuterRef('region_id')).values('name')[:1],
                     output_field=JSONField(),
                 ),
             ),


### PR DESCRIPTION
When looking at proposals the front-end was swapped to a direct string name but the back end was still providing an object 
`{ id: int; name: string}`.  This resulted in the name under proposals being `[Object object]_9999` instead of compounding the region name with the siteId (non-DB Id but the real Id).  Just updated the `get_region` function in model_run.py to fix the issue.