### PR TITLE
Fix ninja swagger page not working

### DIFF
--- a/django/src/rdwatch/api.py
+++ b/django/src/rdwatch/api.py
@@ -9,7 +9,7 @@ from .views.site_evaluation import router as site_evaluation_router
 from .views.site_image import router as images_router
 from .views.site_observation import router as site_observation_router
 
-api = NinjaAPI()
+api = NinjaAPI(title='RD-WATCH', version='0.0.0')
 
 api.add_router('/evaluations/', site_evaluation_router)
 api.add_router('/observations/', site_observation_router)

--- a/django/src/rdwatch/models/site_evaluation.py
+++ b/django/src/rdwatch/models/site_evaluation.py
@@ -142,7 +142,7 @@ class SiteEvaluation(models.Model):
                 start_date=site_feature.properties.start_date,
                 end_date=site_feature.properties.end_date,
                 timestamp=datetime.now(),
-                geom=site_feature.geometry,
+                geom=site_feature.parsed_geometry,
                 label=label,
                 score=site_feature.properties.score,
                 status=status,
@@ -175,13 +175,13 @@ class SiteEvaluation(models.Model):
         site_evals: list[SiteEvaluation] = []
         with transaction.atomic():
             region = get_or_create_region(
-                region_feature.properties.region_id, region_feature.geometry
+                region_feature.properties.region_id, region_feature.parsed_geometry
             )[0]
 
             for feature in region_model.site_summary_features:
                 assert isinstance(feature.properties, SiteSummaryFeature)
 
-                geometry = feature.geometry
+                geometry = feature.parsed_geometry
                 if isinstance(geometry, MultiPolygon):
                     geometry = geometry.convex_hull
 

--- a/django/src/rdwatch/models/site_observation.py
+++ b/django/src/rdwatch/models/site_observation.py
@@ -96,12 +96,12 @@ class SiteObservation(models.Model):
 
             constellation = constellation_map.get(feature.properties.sensor_name, None)
 
-            assert isinstance(feature.geometry, Polygon | MultiPolygon)
+            assert isinstance(feature.parsed_geometry, Polygon | MultiPolygon)
 
             geometry = (
-                feature.geometry
-                if isinstance(feature.geometry, MultiPolygon)
-                else MultiPolygon([feature.geometry])
+                feature.parsed_geometry
+                if isinstance(feature.parsed_geometry, MultiPolygon)
+                else MultiPolygon([feature.parsed_geometry])
             )
             for i, polygon in enumerate(geometry):
                 if feature.properties.current_phase:

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -166,22 +166,24 @@ class ObservationFeature(Schema):
 
 
 class Feature(Schema):
-    class Config:
-        arbitrary_types_allowed = True
-
     type: Literal['Feature']
     properties: Annotated[
         SiteFeature | ObservationFeature,
         Field(discriminator='type'),
     ]
-    geometry: GEOSGeometry
+    geometry: dict[str, Any]
+
+    @property
+    def parsed_geometry(self) -> GEOSGeometry:
+        return GEOSGeometry(json.dumps(self.geometry))
 
     @validator('geometry', pre=True)
     def parse_geometry(cls, v: dict[str, Any]):
         try:
-            return GEOSGeometry(json.dumps(v))
+            GEOSGeometry(json.dumps(v))
         except GDALException:
             raise ValueError('Failed to parse geometry.')
+        return v
 
     @root_validator
     def ensure_correct_geometry_type(cls, values: dict[str, Any]):
@@ -189,7 +191,7 @@ class Feature(Schema):
             return values
         if (
             isinstance(values['properties'], SiteFeature)
-            and values['geometry'].geom_type != 'Polygon'
+            and values['geometry'].get('type') != 'Polygon'
         ):
             raise ValueError('Site geometry must be of type "Polygon"')
         return values


### PR DESCRIPTION
The autogenerated swagger page provided by ninja wasn't working due to the use of complex types like `GEOSGeometry` and `Polygon` directly in our pydantic request models. I moved those to dynamic properties and updated the ingest code to use those, and it works now. See `/api/docs/`.