### PR TITLE
pan sharpening fix

### DIFF
--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -69,6 +69,7 @@ def get_siteobservations_images(
     dayRange=14,
     no_data_limit=50,
     overrideDates: None | list[datetime, datetime] = None,
+    scale='default',
 ) -> None:
     constellationObj = Constellation.objects.filter(slug=baseConstellation).first()
     # Ensure we are using ints for the DayRange and no_data_limit
@@ -149,7 +150,7 @@ def get_siteobservations_images(
                 count += 1
                 continue
             results = fetch_boundbox_image(
-                bbox, timestamp, constellation, baseConstellation == 'WV'
+                bbox, timestamp, constellation, baseConstellation == 'WV', scale
             )
             if results is None:
                 logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -69,7 +69,7 @@ def get_siteobservations_images(
     dayRange=14,
     no_data_limit=50,
     overrideDates: None | list[datetime, datetime] = None,
-    scale='default',
+    scale: Literal['default', 'bits'] = 'default'
 ) -> None:
     constellationObj = Constellation.objects.filter(slug=baseConstellation).first()
     # Ensure we are using ints for the DayRange and no_data_limit

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -69,7 +69,7 @@ def get_siteobservations_images(
     dayRange=14,
     no_data_limit=50,
     overrideDates: None | list[datetime, datetime] = None,
-    scale: Literal['default', 'bits'] = 'default'
+    scale: Literal['default', 'bits'] = 'default',
 ) -> None:
     constellationObj = Constellation.objects.filter(slug=baseConstellation).first()
     # Ensure we are using ints for the DayRange and no_data_limit

--- a/django/src/rdwatch/utils/images.py
+++ b/django/src/rdwatch/utils/images.py
@@ -90,7 +90,7 @@ def fetch_boundbox_image(
     timestamp: datetime,
     constellation: str,
     worldView=False,
-    scale='default',
+    scale: Literal['default', 'bits'] = 'default'
 ):
     timebuffer = timedelta(days=1)
     try:

--- a/django/src/rdwatch/utils/images.py
+++ b/django/src/rdwatch/utils/images.py
@@ -1,6 +1,7 @@
 import io
 import logging
 from datetime import datetime, timedelta
+from typing import Literal
 from urllib.error import URLError
 
 from PIL import Image
@@ -90,7 +91,7 @@ def fetch_boundbox_image(
     timestamp: datetime,
     constellation: str,
     worldView=False,
-    scale: Literal['default', 'bits'] = 'default'
+    scale: Literal['default', 'bits'] = 'default',
 ):
     timebuffer = timedelta(days=1)
     try:

--- a/django/src/rdwatch/utils/images.py
+++ b/django/src/rdwatch/utils/images.py
@@ -90,6 +90,7 @@ def fetch_boundbox_image(
     timestamp: datetime,
     constellation: str,
     worldView=False,
+    scale='default',
 ):
     timebuffer = timedelta(days=1)
     try:
@@ -105,7 +106,7 @@ def fetch_boundbox_image(
         return None
     closest_capture = min(captures, key=lambda band: abs(band.timestamp - timestamp))
     if worldView:
-        bytes = get_worldview_processed_visual_bbox(closest_capture, bbox)
+        bytes = get_worldview_processed_visual_bbox(closest_capture, bbox, 'PNG', scale)
     else:
         bytes = get_raster_bbox(closest_capture.uri, bbox)
     return {

--- a/django/src/rdwatch/utils/worldview/raster_tile.py
+++ b/django/src/rdwatch/utils/worldview/raster_tile.py
@@ -19,7 +19,9 @@ def get_worldview_visual_tile(
         if capture.image_representation != 'RGB' and capture.panuri:
             with Reader(input=capture.panuri) as img:
                 pan = img.tile(x, y, z, tilesize=512)
-            rgb.from_array(pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16'))
+                rgb = rgb.from_array(
+                    pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16')
+                )
 
         if capture.bits_per_pixel != 8:
             max_bits = 2**capture.bits_per_pixel - 1

--- a/django/src/rdwatch/utils/worldview_processed/raster_tile.py
+++ b/django/src/rdwatch/utils/worldview_processed/raster_tile.py
@@ -40,7 +40,9 @@ def get_worldview_processed_visual_tile(
                 )
                 with Reader(input=capture.uri) as rgbimg:
                     rgb = rgbimg.tile(x, y, z, tilesize=512)
-                rgb.data = pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16')
+                    rgb = rgb.from_array(
+                        pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16')
+                    )
             rgb.rescale(in_range=((0, 10000),))
         return rgb.render(img_format='WEBP')
 
@@ -54,6 +56,7 @@ def get_worldview_processed_visual_bbox(
     capture: WorldViewProcessedCapture,
     bbox: tuple[float, float, float, float],
     format='PNG',
+    scale='default',
 ) -> bytes:
     with rasterio.Env(
         GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR',
@@ -82,9 +85,17 @@ def get_worldview_processed_visual_bbox(
                 with Reader(input=capture.uri) as rgbimg:
                     rgb = rgbimg.part(bbox, width=pan.width, height=pan.height)
                     logger.warning(f'RGB Download Time: {time.time() - startTime}')
-                logger.warning(f'PanSharpening: {capture.panuri}')
-                rgb.from_array(pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16'))
-                logger.warning(f'Pan Sharpening Time: {time.time() - startTime}')
+                    logger.warning(f'PanSharpening: {capture.panuri}')
+                    rgb = rgb.from_array(
+                        pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16')
+                    )
+                    logger.warning(f'Pan Sharpening Time: {time.time() - startTime}')
 
-        rgb.rescale(in_range=((0, 10000),))
+        if scale == 'default':
+            rgb.rescale(in_range=((0, 10000),))
+        elif scale == 'bits':
+            if capture.bits_per_pixel != 8:
+                max_bits = 2**capture.bits_per_pixel - 1
+                rgb.rescale(in_range=((0, max_bits),))
+
         return rgb.render(img_format=format)

--- a/django/src/rdwatch/utils/worldview_processed/raster_tile.py
+++ b/django/src/rdwatch/utils/worldview_processed/raster_tile.py
@@ -56,7 +56,7 @@ def get_worldview_processed_visual_bbox(
     capture: WorldViewProcessedCapture,
     bbox: tuple[float, float, float, float],
     format='PNG',
-    scale='default',
+    scale: Literal['default', 'bits'] = 'default',
 ) -> bytes:
     with rasterio.Env(
         GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR',

--- a/django/src/rdwatch/utils/worldview_processed/raster_tile.py
+++ b/django/src/rdwatch/utils/worldview_processed/raster_tile.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Literal
 
 import rasterio  # type: ignore
 from rio_tiler.io.rasterio import Reader

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -357,6 +357,7 @@ def generate_images(
     noData: int = 50,
     overrideDates: None | list[str] = None,
     force: bool = False,
+    scale: str = 'default',
 ):
     siteEvaluations = SiteEvaluation.objects.filter(configuration=model_run_id)
 
@@ -369,6 +370,7 @@ def generate_images(
             noData,
             overrideDates,
             force,
+            scale,
         )
 
     return 202, True

--- a/django/src/rdwatch/views/site_observation.py
+++ b/django/src/rdwatch/views/site_observation.py
@@ -176,6 +176,7 @@ def get_site_observation_images(
     noData: int = 50,
     overrideDates: None | list[str] = None,
     force: bool = False,
+    scale: str = 'default',
 ):
     # Make sure site evaluation actually exists
     siteeval = get_object_or_404(SiteEvaluation, pk=evaluation_id)
@@ -211,6 +212,7 @@ def get_site_observation_images(
             dayRange,
             noData,
             overrideDates,
+            scale,
         )
         fetching_task.celery_id = task_id.id
         fetching_task.save()

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -89,6 +89,7 @@ export interface DownloadSettings {
   noData?: number;
   customDateRange?: [string, string];
   force?: boolean;
+  scale?: 'default' | 'bits'
 }
 
 export type CeleryStates = 'FAILURE' | 'PENDING' | 'SUCCESS' | 'RETRY' | 'REVOKED' | 'STARTED';

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -17,6 +17,8 @@ const overrideDates: Ref<[string, string]> = ref(['2013-01-01', new Date().toISO
 const showAdvanced = ref(false);
 const force =ref(false);
 const customDateRange = ref(false);
+const scaleOptions = ref(['default', 'bits'])
+const scale: Ref<'default' | 'bits'> = ref('default')
 
 const download = () => {
     emit('download', {
@@ -25,6 +27,7 @@ const download = () => {
         noData: noData.value,
         customDateRange: customDateRange.value ? overrideDates.value : undefined,
         force: force.value,
+        scale: scale.value,
     })
 }
 
@@ -80,6 +83,21 @@ const display = ref(true);
               persistent-hint
             />
           </v-row>        
+          <v-row
+            v-if="selectedSource === 'WV'"
+            dense
+            align="center"
+            class="pb-5"
+          >
+            <v-select
+              v-model="scale"
+              :items="scaleOptions"
+              density="compact"
+              label="Bit Scaling"
+              persistent-hint
+            />
+          </v-row>        
+
           <v-row
             dense
             align="center"

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -219,7 +219,8 @@ const drawData = (canvas: HTMLCanvasElement, image: EvaluationImage, poly:PixelP
                   context.lineTo(x, image.image_dimensions[1] - y);
               }
             });
-            context.lineWidth = 4;
+            const lineDivisor = Math.max(image.image_dimensions[0], image.image_dimensions[1])
+            context.lineWidth = lineDivisor/ 50.0;
             context.strokeStyle = getColorFromLabel(groundTruthPoly.label);
             context.stroke();
           });
@@ -232,7 +233,8 @@ const drawData = (canvas: HTMLCanvasElement, image: EvaluationImage, poly:PixelP
                 context.lineTo(x, image.image_dimensions[1] - y);
             }
           });
-          context.lineWidth = 1;
+          const lineDivisor = Math.max(image.image_dimensions[0], image.image_dimensions[1])
+          context.lineWidth = lineDivisor/ 100.0;
           context.strokeStyle = getColorFromLabel(poly.label);
           currentLabel.value = siteEvaluationLabel.value == poly.label ? '' : poly.label;
           context.stroke();


### PR DESCRIPTION
- I had to previously change some `rgb.data =` to `rgb.from_array(` but I missed assignment before.  I updated that so the pan-sharpening images should now download properly.
- While I was in here I added a download option to use the bits per pixel to scale the image instead of the default value of 10,000.  This will brighten up a lot of the dark images.
- I then added the corresponding UI to the front-end when selecting WV images to show that option for changing the scaling method from 'default' to 'bits'.