### PR TITLE
Update model run upload script for new endpoint response format

### DIFF
--- a/scripts/loadModelRun.py
+++ b/scripts/loadModelRun.py
@@ -91,8 +91,7 @@ def upload_to_rgd(
             model_run['title'] == title
             and model_run['performer']['short_code'] == performer_shortcode
             and 'region' in model_run
-            and model_run['region'] is not None
-            and model_run['region'].get('name') == region_id
+            and model_run['region'] == region_id
         ):  # noqa
             existing_model_run = model_run
             break


### PR DESCRIPTION
Regions are now returned from the API as simple strings, not objects. I missed this in #268, and noticed this when uploading proposals to test #278.