### PR TITLE
fix override date error, ordering, padding for regions

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -168,7 +168,7 @@ def get_queryset():
             )
         )
         # Order queryset so that ground truths are first
-        .order_by('-groundtruth', '-id')
+        .order_by('groundtruth', '-created')
         .alias(
             region_id=F('evaluations__region_id'),
             evaluation_configuration=F('evaluations__configuration'),

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -225,7 +225,7 @@ def get_site_model_feature_JSON(id: UUID4, obsevations=False):
         data = query[0]['json']
 
         region_name = data['site']['region']
-        site_id = f'{region_name}_{str(data["site"]["number"]).zfill(3)}'
+        site_id = f'{region_name}_{str(data["site"]["number"]).zfill(4)}'
         version = data['version']
         output = {
             'type': 'FeatureCollection',

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -87,7 +87,7 @@ export interface DownloadSettings {
   constellation: 'S2' | 'WV' | 'L8';
   dayRange?: number;
   noData?: number;
-  customDateRange?: [string, string];
+  overrideDates?: [string, string];
   force?: boolean;
   scale?: 'default' | 'bits'
 }

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -25,7 +25,7 @@ const download = () => {
         constellation: selectedSource.value,
         dayRange: dayRange.value,
         noData: noData.value,
-        customDateRange: customDateRange.value ? overrideDates.value : undefined,
+        overrideDates: customDateRange.value ? overrideDates.value : undefined,
         force: force.value,
         scale: scale.value,
     })

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -59,9 +59,7 @@ async function loadMore() {
     totalModelRuns.value = modelRunList.count;
 
     // sort list to show ground truth near the top
-    const modelRunResults = modelRunList.items.sort((a, b) =>
-      b.parameters["ground_truth"] === true ? 1 : -1
-    );
+    const modelRunResults = modelRunList.items;
     const keyedModelRunResults = modelRunResults.map((val, i) => {
       return {
         ...val,


### PR DESCRIPTION
- Fixes the customDate override downloading.  I was using a different parameter name for some reason on the client side.  I must have changed it at sometime because it was working before.
- Fixes ordering by removing the client side ordering and ordering in Django, by making newer non-GT model runs first followed by the GT model runs.
- Modified the export to zfill 4 places instead of 3.  I kept getting 003 and 002 when exporting.  I wanted to fix this issue.