### PR TITLE
Downloading Image Sequences

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@fontsource/inter": "^4.5.12",
         "@fontsource/iosevka": "^4.5.4",
+        "canvas-capture": "^2.1.1",
         "lodash": "^4.17.21",
         "maplibre-gl": "^2.1.9",
         "vue": "^3.2.37",
@@ -357,6 +358,20 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
+      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.1",
+        "regenerator-runtime": "^0.13.7",
+        "resolve-url": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=12.16.1"
       }
     },
     "node_modules/@fontsource/inter": {
@@ -1283,6 +1298,19 @@
         }
       ]
     },
+    "node_modules/canvas-capture": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/canvas-capture/-/canvas-capture-2.1.1.tgz",
+      "integrity": "sha512-fY1iCk0xajXm1pCYUSW3gyDGqSyQdejwPcbXAEUFajg7Hy3SX/tSsKwdWnZf6lXa3VwTXl2TNEJ5P1dVfGM1qQ==",
+      "dependencies": {
+        "@ffmpeg/ffmpeg": "^0.10.1",
+        "changedpi": "^1.0.4",
+        "file-saver": "^2.0.5",
+        "jszip": "^3.7.1",
+        "mdn-polyfills": "^5.20.0",
+        "micromodal": "^0.4.6"
+      }
+    },
     "node_modules/chai": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
@@ -1316,6 +1344,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/changedpi": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/changedpi/-/changedpi-1.0.4.tgz",
+      "integrity": "sha512-9r6MNQrbg+cFURvEy10wo9Q35PD5GVj2GvXCbUYv8mU0Uf/NbkR7KlzMrjT4Ycd8a2nxApFJXQX2lTOPRFyG2g=="
     },
     "node_modules/check-error": {
       "version": "1.0.2",
@@ -1419,6 +1452,11 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -2397,6 +2435,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2807,6 +2850,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/immutable": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
@@ -2872,8 +2920,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -2976,6 +3023,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3062,6 +3119,17 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kdbush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
@@ -3092,6 +3160,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3260,6 +3336,11 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
+    "node_modules/mdn-polyfills": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/mdn-polyfills/-/mdn-polyfills-5.20.0.tgz",
+      "integrity": "sha512-AbTv1ytcoOUAkxw6u5oo2QPf27kEZgxBAQr49jFb4i2VnTnFGfJbcIQ9UDBOdfNECeXsgkYFwB2BkdeTfOzztw=="
+    },
     "node_modules/meow": {
       "version": "10.1.5",
       "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
@@ -3318,6 +3399,14 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromodal": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+      "integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/min-indent": {
@@ -3408,6 +3497,25 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
@@ -3564,6 +3672,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3836,6 +3949,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -3952,6 +4070,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3979,6 +4111,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -4022,6 +4159,12 @@
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -4106,6 +4249,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/sass": {
       "version": "1.64.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
@@ -4137,6 +4285,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4245,6 +4398,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4578,6 +4739,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -4731,8 +4897,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -5004,6 +5169,20 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5273,6 +5452,17 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
       "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
       "dev": true
+    },
+    "@ffmpeg/ffmpeg": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
+      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "requires": {
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.1",
+        "regenerator-runtime": "^0.13.7",
+        "resolve-url": "^0.2.1"
+      }
     },
     "@fontsource/inter": {
       "version": "4.5.15",
@@ -5943,6 +6133,19 @@
       "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true
     },
+    "canvas-capture": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/canvas-capture/-/canvas-capture-2.1.1.tgz",
+      "integrity": "sha512-fY1iCk0xajXm1pCYUSW3gyDGqSyQdejwPcbXAEUFajg7Hy3SX/tSsKwdWnZf6lXa3VwTXl2TNEJ5P1dVfGM1qQ==",
+      "requires": {
+        "@ffmpeg/ffmpeg": "^0.10.1",
+        "changedpi": "^1.0.4",
+        "file-saver": "^2.0.5",
+        "jszip": "^3.7.1",
+        "mdn-polyfills": "^5.20.0",
+        "micromodal": "^0.4.6"
+      }
+    },
     "chai": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
@@ -5967,6 +6170,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "changedpi": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/changedpi/-/changedpi-1.0.4.tgz",
+      "integrity": "sha512-9r6MNQrbg+cFURvEy10wo9Q35PD5GVj2GvXCbUYv8mU0Uf/NbkR7KlzMrjT4Ycd8a2nxApFJXQX2lTOPRFyG2g=="
     },
     "check-error": {
       "version": "1.0.2",
@@ -6049,6 +6257,11 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
       "version": "8.2.0",
@@ -6682,6 +6895,11 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6969,6 +7187,11 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "immutable": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
@@ -7016,8 +7239,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -7093,6 +7315,16 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7162,6 +7394,17 @@
         "universalify": "^2.0.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "kdbush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
@@ -7186,6 +7429,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -7318,6 +7569,11 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
+    "mdn-polyfills": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/mdn-polyfills/-/mdn-polyfills-5.20.0.tgz",
+      "integrity": "sha512-AbTv1ytcoOUAkxw6u5oo2QPf27kEZgxBAQr49jFb4i2VnTnFGfJbcIQ9UDBOdfNECeXsgkYFwB2BkdeTfOzztw=="
+    },
     "meow": {
       "version": "10.1.5",
       "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
@@ -7361,6 +7617,11 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "micromodal": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+      "integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -7426,6 +7687,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-releases": {
       "version": "2.0.13",
@@ -7542,6 +7811,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "devOptional": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -7730,6 +8004,11 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -7803,6 +8082,20 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7821,6 +8114,11 @@
         "indent-string": "^5.0.0",
         "strip-indent": "^4.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -7852,6 +8150,11 @@
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -7902,6 +8205,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "sass": {
       "version": "1.64.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
@@ -7921,6 +8229,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -8002,6 +8315,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -8253,6 +8574,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -8342,8 +8668,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -8479,6 +8804,20 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.11.tgz",
       "integrity": "sha512-hlbSgxXCcEu4VelJMRHKhvLpaitLsruHvdvolbqbCS6Z64XoulUDw3CQ9ay6WGBL7uckmop0bUYidD2d8mN0UQ==",
       "requires": {}
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/vue/package.json
+++ b/vue/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@fontsource/inter": "^4.5.12",
     "@fontsource/iosevka": "^4.5.4",
-    "canvas-capture": "https://github.com/amandaghassaei/canvas-capture#dev",
+    "canvas-capture": "^2.1.1",
     "lodash": "^4.17.21",
     "maplibre-gl": "^2.1.9",
     "vue": "^3.2.37",

--- a/vue/package.json
+++ b/vue/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@fontsource/inter": "^4.5.12",
     "@fontsource/iosevka": "^4.5.4",
+    "canvas-capture": "https://github.com/amandaghassaei/canvas-capture#dev",
     "lodash": "^4.17.21",
     "maplibre-gl": "^2.1.9",
     "vue": "^3.2.37",
@@ -51,7 +52,7 @@
     "vue-eslint-parser": "^9.0.3",
     "vue-tsc": "^0.38.4"
   },
-  "//":"vue/no-setup-props-destructure is disabled in esLint, due to an issue with utilizing DefineProps: https://github.com/vuejs/eslint-plugin-vue/issues/2121",
+  "//": "vue/no-setup-props-destructure is disabled in esLint, due to an issue with utilizing DefineProps: https://github.com/vuejs/eslint-plugin-vue/issues/2121",
   "eslintConfig": {
     "root": true,
     "env": {

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -280,21 +280,39 @@ const drawData = (
           context.canvas.style.width = `${width}px`
           context.canvas.style.height = `${height}px`;
         } else { // We draw a label for downloaded GIFs
-          const fontSize = Math.max(canvas.width, canvas.height) / 50;
+          const fontSize = canvas.height / 20;
           context.font = `${fontSize * 0.75}px Arial`;
-          const calcWidth = context.measureText(poly.label).width;
-          const labelWidth = Math.max(canvas.width / 8, calcWidth * 1.2);
-          const labelHeight = canvas.height / 4;
-          context.fillStyle = 'rgba(255, 255, 255, 0.5)';
-          context.fillRect(0, 0, labelWidth, labelHeight);
-          context.fillStyle = 'black';
-          context.font = `${fontSize}px Arial`;
-          context.fillText(image.source, 10, labelHeight / 4);
-          context.font = `${fontSize * 0.75}px Arial`;
-          const date = new Date(image.timestamp * 1000).toISOString().split('T')[0]
-          context.fillText(date, 10, labelHeight / 2);
-          context.fillStyle = getColorFromLabel(poly.label);
-          context.fillText(poly.label, 10, labelHeight * 0.75, labelWidth);
+          // Source Satellite
+          if (image.source) {
+            const calc = context.measureText(image.source);
+            // Background
+            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
+            const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
+            context.fillRect(0, 0, calc.width*1.10, fontHeight);
+            context.fillStyle = 'black';
+            context.fillText(image.source, 1, fontHeight);
+          }
+          if (image.timestamp) {
+            const date = new Date(image.timestamp * 1000).toISOString().split('T')[0]
+            const calc = context.measureText(date);
+            // Background
+            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
+            const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
+            const xPos = (canvas.width * 0.5) - (calc.width * 1.10 * 0.5);
+            context.fillRect(xPos, 0, calc.width*1.10, fontHeight * 0.90);
+            context.fillStyle = 'black';
+            context.fillText(date, xPos, fontHeight);
+          }
+          if (image.timestamp) {
+            const calc = context.measureText(poly.label);
+            // Background
+            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
+            const fontHeight =  (calc.fontBoundingBoxAscent + calc.fontBoundingBoxDescent) * 1.10;
+            const xPos = (canvas.width) - (calc.width * 1.10);
+            context.fillRect(xPos, 0, calc.width*1.10, fontHeight);
+            context.fillStyle = getColorFromLabel(poly.label);
+            context.fillText(poly.label, xPos, fontHeight * 0.90);
+          }
           context.stroke();
         }
       } 

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { Ref, computed, ref, watch, withDefaults } from "vue";
 import { ApiService } from "../../client";
-import {EvaluationGeoJSON, EvaluationImage, EvaluationImageResults } from "../../types";
+import { EvaluationImage, EvaluationImageResults } from "../../types";
 import { getColorFromLabel, styles } from '../../mapstyle/annotationStyles';
 import { loadAndToggleSatelliteImages, state } from '../../store'
 import { VDatePicker } from 'vuetify/labs/VDatePicker'
 import { SiteModelStatus } from "../../client/services/ApiService";
 import { CanvasCapture } from 'canvas-capture';
+import type { PixelPoly } from './imageUtils';
+import { createCanvas, drawData, processImagePoly } from './imageUtils';
 
 interface Props {
   siteEvalId: string;
@@ -24,11 +26,6 @@ const props = withDefaults(defineProps<Props>(), {
   siteEvaluationName: null,
   dateRange: null,
 });
-
-interface PixelPoly {
-    coords: {x:number; y:number}[][];
-    label: string;
-}
 
 const emit = defineEmits<{
   (e: "close"): void;
@@ -72,20 +69,7 @@ const hasGroundTruth = ref(false);
 const groundTruth: Ref<EvaluationImageResults['groundTruth'] | null > = ref(null);
 const drawGroundTruth = ref(false);
 const siteEvaluationList = computed(() => Object.entries(styles).filter(([, { type }]) => type === 'sites').map(([label]) => label));
-const getClosestPoly = (timestamp: number, polys: EvaluationGeoJSON[], evaluationPoly: EvaluationGeoJSON['geoJSON'], siteEvalLabel: string) => {
-  if (polys.length === 0) {
-    return {geoJSON: evaluationPoly, label:siteEvalLabel};
-  }
-    let found = polys[0];
-    for (let i = 0; i < polys.length; i += 1) {
-        if (timestamp > polys[i].timestamp) {
-            if (i > 0) {
-                found = polys[i -1]
-            }
-        }
-    }
-    return found;
-}
+
 
 const filteredImages = computed(() => {
   return combinedImages.value.filter((item) => {
@@ -125,15 +109,6 @@ watch(currentTimestamp, () => {
   currentDate.value = currentTimestamp.value;
 });
 
-function createCanvas(width: number, height: number){
-    const myOffScreenCanvas: HTMLCanvasElement & { ctx?: CanvasRenderingContext2D | null } = document.createElement("canvas");
-    myOffScreenCanvas.width = width;
-    myOffScreenCanvas.height = height;
-    // attach the context to the canvas for easy access and to reduce complexity.
-    myOffScreenCanvas.ctx = myOffScreenCanvas.getContext("2d");
-    return myOffScreenCanvas;
- }
-
 
 const getImageData = async () => {
     combinedImages.value = [];
@@ -157,180 +132,37 @@ const getImageData = async () => {
     // Lets process the polygons to get them in pixel space.
     // For each polygon we need to convert it to the proper image sizing result.
     images.forEach((image) => {
-        const closestPoly = getClosestPoly(image.timestamp, polygons, data.evaluationGeoJSON, data.label);
-        // Now we convert the coordinates to
-        const bboxWidth = image.bbox.xmax - image.bbox.xmin;
-        const bboxHeight = image.bbox.ymax - image.bbox.ymin;
-        const imageWidth = image.image_dimensions[0];
-        const imageHeight = image.image_dimensions[1];
-        const imageNormalizePoly: {x: number, y: number}[][] = []
-        closestPoly.geoJSON.coordinates.forEach((ring) => {
-          imageNormalizePoly.push([]);
-            ring.forEach((coord) => {
-                const normalize_x = (coord[0] - image.bbox.xmin) / bboxWidth;
-            const normalize_y = (coord[1] - image.bbox.ymin) / bboxHeight;
-            const image_x = normalize_x * imageWidth;
-            const image_y = normalize_y * imageHeight;
-            imageNormalizePoly[imageNormalizePoly.length -1].push({x: image_x, y: image_y});
-
-            })
-        })
-        let groundTruthPoly;
-        if (hasGroundTruth.value && groundTruth.value) {
-          const gtNormalizePoly: {x: number, y: number}[][] = []
-          groundTruth.value.geoJSON.coordinates.forEach((ring) => {
-            gtNormalizePoly.push([]);
-            ring.forEach((coord) => {
-                const normalize_x = (coord[0] - image.bbox.xmin) / bboxWidth;
-              const normalize_y = (coord[1] - image.bbox.ymin) / bboxHeight;
-              const image_x = normalize_x * imageWidth;
-              const image_y = normalize_y * imageHeight;
-              gtNormalizePoly[imageNormalizePoly.length -1].push({x: image_x, y: image_y});
-              })
-              groundTruthPoly = { coords: gtNormalizePoly, label: groundTruth.value?.label}
-          })
-
-        }
-        combinedImages.value.push({ image: image, poly: {coords: imageNormalizePoly, label: closestPoly.label}, groundTruthPoly });
+        const result = processImagePoly(image, polygons, data.evaluationGeoJSON, data.label, hasGroundTruth.value, groundTruth.value);
+        combinedImages.value.push(result);
     })
 }
 let background: HTMLCanvasElement & { ctx?: CanvasRenderingContext2D | null };
-const drawData = (
-  canvas: HTMLCanvasElement,
-  image: EvaluationImage,
-  poly:PixelPoly,
-  groundTruthPoly?: PixelPoly,
-  overrideWidth = -1,
-  overrideHeight = -1,
-  ) => {
-    const context = canvas.getContext('2d');
-    const imageObj = new Image();
-    imageObj.src = image.image;
-    imageObj.crossOrigin = "Anonymous";
-    if (!background) {
-        background = createCanvas(image.image_dimensions[0], image.image_dimensions[1]);
-    }
-    background.width = image.image_dimensions[0];
-    background.height = image.image_dimensions[1];
-    const { coords } = poly;
-    const renderFunction = () => {
-        if (context) {
-        canvas.width = overrideWidth === -1 ? image.image_dimensions[0]: overrideWidth;
-        canvas.height = overrideHeight === -1 ? image.image_dimensions[1]: overrideHeight;
-        // draw the offscreen canvas
-        if (overrideWidth !== -1 || overrideHeight !== -1) {
-          context.drawImage(background, 0, 0, image.image_dimensions[0], image.image_dimensions[1], 0, 0, overrideWidth, overrideHeight);
-        } else {
-          context.drawImage(background, 0, 0);
-        }
-        const widthRatio = overrideWidth / image.image_dimensions[0];
-        const heightRatio = overrideHeight / image.image_dimensions[1];
 
-        // We draw the ground truth
-        if (groundTruthPoly && drawGroundTruth.value) {
-          groundTruthPoly.coords.forEach((ring) => {
-            const xPos = overrideWidth === -1 ? ring[0].x : ring[0].x * widthRatio ;
-            const yPos = overrideHeight === -1 ? image.image_dimensions[1] - ring[0].y : overrideHeight - (ring[0].y * overrideHeight);
-            context.moveTo(xPos, yPos);
-            context.beginPath();
-            ring.forEach(({x, y}) => {
-              const yPosEnd =  overrideHeight === -1 ? image.image_dimensions[1] - y : overrideHeight - (y * heightRatio);
-              const xPos = overrideWidth === -1 ? x : x * widthRatio;
-              if (context){
-                  context.lineTo(xPos, yPosEnd);
-              }
-            });
-            const lineDivisor = Math.max(canvas.width, canvas.height)
-            context.lineWidth = lineDivisor/ 50.0;
-            context.strokeStyle = getColorFromLabel(groundTruthPoly.label);
-            context.stroke();
-          });
-        }
+// GIF Settings and Variables
 
-        coords.forEach((ring) => {
-          const xPos = overrideWidth === -1 ? ring[0].x : ring[0].x * widthRatio ;
-          const yPos = overrideHeight === -1 ? image.image_dimensions[1] - ring[0].y : overrideHeight - (ring[0].y * overrideHeight);
-          
-          context.moveTo(xPos, yPos);
-          context.beginPath();
-          ring.forEach(({x, y}) => {
-            const yPosEnd =  overrideHeight === -1 ? image.image_dimensions[1] - y : overrideHeight - (y * heightRatio);
-            const xPos = overrideWidth === -1 ? x : x * widthRatio;
-            if (context){
-                context.lineTo(xPos, yPosEnd);
-            }
-          });
-          const lineDivisor = Math.max(canvas.width, canvas.height);
-          context.lineWidth = lineDivisor/ 100.0;
-          context.strokeStyle = getColorFromLabel(poly.label);
-          currentLabel.value = siteEvaluationLabel.value == poly.label ? '' : poly.label;
-          context.stroke();
-        });
-        // Now scale the canvas to the proper size
-        if (overrideHeight === -1  && overrideWidth === -1) {
-          const ratio = image.image_dimensions[1] / image.image_dimensions[0];
-          const maxHeight = document.documentElement.clientHeight * 0.30;
-          const maxWidth = document.documentElement.clientWidth - 550;
-          let width = maxWidth
-          let height = width * ratio;
-          if (height > maxHeight) {
-            height = maxHeight;
-            width = height / ratio;
-          }
-          context.canvas.style.width = `${width}px`
-          context.canvas.style.height = `${height}px`;
-        } else { // We draw a label for downloaded GIFs
-          const fontSize = canvas.height / 20;
-          context.font = `${fontSize * 0.75}px Arial`;
-          // Source Satellite
-          if (image.source) {
-            const calc = context.measureText(image.source);
-            // Background
-            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
-            const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
-            context.fillRect(0, 0, calc.width*1.10, fontHeight);
-            context.fillStyle = 'black';
-            context.fillText(image.source, 1, fontHeight);
-          }
-          if (image.timestamp) {
-            const date = new Date(image.timestamp * 1000).toISOString().split('T')[0]
-            const calc = context.measureText(date);
-            // Background
-            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
-            const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
-            const xPos = (canvas.width * 0.5) - (calc.width * 1.10 * 0.5);
-            context.fillRect(xPos, 0, calc.width*1.10, fontHeight * 0.90);
-            context.fillStyle = 'black';
-            context.fillText(date, xPos, fontHeight);
-          }
-          if (image.timestamp) {
-            const calc = context.measureText(poly.label);
-            // Background
-            context.fillStyle = 'rgba(255, 255, 255, 0.5)';
-            const fontHeight =  (calc.fontBoundingBoxAscent + calc.fontBoundingBoxDescent) * 1.10;
-            const xPos = (canvas.width) - (calc.width * 1.10);
-            context.fillRect(xPos, 0, calc.width*1.10, fontHeight);
-            context.fillStyle = getColorFromLabel(poly.label);
-            context.fillText(poly.label, xPos, fontHeight * 0.90);
-          }
-          context.stroke();
-        }
-      } 
-    }
 
-    imageObj.onload = () => {
-        if (background.ctx) {
-            background.width = image.image_dimensions[0];
-            background.height = image.image_dimensions[1];
-            background.ctx.drawImage(imageObj, 0, 0, image.image_dimensions[0], image.image_dimensions[1]);
-            renderFunction();
-        }
-    }
-    };
+const downloadingGifFPS = computed({
+  get() {
+    return state.gifSettings.fps || 1;
+  },
+  set(val: number) {
+    state.gifSettings = { ...state.gifSettings, fps: val };
+  },
+});
+const downloadingGifQuality = computed({
+  get() {
+    return state.gifSettings.quality || 0.01;
+  },
+  set(val: number) {
+    state.gifSettings = { ...state.gifSettings, quality: val };
+  },
+});
+
 
 const downloadingGif = ref(false);
 const downloadingGifState: Ref<null | 'drawing' | 'generating'> = ref(null);
 const downloadingGifProgress = ref(0);
+const GifSettingsDialog = ref(false);
 const exportProgress = (progress: number) => {
   downloadingGifProgress.value = progress * 100;
   if (progress === 1) {
@@ -363,7 +195,12 @@ function drawForDownload() {
   const offScreenCanvas = createCanvas(width, height);
   downloadingGifState.value = 'drawing';
   CanvasCapture.init(offScreenCanvas, { verbose: false});
-  CanvasCapture.beginGIFRecord({name: props.siteEvaluationName || 'download', fps: 1, onExportProgress: exportProgress});
+  CanvasCapture.beginGIFRecord({
+    name: props.siteEvaluationName || 'download',
+    fps: downloadingGifFPS.value,
+    quality: downloadingGifQuality.value,
+    onExportProgress: exportProgress,
+  });
   let index = 0;
   function drawImageForRecord(){
     requestAnimationFrame(drawImageForRecord);
@@ -375,6 +212,8 @@ function drawForDownload() {
         filteredImages.value[index].groundTruthPoly,
         width,
         height,
+        background,
+        drawGroundTruth.value,
       );
       CanvasCapture.recordFrame();
       index += 1
@@ -406,7 +245,11 @@ const load = async (newValue?: string, oldValue?: string) => {
         canvasRef.value,
         filteredImages.value[currentImage.value].image,
         filteredImages.value[currentImage.value].poly,
-        filteredImages.value[currentImage.value].groundTruthPoly
+        filteredImages.value[currentImage.value].groundTruthPoly,
+        -1, 
+        -1,
+        background,
+        drawGroundTruth.value,
         )
   }
   loading.value = false;
@@ -440,6 +283,10 @@ watch([currentImage, imageRef, filteredImages, drawGroundTruth], () => {
           filteredImages.value[currentImage.value].image,
           filteredImages.value[currentImage.value].poly,
           filteredImages.value[currentImage.value].groundTruthPoly,
+          -1,
+          -1,
+          background,
+          drawGroundTruth.value,
         )
     }
     if (props.dialog === false && filteredImages.value[currentImage.value]) {
@@ -752,6 +599,9 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
           <v-icon v-else>
             mdi-spin mdi-sync
           </v-icon>
+          <v-icon @click="GifSettingsDialog = true">
+            mdi-cog
+          </v-icon>
         </template>
         <span>
           Download Images to GIF.
@@ -927,6 +777,44 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
         {{ notes }}
       </p>
     </div>
+    <v-dialog
+      v-model="GifSettingsDialog"
+      width="400"
+    >
+      <v-card>
+        <v-card-title> GIF Downloading Settings</v-card-title>
+        <v-card-text>
+          <v-row dense>
+            <v-text-field
+              v-model.number="downloadingGifFPS"
+              type="number"
+              label="FPS"
+              :rules="[v => v > 0 || 'Value must be greater than 0']"
+            />
+          </v-row>
+          <v-row dense>
+            <v-slider
+              v-model="downloadingGifQuality"
+              min="0"
+              max="1"
+              step="0.1"
+              :label="`Quality (${downloadingGifQuality.toFixed(2)})`"
+            />
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-row>
+            <v-spacer />
+            <v-btn
+              color="success"
+              @click="GifSettingsDialog = false"
+            >
+              OK
+            </v-btn>
+          </v-row>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-dialog
       v-model="editDialog"
       width="400"

--- a/vue/src/components/imageViewer/ImageViewerButton.vue
+++ b/vue/src/components/imageViewer/ImageViewerButton.vue
@@ -4,6 +4,7 @@ import ImageViewer from './ImageViewer.vue';
 
 defineProps<{
   siteEvalId: string;
+  siteEvaluationName?: string;
 }>();
 
 const displayImage = ref(false);
@@ -22,6 +23,7 @@ const displayImage = ref(false);
     >
       <ImageViewer
         :site-eval-id="siteEvalId"
+        :site-evaluation-name="siteEvaluationName"
         dialog
         @close="displayImage = false"
       />

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -1,0 +1,219 @@
+import { getColorFromLabel } from "../../mapstyle/annotationStyles";
+import { EvaluationGeoJSON, EvaluationImage, EvaluationImageResults } from "../../types";
+
+export interface PixelPoly {
+    coords: {x:number; y:number}[][];
+    label: string;
+}
+
+const getClosestPoly = (timestamp: number, polys: EvaluationGeoJSON[], evaluationPoly: EvaluationGeoJSON['geoJSON'], siteEvalLabel: string) => {
+    if (polys.length === 0) {
+      return {geoJSON: evaluationPoly, label:siteEvalLabel};
+    }
+      let found = polys[0];
+      for (let i = 0; i < polys.length; i += 1) {
+          if (timestamp > polys[i].timestamp) {
+              if (i > 0) {
+                  found = polys[i -1]
+              }
+          }
+      }
+      return found;
+  }
+  
+
+const createCanvas = (width: number, height: number) => {
+    const myOffScreenCanvas: HTMLCanvasElement & { ctx?: CanvasRenderingContext2D | null } = document.createElement("canvas");
+    myOffScreenCanvas.width = width;
+    myOffScreenCanvas.height = height;
+    // attach the context to the canvas for easy access and to reduce complexity.
+    myOffScreenCanvas.ctx = myOffScreenCanvas.getContext("2d");
+    return myOffScreenCanvas;
+ }
+
+
+const drawData = (
+    canvas: HTMLCanvasElement,
+    image: EvaluationImage,
+    poly: PixelPoly,
+    groundTruthPoly?: PixelPoly,
+    overrideWidth = -1,
+    overrideHeight = -1,
+    background: HTMLCanvasElement & { ctx?: CanvasRenderingContext2D | null } | null = null,
+    drawGroundTruth = false,
+    ) => {
+      const context = canvas.getContext('2d');
+      const imageObj = new Image();
+      imageObj.src = image.image;
+      imageObj.crossOrigin = "Anonymous";
+      if (!background) {
+          background = createCanvas(image.image_dimensions[0], image.image_dimensions[1]);
+      }
+      background.width = image.image_dimensions[0];
+      background.height = image.image_dimensions[1];
+      const { coords } = poly;
+      const renderFunction = () => {
+          if (context) {
+          canvas.width = overrideWidth === -1 ? image.image_dimensions[0]: overrideWidth;
+          canvas.height = overrideHeight === -1 ? image.image_dimensions[1]: overrideHeight;
+          // draw the offscreen canvas
+          if ((overrideWidth !== -1 || overrideHeight !== -1) && background) {
+            context.drawImage(background, 0, 0, image.image_dimensions[0], image.image_dimensions[1], 0, 0, overrideWidth, overrideHeight);
+          } else if (background) {
+            context.drawImage(background, 0, 0);
+          }
+          const widthRatio = overrideWidth / image.image_dimensions[0];
+          const heightRatio = overrideHeight / image.image_dimensions[1];
+  
+          // We draw the ground truth
+          if (groundTruthPoly && drawGroundTruth) {
+            groundTruthPoly.coords.forEach((ring) => {
+              const xPos = overrideWidth === -1 ? ring[0].x : ring[0].x * widthRatio ;
+              const yPos = overrideHeight === -1 ? image.image_dimensions[1] - ring[0].y : overrideHeight - (ring[0].y * overrideHeight);
+              context.moveTo(xPos, yPos);
+              context.beginPath();
+              ring.forEach(({x, y}) => {
+                const yPosEnd =  overrideHeight === -1 ? image.image_dimensions[1] - y : overrideHeight - (y * heightRatio);
+                const xPos = overrideWidth === -1 ? x : x * widthRatio;
+                if (context){
+                    context.lineTo(xPos, yPosEnd);
+                }
+              });
+              const lineDivisor = Math.max(canvas.width, canvas.height)
+              context.lineWidth = lineDivisor/ 50.0;
+              context.strokeStyle = getColorFromLabel(groundTruthPoly.label);
+              context.stroke();
+            });
+          }
+  
+          coords.forEach((ring) => {
+            const xPos = overrideWidth === -1 ? ring[0].x : ring[0].x * widthRatio ;
+            const yPos = overrideHeight === -1 ? image.image_dimensions[1] - ring[0].y : overrideHeight - (ring[0].y * overrideHeight);
+            
+            context.moveTo(xPos, yPos);
+            context.beginPath();
+            ring.forEach(({x, y}) => {
+              const yPosEnd =  overrideHeight === -1 ? image.image_dimensions[1] - y : overrideHeight - (y * heightRatio);
+              const xPos = overrideWidth === -1 ? x : x * widthRatio;
+              if (context){
+                  context.lineTo(xPos, yPosEnd);
+              }
+            });
+            const lineDivisor = Math.max(canvas.width, canvas.height);
+            context.lineWidth = lineDivisor/ 100.0;
+            context.strokeStyle = getColorFromLabel(poly.label);
+            context.stroke();
+          });
+          // Now scale the canvas to the proper size
+          if (overrideHeight === -1  && overrideWidth === -1) {
+            const ratio = image.image_dimensions[1] / image.image_dimensions[0];
+            const maxHeight = document.documentElement.clientHeight * 0.30;
+            const maxWidth = document.documentElement.clientWidth - 550;
+            let width = maxWidth
+            let height = width * ratio;
+            if (height > maxHeight) {
+              height = maxHeight;
+              width = height / ratio;
+            }
+            context.canvas.style.width = `${width}px`
+            context.canvas.style.height = `${height}px`;
+          } else { // We draw a label for downloaded GIFs
+            const fontSize = canvas.height / 15;
+            context.font = `${fontSize}px Arial`;
+            // Source Satellite
+            if (image.source) {
+              const drawText = image.siteobs_id !== null ? `*${image.source}` : image.source;
+              const calc = context.measureText(drawText);
+              context.fillStyle = 'rgba(255, 255, 255, 0.5)';
+              const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
+              context.fillRect(0, 0, calc.width*1.10, fontHeight * 1.10);
+              context.fillStyle = 'black';
+              context.fillText(drawText, 0, fontHeight);
+            }
+            // Date Drawing
+            if (image.timestamp) {
+              const date = new Date(image.timestamp * 1000).toISOString().split('T')[0]
+              const calc = context.measureText(date);
+              context.fillStyle = 'rgba(255, 255, 255, 0.5)';
+              const fontHeight =  (calc.actualBoundingBoxAscent + calc.actualBoundingBoxDescent) * 1.10;
+              const xPos = (canvas.width * 0.5) - (calc.width * 1.10 * 0.5);
+              context.fillRect(xPos, 0, calc.width*1.10, fontHeight * 1.10);
+              context.fillStyle = 'black';
+              context.fillText(date, xPos, fontHeight);
+            }
+            // Label Drawing
+            if (image.timestamp) {
+              const calc = context.measureText(poly.label);
+              context.fillStyle = 'rgba(255, 255, 255, 0.5)'; 
+              const fontHeight =  (calc.fontBoundingBoxAscent + calc.fontBoundingBoxDescent) * 1.10;
+              const xPos = (canvas.width) - (calc.width * 1.10);
+              context.fillRect(xPos, 0, calc.width*1.10, fontHeight * 1.10);
+              context.fillStyle = getColorFromLabel(poly.label);
+              context.fillText(poly.label, xPos, fontHeight * 0.90);
+            }
+            context.stroke();
+          }
+        } 
+      }
+  
+      imageObj.onload = () => {
+          if (background && background.ctx) {
+              background.width = image.image_dimensions[0];
+              background.height = image.image_dimensions[1];
+              background.ctx.drawImage(imageObj, 0, 0, image.image_dimensions[0], image.image_dimensions[1]);
+              renderFunction();
+          }
+      }
+    };
+
+
+const processImagePoly = (
+    image: EvaluationImage,
+    polygons: EvaluationGeoJSON[],
+    evaluationGeoJSON: EvaluationImageResults['evaluationGeoJSON'],
+    label: string,
+    hasGroundTruth: boolean,
+    groundTruth: EvaluationImageResults['groundTruth'] | null,
+    ) => {
+    const closestPoly = getClosestPoly(image.timestamp, polygons, evaluationGeoJSON, label);
+        // Now we convert the coordinates to
+        const bboxWidth = image.bbox.xmax - image.bbox.xmin;
+        const bboxHeight = image.bbox.ymax - image.bbox.ymin;
+        const imageWidth = image.image_dimensions[0];
+        const imageHeight = image.image_dimensions[1];
+        const imageNormalizePoly: {x: number, y: number}[][] = []
+        closestPoly.geoJSON.coordinates.forEach((ring) => {
+          imageNormalizePoly.push([]);
+            ring.forEach((coord) => {
+                const normalize_x = (coord[0] - image.bbox.xmin) / bboxWidth;
+            const normalize_y = (coord[1] - image.bbox.ymin) / bboxHeight;
+            const image_x = normalize_x * imageWidth;
+            const image_y = normalize_y * imageHeight;
+            imageNormalizePoly[imageNormalizePoly.length -1].push({x: image_x, y: image_y});
+
+            })
+        })
+        let groundTruthPoly;
+        if (hasGroundTruth && groundTruth) {
+          const gtNormalizePoly: {x: number, y: number}[][] = []
+          groundTruth.geoJSON.coordinates.forEach((ring) => {
+            gtNormalizePoly.push([]);
+            ring.forEach((coord) => {
+                const normalize_x = (coord[0] - image.bbox.xmin) / bboxWidth;
+              const normalize_y = (coord[1] - image.bbox.ymin) / bboxHeight;
+              const image_x = normalize_x * imageWidth;
+              const image_y = normalize_y * imageHeight;
+              gtNormalizePoly[imageNormalizePoly.length -1].push({x: image_x, y: image_y});
+              })
+              groundTruthPoly = { coords: gtNormalizePoly, label: groundTruth.label}
+          })
+
+        }
+        return { image: image, poly: {coords: imageNormalizePoly, label: closestPoly.label}, groundTruthPoly };
+}
+export {
+    drawData,
+    createCanvas,
+    getClosestPoly,
+    processImagePoly,
+}

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -118,7 +118,7 @@ const drawData = (
             context.canvas.style.width = `${width}px`
             context.canvas.style.height = `${height}px`;
           } else { // We draw a label for downloaded GIFs
-            const fontSize = canvas.height / 15;
+            const fontSize = canvas.height / 25;
             context.font = `${fontSize}px Arial`;
             // Source Satellite
             if (image.source) {

--- a/vue/src/components/siteObservations/EvaluationDisplay.vue
+++ b/vue/src/components/siteObservations/EvaluationDisplay.vue
@@ -267,8 +267,9 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
       </v-row>
       <v-row>
         <image-viewer-button
-          v-if="hasLoadedImages"
+          v-if="hasLoadedImages && siteObservation.scoringBase"
           :site-eval-id="siteObservation.id"
+          :site-evaluation-name="`${siteObservation.scoringBase.region}_${siteObservation.scoringBase.siteNumber.toString().padStart(4, '0')}`"
         />
       </v-row>
     </v-card-text>

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -113,7 +113,7 @@ const getAnnotationColor = (filters: MapFilters) => {
 const getText = (textType: string) => {
     const result = [];
     result.push('case');
-    Object.entries(styles).filter(([label, { type }]) => type === textType).forEach(([label, { type }]) => {
+    Object.entries(styles).filter(([, { type }]) => type === textType).forEach(([label,]) => {
         result.push(['==', ['get', 'label'], label]);
         result.push(label);
     })

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -146,6 +146,7 @@ export const state = reactive<{
   loopingId: string | null,
   modelRuns: KeyedModelRun[],
   openedModelRuns: Set<KeyedModelRun["key"]>
+  gifSettings: { fps: number, quality: number},
 }>({
   timestamp: Math.floor(Date.now() / 1000),
   timeMin: new Date(0).valueOf(),
@@ -191,6 +192,7 @@ export const state = reactive<{
   loopingId: null,
   modelRuns: [],
   openedModelRuns: new Set<KeyedModelRun["key"]>(),
+  gifSettings: { fps: 1, quality: 1}
 });
 
 export const filteredSatelliteTimeList = computed(() => {


### PR DESCRIPTION
- Adds a tool called 'canvas-capture' which is based on 'ccapture.js' for creating GIFs in the client and downloading them from a canvas.  That's why there are package.json and package-lock.json changes.
- On hitting the download button a secondary hidden canvas is created and draws the images uses requestAnimationFrame, the canvas-capture tool then records the information and generates a GIF once complete.
- The drawing tool for the images has been modified to accept an override Width/Height which can resize to a specific value.  This is used to find the max size of the images in the `filteredImages` list and then rescale everything to the same size.  If all images are below 500px in any dimension it will resize them so that the smallest dimension is 500px.
- Added a section to the draw images to create a legend that would include the Source, Date, Activity.
- For right now there is a default quality and default FPS of 1Hz.  We can update these in the future when needed.
- Progress indicator is used to indicate the drawing section of the process and then the GIF creation
- Settings option is used to set the FPS and quality levels (I don't think quality matters much with full screen changes but added it anyways.
- Refactored some bigger functions in the Vue component into an `imageUtils.ts` file.
- If you see a console error just turn of your vue development tools.  The Vue error doesn't seem to effect any rendering/functionality and is only there in the development tools.  This seems to be a known issue with a dependency that all tools (React/Vue) seem to be using a similar global name.
