### PR TITLE
Fixes the site image endpoints by changing the int to str

### DIFF
--- a/django/src/rdwatch/views/site_image.py
+++ b/django/src/rdwatch/views/site_image.py
@@ -20,7 +20,7 @@ class SiteImageSchema(Schema):
     source: str
     cloudcover: float
     image: str
-    siteobs_id: int | None
+    siteobs_id: str | None
     percent_black: float
     bbox: BoundingBoxSchema
     image_dimensions: list[int]

--- a/django/src/rdwatch/views/site_observation.py
+++ b/django/src/rdwatch/views/site_observation.py
@@ -49,7 +49,7 @@ class SiteEvaluationImageSchema(Schema):
     cloudcover: float
     percent_black: float
     source: str
-    siteobs_id: int | None
+    siteobs_id: str | None
     bbox: BoundingBoxSchema
     image_dimensions: list[int]
     aws_location: str


### PR DESCRIPTION
Just noticed two locations where the siteobs_id was still an int which would cause nasty ninja validation errors when downloading images or viewing them.

There is a secondary problem that I can't figure out at all.  If you bring up a model run and click on a polygon it displays in the right side of the screen.  If you hover over that card on the right side of the screen it's supposed to highlight the polygon by making it thicker.  This is to associate your card with a polygon.  For some reason this makes all annotations disappear at once when you hover over the card.  I tried looking into the filters and a bunch of areas but this has me stumped.