### PR TITLE
fixing date/time picker and updating vuetify

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -13,7 +13,7 @@
         "maplibre-gl": "^2.1.9",
         "vue": "^3.2.37",
         "vue-router": "^4.2.4",
-        "vuetify": "^3.3.1"
+        "vuetify": "^3.3.4"
       },
       "devDependencies": {
         "@mdi/font": "^7.2.96",

--- a/vue/package.json
+++ b/vue/package.json
@@ -24,7 +24,7 @@
     "maplibre-gl": "^2.1.9",
     "vue": "^3.2.37",
     "vue-router": "^4.2.4",
-    "vuetify": "^3.3.1"
+    "vuetify": "^3.3.4"
   },
   "devDependencies": {
     "@mdi/font": "^7.2.96",

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -329,9 +329,13 @@ const setEditingMode = (mode: EditModes) => {
   if (['StartDate', 'EndDate'].includes(mode)){
     if (startDate.value === null) {
       startDateTemp.value = currentDate.value;
+    } else {
+      startDateTemp.value = startDate.value;
     }
     if (endDate.value === null) {
       endDateTemp.value = currentDate.value;
+    } else {
+      endDateTemp.value = endDate.value;
     }
   }
   editDialog.value = true;
@@ -876,9 +880,9 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
             <v-date-picker
               v-if="startDateTemp !== null"
               :model-value="[startDateTemp ? startDateTemp : currentTimestamp]"
-              @update:model-value="updateTime($event, 'StartDateTemp')"
+              @update:model-value="updateTime($event, 'StartDate')"
               @click:cancel="editDialog = false"
-              @click:save="updateTime(startDateTemp, 'StartDate'); editDialog = false"
+              @click:save="editDialog = false"
             />
           </v-card-text>
         </v-card>
@@ -911,9 +915,9 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
             <v-date-picker
               v-if="endDateTemp !== null"
               :model-value="[endDateTemp ? endDateTemp : currentTimestamp]"
-              @update:model-value="updateTime($event, 'EndDateTemp')"
+              @update:model-value="updateTime($event, 'EndDate')"
               @click:cancel="editDialog = false"
-              @click:save="updateTime(endDateTemp, 'EndDate');editDialog = false"
+              @click:save="editDialog = false"
             />
           </v-card-text>
         </v-card>


### PR DESCRIPTION
Vuetify released an updated version with some changes to the Vue-Date-Picker: [v3.3.4](https://vuetifyjs.com/en/getting-started/release-notes/?version=v3.3.4
)
Some of the usage before has changed.

- I believe that before the model-value/v-model updated when the date was changed.  This one the value only updates when the user clicks 'OK'.
- I don't know if I really like this behavior but I needed to adjust the current component to fix it.
- I also added the ability for it to load the proper current date when initially clicking the edit button.