### PR TITLE
Allow `cache` values to be null in site model schema

### DIFF
--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -11,9 +11,9 @@ from django.contrib.gis.geos import GEOSGeometry
 
 
 class SiteFeatureCache(Schema):
-    originator_file: str
+    originator_file: str | None
     timestamp: datetime | None
-    commit_hash: str
+    commit_hash: str | None
 
 
 class SiteFeature(Schema):


### PR DESCRIPTION
The site model schema only specifies `cache` as a generic object, so we can't assume that these fields exist just because `cache` exists.

I don't think this will impact the fields on the `SiteEvaluation` model, since they are already nullable in the case that there is no `cache` at all.