### PR TITLE
Fix Proposal Patch

### DIFF
--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -178,19 +178,14 @@ def patch_site_evaluation(request: HttpRequest, id: UUID4, data: SiteEvaluationR
             site_evaluation.label = lookups.ObservationLabel.objects.get(
                 slug=data.label
             )
-        print(data.dict())
-        if data.start_date == 'null':
-            site_evaluation.start_date = None
-        elif data.start_date:
-            site_evaluation.start_date = data.start_date
-        if data.end_date == 'null':
-            site_evaluation.end_date = None
-        elif data.end_date:
-            site_evaluation.end_date = data.end_date
-        if data.notes:
-            site_evaluation.notes = data.notes
-        if data.status:
-            site_evaluation.status = data.status
+
+        # Use `exclude_unset` here because an explicitly `null` start/end date
+        # means something different than a missing start/end date.
+        data_dict = data.dict(exclude_unset=True)
+
+        FIELDS = ('start_date', 'end_date', 'notes', 'status')
+        for field in filter(lambda f: f in data_dict, FIELDS):
+            setattr(site_evaluation, field, data_dict[field])
 
         site_evaluation.save()
 

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -178,8 +178,15 @@ def patch_site_evaluation(request: HttpRequest, id: UUID4, data: SiteEvaluationR
             site_evaluation.label = lookups.ObservationLabel.objects.get(
                 slug=data.label
             )
-        site_evaluation.start_date = data.start_date
-        site_evaluation.end_date = data.end_date
+        print(data.dict())
+        if data.start_date == 'null':
+            site_evaluation.start_date = None
+        elif data.start_date:
+            site_evaluation.start_date = data.start_date
+        if data.end_date == 'null':
+            site_evaluation.end_date = None
+        elif data.end_date:
+            site_evaluation.end_date = data.end_date
         if data.notes:
             site_evaluation.notes = data.notes
         if data.status:

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -440,14 +440,6 @@ export class ApiService {
   }
 
   public static patchSiteEvaluation(id: string, data: SiteEvaluationUpdateQuery): CancelablePromise<boolean> {
-    const dataCopy = { ...data};
-    // Django-Ninja can't differentiate betwen null and missing parameters
-    if (data.start_date === null) {
-      dataCopy.start_date = 'null';
-    }
-    if (data.end_date === null) {
-      dataCopy.end_date = 'null';
-    }
     return __request(OpenAPI, {
       method: 'PATCH',
       url: "/api/evaluations/{id}/",

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -440,6 +440,14 @@ export class ApiService {
   }
 
   public static patchSiteEvaluation(id: string, data: SiteEvaluationUpdateQuery): CancelablePromise<boolean> {
+    const dataCopy = { ...data};
+    // Django-Ninja can't differentiate betwen null and missing parameters
+    if (data.start_date === null) {
+      dataCopy.start_date = 'null';
+    }
+    if (data.end_date === null) {
+      dataCopy.end_date = 'null';
+    }
     return __request(OpenAPI, {
       method: 'PATCH',
       url: "/api/evaluations/{id}/",

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -98,8 +98,8 @@ const filteredImages = computed(() => {
 
 
 const currentTimestamp = computed(() => {
-    if (combinedImages.value[currentImage.value]) {
-    const time = combinedImages.value[currentImage.value].image.timestamp;
+    if (filteredImages.value[currentImage.value]) {
+    const time = filteredImages.value[currentImage.value].image.timestamp;
     return new Date(time * 1000).toISOString().split('T')[0]
     }
     return new Date().toISOString().split('T')[0]


### PR DESCRIPTION
`null` and the date have specific meanings in RGD.

When we do an approve/reject or the reverse we make a call to the patch endpoint with the other fields empty.
Python/django-ninja don't make a distinction between and empty parameter in the body or a null one.  So a call to the approve/unapprove/rejected endpoint would set the start/end dates to null/None.

I tried seeing if I could interpret and see if the keys are available in the dictionary of the request but by default it sets them to None.

I tried looking up some stuff to see if Ninja had a good way to differentiate between Null/None and an empty parameter but I couldn't find anything.

So in the client side I injected a string 'null' for the value if the request if it is explicitly set and the back-end will read this and set the date to None if that happens.