### PR TITLE
Fix type error in model run response schema

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -101,7 +101,7 @@ class ModelRunDetailSchema(Schema):
     timerange: TimeRangeSchema | None = None
     bbox: dict | None
     created: datetime
-    expiration_time: str | None = None
+    expiration_time: timedelta | None = None
     evaluation: int | None = None
     evaluation_run: int | None = None
     proposal: str = None
@@ -121,7 +121,7 @@ class ModelRunListSchema(Schema):
     timerange: TimeRangeSchema | None = None
     bbox: dict | None
     created: datetime
-    expiration_time: str | None = None
+    expiration_time: timedelta | None = None
     evaluation: int | None = None
     evaluation_run: int | None = None
     proposal: str = None
@@ -277,7 +277,7 @@ def create_model_run(
         'parameters': model_run.parameters,
         'numsites': 0,
         'created': model_run.created,
-        'expiration_time': str(model_run.expiration_time),
+        'expiration_time': model_run.expiration_time,
     }
 
 


### PR DESCRIPTION
The type annotation for `expiration_time` is incorrect. Note that if no model runs in the DB have an `expiration_time` set, this bug will not occur. However, if there is at least one model run with a non-null `expiration_time` in the database, all calls to the `/api/model-runs/` endpoint will fail. I assume this went unnoticed because it's not common to set an `expiration_time` for model runs in local development, so we didn't notice until today when I deployed it and saw API calls start failing.