### PR TITLE
Ignore unset values in PATCH request body

### DIFF
--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -178,19 +178,14 @@ def patch_site_evaluation(request: HttpRequest, id: UUID4, data: SiteEvaluationR
             site_evaluation.label = lookups.ObservationLabel.objects.get(
                 slug=data.label
             )
-        print(data.dict())
-        if data.start_date == 'null':
-            site_evaluation.start_date = None
-        elif data.start_date:
-            site_evaluation.start_date = data.start_date
-        if data.end_date == 'null':
-            site_evaluation.end_date = None
-        elif data.end_date:
-            site_evaluation.end_date = data.end_date
-        if data.notes:
-            site_evaluation.notes = data.notes
-        if data.status:
-            site_evaluation.status = data.status
+
+        # Use `exclude_unset` here because an explicitly `null` start/end date
+        # means something different than a missing start/end date.
+        data_dict = data.dict(exclude_unset=True)
+
+        FIELDS = ('start_date', 'end_date', 'notes', 'status')
+        for field in filter(lambda f: f in data_dict, FIELDS):
+            setattr(site_evaluation, field, data_dict[field])
 
         site_evaluation.save()
 

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -440,14 +440,6 @@ export class ApiService {
   }
 
   public static patchSiteEvaluation(id: string, data: SiteEvaluationUpdateQuery): CancelablePromise<boolean> {
-    const dataCopy = { ...data};
-    // Django-Ninja can't differentiate betwen null and missing parameters
-    if (data.start_date === null) {
-      dataCopy.start_date = 'null';
-    }
-    if (data.end_date === null) {
-      dataCopy.end_date = 'null';
-    }
     return __request(OpenAPI, {
       method: 'PATCH',
       url: "/api/evaluations/{id}/",


### PR DESCRIPTION
Calling `.dict()` on a pydantic model instance with `exclude_unset` set will cause values that are not present/undefined to simply be excluded from the resulting dict instead of casting them to `None`, while values that are explicitly set to `null` in the request body will be cast to `None` as expected. 

[Docs for `exclude_unset`](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict)