### PR TITLE
Add pansharpening to non-observations

### DIFF
--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -264,7 +264,9 @@ def get_siteobservations_images(
             # we need to add a new image into the structure
             bytes = None
             if worldView:
-                bytes = get_worldview_processed_visual_bbox(capture, max_bbox)
+                bytes = get_worldview_processed_visual_bbox(
+                    capture, max_bbox, 'PNG', scale
+                )
             else:
                 bytes = get_raster_bbox(capture.uri, max_bbox)
             if bytes is None:


### PR DESCRIPTION
Happened to miss the option to add the pansharpening to non-observation images.  This adds it back in.