### PR TITLE
Switch to ninja's built-in pagination for model runs endpoint/eliminate JSONB subquery

### DIFF
--- a/django/src/rdwatch/tests/test_model_runs.py
+++ b/django/src/rdwatch/tests/test_model_runs.py
@@ -79,14 +79,14 @@ def test_model_run_rest_list(test_client: TestClient) -> None:
     assert res.status_code == 200
     assert res.json()['count'] == len(model_runs)
     assert {
-        (mr['title'], mr['performer']['short_code']) for mr in res.json()['results']
+        (mr['title'], mr['performer']['short_code']) for mr in res.json()['items']
     } == {(mr.title, mr.performer.slug) for mr in model_runs}
 
     # Test performer filter
     for performer in performers:
         res = test_client.get(f'/model-runs/?performer={performer.slug}')
         assert res.status_code == 200
-        assert [mr['title'] for mr in res.json()['results']] == [
+        assert [mr['title'] for mr in res.json()['items']] == [
             mr.title for mr in model_runs if mr.performer == performer
         ]
 

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import Any, Literal
 
 from celery.result import AsyncResult
 from ninja import Field, FilterSchema, Query, Schema
-from ninja.errors import ValidationError
-from ninja.pagination import RouterPaginated
+from ninja.pagination import PageNumberPagination, RouterPaginated, paginate
 from ninja.schema import validator
 from pydantic import UUID4, constr  # type: ignore
 
@@ -21,6 +20,7 @@ from django.db.models import (
     Min,
     OuterRef,
     Q,
+    QuerySet,
     Subquery,
     When,
 )
@@ -28,12 +28,7 @@ from django.db.models.functions import Coalesce, JSONObject
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 
-from rdwatch.db.functions import (
-    AggregateArraySubquery,
-    BoundingBox,
-    BoundingBoxGeoJSON,
-    ExtractEpoch,
-)
+from rdwatch.db.functions import BoundingBox, BoundingBoxGeoJSON, ExtractEpoch
 from rdwatch.models import (
     AnnotationExport,
     ModelRun,
@@ -114,40 +109,33 @@ class ModelRunDetailSchema(Schema):
 
 
 class ModelRunListSchema(Schema):
-    count: int
+    id: UUID4
+    title: str
+    region: str | None = None
+    performer: PerformerSchema
+    parameters: dict
+    numsites: int
+    downloading: int | None = None
+    score: float | None = None
+    timestamp: int | None = None
     timerange: TimeRangeSchema | None = None
-    bbox: dict | None = None
-    results: list[ModelRunDetailSchema]
+    bbox: dict | None
+    created: datetime
+    expiration_time: str | None = None
+    evaluation: int | None = None
+    evaluation_run: int | None = None
+    proposal: str = None
+    adjudicated: ModelRunAdjudicated | None = None
 
 
 def get_queryset():
-    # Subquery to count unique SiteEvaluations
-    # with proposal='PROPOSAL' for each ModelRun
-    proposed_count_subquery = (
-        SiteEvaluation.objects.filter(
-            configuration=OuterRef('pk'),
-            status='PROPOSAL',
-        )
-        .values('configuration')
-        .annotate(count=Count('pk'))
-        .values('count')
-    )
-
-    # Subquery to count unique SiteEvaluations with proposal
-    # not equal to 'PROPOSAL' for each ModelRun
-    other_count_subquery = (
-        SiteEvaluation.objects.filter(configuration=OuterRef('pk'))
-        .exclude(status='PROPOSAL')
-        .values('configuration')
-        .annotate(count=Count('pk'))
-        .values('count')
-    )
-
     return (
-        ModelRun.objects.select_related('evaluations', 'performer', 'satellitefetching')
+        ModelRun.objects
         # Get minimum score and performer so that we can tell which runs
         # are ground truth
-        .alias(min_score=Min('evaluations__score'), performer_slug=F('performer__slug'))
+        .annotate(
+            min_score=Min('evaluations__score'), performer_slug=F('performer__slug')
+        )
         # Label ground truths as such. A ground truth is defined as a model run
         # with a min_score of 1 and a performer of "TE"
         .alias(
@@ -163,65 +151,73 @@ def get_queryset():
             evaluation_configuration=F('evaluations__configuration'),
             proposal_val=F('proposal'),
         )
+        .values()
         .annotate(
-            json=JSONObject(
-                id='pk',
-                title='title',
-                created='created',
-                expiration_time='expiration_time',
-                performer=Subquery(  # prevents including "performer" in slow GROUP BY
-                    lookups.Performer.objects.filter(
-                        pk=OuterRef('performer_id')
-                    ).values(
-                        json=JSONObject(
-                            id='id',
-                            team_name='description',
-                            short_code='slug',
-                        )
-                    ),
-                    output_field=JSONField(),
+            performer=Subquery(  # prevents including "performer" in slow GROUP BY
+                lookups.Performer.objects.filter(pk=OuterRef('performer_id')).values(
+                    json=JSONObject(
+                        id='id',
+                        team_name='description',
+                        short_code='slug',
+                    )
                 ),
-                region=Subquery(  # prevents including "region" in slow GROUP BY
-                    Region.objects.filter(pk=OuterRef('region_id')).values('name')[:1],
+                output_field=JSONField(),
+            ),
+            region=Subquery(  # prevents including "region" in slow GROUP BY
+                Region.objects.filter(pk=OuterRef('region_id')).values('name')[:1],
+            ),
+            downloading=Coalesce(
+                Subquery(
+                    SatelliteFetching.objects.filter(
+                        siteeval__configuration_id=OuterRef('evaluation_configuration'),
+                        status=SatelliteFetching.Status.RUNNING,
+                    )
+                    .annotate(count=Func(F('id'), function='Count'))
+                    .values('count')
                 ),
-                downloading=Coalesce(
-                    Subquery(
-                        SatelliteFetching.objects.filter(
-                            siteeval__configuration_id=OuterRef(
-                                'evaluation_configuration'
-                            ),
-                            status=SatelliteFetching.Status.RUNNING,
-                        )
-                        .annotate(count=Func(F('id'), function='Count'))
-                        .values('count')
-                    ),
-                    0,  # Default value when evaluations are None
-                ),
-                parameters='parameters',
-                numsites=Count('evaluations__pk', distinct=True),
-                score=Avg('evaluations__score'),
-                evaluation='evaluation',
-                evaluation_run='evaluation_run',
-                timestamp=ExtractEpoch(Max('evaluations__timestamp')),
-                timerange=JSONObject(
-                    min=ExtractEpoch(Min('evaluations__start_date')),
-                    max=ExtractEpoch(Max('evaluations__end_date')),
-                ),
-                bbox=BoundingBoxGeoJSON('evaluations__geom'),
-                proposal='proposal_val',
-                adjudicated=Case(
-                    When(
-                        ~Q(proposal_val=None),  # When proposal has a value
-                        then=JSONObject(
-                            proposed=Coalesce(Subquery(proposed_count_subquery), 0),
-                            other=Coalesce(Subquery(other_count_subquery), 0),
-                        ),
-                    ),
-                    default=None,
-                ),
-            )
+                0,  # Default value when evaluations are None
+            ),
+            numsites=Count('evaluations__pk', distinct=True),
+            score=Avg('evaluations__score'),
+            timestamp=ExtractEpoch(Max('evaluations__timestamp')),
+            timerange=JSONObject(
+                min=ExtractEpoch(Min('evaluations__start_date')),
+                max=ExtractEpoch(Max('evaluations__end_date')),
+            ),
+            bbox=BoundingBoxGeoJSON('evaluations__geom'),
         )
     )
+
+
+class ModelRunPagination(PageNumberPagination):
+    class Output(Schema):
+        count: int
+        timerange: TimeRangeSchema | None = None
+        bbox: dict | None = None
+        items: list[ModelRunListSchema]
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        filters: ModelRunFilterSchema,
+        **params,
+    ) -> dict[str, Any]:
+        qs = super().paginate_queryset(queryset, pagination, **params)
+
+        aggregate_kwargs = {
+            'timerange': JSONObject(
+                min=ExtractEpoch(Min('evaluations__start_date')),
+                max=ExtractEpoch(Max('evaluations__end_date')),
+            ),
+        }
+        if filters.region:
+            aggregate_kwargs['bbox'] = Coalesce(
+                BoundingBoxGeoJSON('evaluations__region__geom'),
+                BoundingBoxGeoJSON('evaluations__geom'),
+            )
+
+        return qs | queryset.aggregate(**aggregate_kwargs)
 
 
 @router.post('/', response={200: ModelRunDetailSchema}, exclude_none=True)
@@ -253,69 +249,19 @@ def create_model_run(
     }
 
 
-@router.get('/', response={200: ModelRunListSchema})
+@router.get('/', response={200: list[ModelRunListSchema]})
+@paginate(ModelRunPagination)
 def list_model_runs(
     request: HttpRequest,
     filters: ModelRunFilterSchema = Query(...),  # noqa: B008
-    limit: int = 25,
-    page: int = 1,
 ):
     queryset = get_queryset()
-    queryset = filters.filter(
-        queryset.alias(
-            min_score=Min('evaluations__score'),
-            performer_slug=F('performer__slug'),
-            region=F('evaluations__region__name'),
-        )
-    )
-
-    if page < 1 or (not limit and page != 1):
-        raise ValidationError(f"Invalid page '{page}'")
-
-    # Calculate total number of model runs prior to paginating queryset
-    total_model_run_count = queryset.count()
-
-    subquery = queryset[(page - 1) * limit : page * limit] if limit else queryset
-    aggregate = queryset.defer('json').aggregate(
-        timerange=JSONObject(
-            min=ExtractEpoch(Min('evaluations__start_date')),
-            max=ExtractEpoch(Max('evaluations__end_date')),
-        ),
-        results=AggregateArraySubquery(subquery.values('json')),
-    )
-
-    aggregate['count'] = total_model_run_count
-
-    # Only bother calculating the entire bounding box of this model run
-    # list if the user has specified a region. We don't want to overload
-    # PostGIS by making it calculate a bounding box for every polygon in
-    # the database.
-    if filters.region is not None:
-        aggregate |= queryset.defer('json').aggregate(
-            # Use the region polygon for the bbox if it exists.
-            # Otherwise, fall back on the site polygon.
-            bbox=Coalesce(
-                BoundingBoxGeoJSON('evaluations__region__geom'),
-                BoundingBoxGeoJSON('evaluations__geom'),
-            )
-        )
-
-    if aggregate['count'] > 0 and not aggregate['results']:
-        raise ValidationError({'page': f"Invalid page '{page}'"})
-
-    return 200, aggregate
+    return filters.filter(queryset)
 
 
 @router.get('/{id}/', response={200: ModelRunDetailSchema})
 def get_model_run(request: HttpRequest, id: UUID4):
-    values = get_queryset().filter(id=id).values_list('json', flat=True)
-
-    if not values.exists():
-        raise Http404()
-
-    model_run = values[0]
-
-    return 200, model_run
+    return get_object_or_404(get_queryset(), id=id)
 
 
 @router.post(

--- a/scripts/loadModelRun.py
+++ b/scripts/loadModelRun.py
@@ -86,7 +86,7 @@ def upload_to_rgd(
     )
 
     existing_model_run = None
-    for model_run in model_runs_result.json().get('results', ()):
+    for model_run in model_runs_result.json().get('items', ()):
         if (
             model_run['title'] == title
             and model_run['performer']['short_code'] == performer_shortcode

--- a/vue/src/client/models/ModelRunList.ts
+++ b/vue/src/client/models/ModelRunList.ts
@@ -9,5 +9,5 @@ export type ModelRunList = {
     max: number;
   } | null;
   bbox: GeoJSON.Polygon | null;
-  results: ModelRun[];
+  items: ModelRun[];
 };

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -59,7 +59,7 @@ async function loadMore() {
     totalModelRuns.value = modelRunList.count;
 
     // sort list to show ground truth near the top
-    const modelRunResults = modelRunList.results.sort((a, b) =>
+    const modelRunResults = modelRunList.items.sort((a, b) =>
       b.parameters["ground_truth"] === true ? 1 : -1
     );
     const keyedModelRunResults = modelRunResults.map((val, i) => {


### PR DESCRIPTION
This PR switches the model run endpoint to use ninja's built-in pagination instead of a manual approach; this involved refactoring the query to remove the JSONB aggregation, which improves readability regardless. Note I haven't removed any fields yet, and the structure of the response returned by the model run LIST and GET endpoints remains mostly unchanged. The exception to this is that `results` becomes `items` in the list endpoint response; this was done to bring the endpoint in line with ninja's default pagination behavior. But in general, this PR is just a refactor that will make it easier to do more extensive changes to the endpoint in a followup PR. 

However, removing the large JSONB aggregation does seems to improve performance on its own, bringing the response time down from about 5 seconds to about 3.5 seconds for me locally with 361 model runs. 