### PR TITLE
fixing annotation group export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ __pycache__
 .venv
 *.pyc
 dmypy.json
+
+# Django Files
+django/celerybeat-schedule.db
+django/nohup.out
+

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -495,7 +495,7 @@ def check_download(request: HttpRequest, task_id: str):
 
 
 @router.get('/{id}/download')
-def get_downloaded_annotations(request: HttpRequest, id: int, task_id: str):
+def get_downloaded_annotations(request: HttpRequest, id: str, task_id: str):
     annotation_export = AnnotationExport.objects.filter(celery_id=task_id)
     if annotation_export.exists():
         annotation_export = annotation_export.first()

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -495,8 +495,10 @@ def check_download(request: HttpRequest, task_id: str):
 
 
 @router.get('/{id}/download')
-def get_downloaded_annotations(request: HttpRequest, id: str, task_id: str):
-    annotation_export = AnnotationExport.objects.filter(celery_id=task_id)
+def get_downloaded_annotations(request: HttpRequest, id: UUID4, task_id: str):
+    annotation_export = AnnotationExport.objects.filter(
+        configuration=id, celery_id=task_id
+    )
     if annotation_export.exists():
         annotation_export = annotation_export.first()
         response = HttpResponse(

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -192,7 +192,7 @@ def patch_site_evaluation(request: HttpRequest, id: UUID4, data: SiteEvaluationR
     return 200
 
 
-def get_site_model_feature_JSON(id: int, obsevations=False):
+def get_site_model_feature_JSON(id: UUID4, obsevations=False):
     query = (
         SiteEvaluation.objects.filter(pk=id)
         .values()


### PR DESCRIPTION
I forgot to check the downloading of group annotations in our conversion to the UUID format.
This resulted in not being able to download groups of proposals.  I'd have to look more into why the type system didn't yell about this before and started yelling recently.

- Updated the relevant model-run endpoint to use str.  I don't know why I had it using int before, the task-id is stored as a charfield.
- Update the function for exporting annotations to use UUID4
- I added the celerybeat and noup.out to the .gitignore.  Was sick of having to skip those files when adding all my commit files.