### PR TITLE
V1.1 UI-Updates

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -54,6 +54,7 @@ class ModelRunFilterSchema(FilterSchema):
     performer: list[str] | None = Field(q='performer_slug')
     region: str | None
     proposal: str | None = Field(q='proposal', ignore_none=False)
+    groundtruth: bool | None
 
     def filter_performer(self, value: list[str] | None) -> Q:
         if value is None or not value:
@@ -62,6 +63,14 @@ class ModelRunFilterSchema(FilterSchema):
         for performer_slug in value:
             performer_q |= Q(performer_slug=performer_slug)
         return performer_q
+
+    def filter_groundtruth(self, value: bool | None) -> Q:
+        if not value:
+            return Q()
+        # Filter for ground_truth performer
+        gt_q = Q(performer_slug='TE')
+        gt_q &= Q(ground_truth=True)
+        return gt_q
 
 
 class ModelRunWriteSchema(Schema):

--- a/django/src/rdwatch/views/vector_tile.py
+++ b/django/src/rdwatch/views/vector_tile.py
@@ -141,6 +141,8 @@ def vector_tile(request: HttpRequest, model_run_id: UUID4, z: int, x: int, y: in
                 id=F('pk'),
                 mvtgeom=mvtgeom,
                 configuration_id=F('siteeval__configuration_id'),
+                configuration_name=F('siteeval__configuration__title'),
+                site_label=F('siteeval__label__slug'),
                 site_number=F('siteeval__number'),
                 label=F('label__slug'),
                 area=Area(Transform('geom', srid=6933)),
@@ -154,6 +156,7 @@ def vector_tile(request: HttpRequest, model_run_id: UUID4, z: int, x: int, y: in
                     ),
                 ),
                 performer_id=F('siteeval__configuration__performer_id'),
+                performer_name=F('siteeval__configuration__performer__slug'),
                 region=F('siteeval__region__name'),
                 version=F('siteeval__version'),
                 groundtruth=Case(

--- a/django/src/rdwatch_scoring/views/vector_tile.py
+++ b/django/src/rdwatch_scoring/views/vector_tile.py
@@ -114,7 +114,7 @@ def vector_tile(
                 region=F('region_id'),
                 groundtruth=Case(
                     When(
-                        Q(originator='te'),
+                        Q(originator='te') | Q(originator='iMERIT'),
                         True,
                     ),
                     default=False,
@@ -178,7 +178,8 @@ def vector_tile(
                 score=F('confidence_score'),
                 groundtruth=Case(
                     When(
-                        Q(site_uuid__originator='te'),
+                        Q(site_uuid__originator='te')
+                        | Q(site_uuid__originator='iMERIT'),
                         True,
                     ),
                     default=False,

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -23,6 +23,7 @@ export interface QueryArguments {
   page?: number;
   limit?: number;
   proposal?: 'PROPOSAL' | 'APPROVED';
+  groundtruth?: boolean;
 }
 
 export interface ScoringResults {

--- a/vue/src/components/MapLegend.vue
+++ b/vue/src/components/MapLegend.vue
@@ -17,7 +17,10 @@ import { state } from '../store';
       </v-card-title>
       <v-card-text>
         <v-row dense>
-          <v-card density="compact">
+          <v-card
+            v-if="state.filters.drawSiteOutline"
+            density="compact"
+          >
             <v-card-title
               class="legend-title"
               :class="{'legend-title-single': !state.filters.scoringColoring}"
@@ -49,7 +52,10 @@ import { state } from '../store';
             </v-card-text>
           </v-card>
 
-          <v-card density="compact">
+          <v-card
+            v-if="state.filters.drawObservations"
+            density="compact"
+          >
             <v-card-title
               class="legend-title"
               :class="{'legend-title-single': !state.filters.scoringColoring}"

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -295,8 +295,8 @@ const determineDownload = () => {
         </v-tooltip>
       </v-row>
       <v-row v-if="downloading > 0">
-        <b class="small">Downloading {{ downloading }} site(s) Images</b>
-        <v-progress-linear indeterminate />
+        <b class="small">Downloading {{ downloading }} site(s) Images <v-icon class="fading">mdi-download</v-icon></b>
+        <v-progress-linear :model-value="((modelRun.numsites - downloading)/modelRun.numsites)*100" />
       </v-row>
       <v-row v-if="downloading > 0">
         <v-btn
@@ -374,5 +374,23 @@ const determineDownload = () => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.fading {
+  animation: fadeIcon 2s linear infinite;
+  overflow:hidden;
+}
+
+@keyframes fadeIcon {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+
+  }
+  100% {
+    opacity: 0;
+  }
 }
 </style>

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -60,7 +60,7 @@ async function loadMore() {
 
     // sort list to show ground truth near the top
     const modelRunResults = modelRunList.items;
-    const keyedModelRunResults = modelRunResults.map((val, i) => {
+    const keyedModelRunResults = modelRunResults.map((val) => {
       return {
         ...val,
         key: `${val.id}`,

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -63,7 +63,7 @@ async function loadMore() {
     const keyedModelRunResults = modelRunResults.map((val, i) => {
       return {
         ...val,
-        key: `${val.id}|${i + state.modelRuns.length}`,
+        key: `${val.id}`,
       };
     });
 

--- a/vue/src/components/PopUpComponent.vue
+++ b/vue/src/components/PopUpComponent.vue
@@ -114,7 +114,6 @@ const props = defineProps<{
             mdi-clock
           </v-icon>: NULL
         </v-chip>
-
       </v-row>
     </v-row>
   </v-card>

--- a/vue/src/components/PopUpComponent.vue
+++ b/vue/src/components/PopUpComponent.vue
@@ -16,47 +16,106 @@ const props = defineProps<{
       dense
       align="center"
       justify="center"
-      class="my-2"
+      class="my-1"
     >
-      <v-chip
-        label
-        :color="item.siteColor"
-        class="mx-2"
+      <v-row
+        dense
+        align="center"
+        justify="center"
       >
-        <v-icon
-          v-if="item.groundTruth"
+        <v-chip
+          label
           size="small"
-          :color="item.siteColor"
+          density="compact"
+          class="mx-1 mb-1"
         >
-          mdi-check-decagram
-        </v-icon>
-        SiteId: {{ item.siteId }}
-      </v-chip>
-      <v-chip
-        label
-        :color="item.scoreColor"
-        class="mx-2"
+          {{ item.performerName }} : {{ item.configName }}: V{{ item.version }}
+        </v-chip>
+      </v-row>
+      <v-row
+        dense
+        align="center"
+        justify="center"
+        class="mb-1"
       >
-        Score: {{ item.score?.toFixed(2) }}
-      </v-chip>
-      <v-chip
-        label
-        color="black"
-        variant="elevated"
-        class="mx-2"
-      >
-        Area: {{ item.area }}m²
-      </v-chip>
-      <v-chip
-        v-if="item.timestamp"
-        label
-        variant="elevated"
-        class="mx-2"
-      >
-        <v-icon size="x-small">
-          mdi-clock
-        </v-icon>: {{ item.timestamp.substring(0,10) }}
-      </v-chip>
+        <v-chip
+          label
+          :color="item.siteColor"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon
+            v-if="item.groundTruth"
+            size="small"
+            :color="item.siteColor"
+          >
+            mdi-check-decagram
+          </v-icon>
+          {{ item.siteLabel }}
+        </v-chip>
+
+        <v-chip
+          label
+          :color="item.obsColor"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon
+            v-if="item.groundTruth"
+            size="small"
+            :color="item.obsColor"
+          >
+            mdi-check-decagram
+          </v-icon>
+          SiteId: {{ item.siteId }}
+        </v-chip>
+        <v-chip
+          label
+          :color="item.scoreColor"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          Score: {{ item.score?.toFixed(2) }}
+        </v-chip>
+        <v-chip
+          label
+          color="black"
+          variant="elevated"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          Area: {{ item.area }}m²
+        </v-chip>
+        <v-chip
+          v-if="item.timestamp"
+          label
+          variant="elevated"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon size="x-small">
+            mdi-clock
+          </v-icon>: {{ item.timestamp.substring(0,10) }}
+        </v-chip>
+        <v-chip
+          v-else-if="item.timestamp === undefined"
+          label
+          variant="elevated"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon size="x-small">
+            mdi-clock
+          </v-icon>: NULL
+        </v-chip>
+
+      </v-row>
     </v-row>
   </v-card>
 </template>

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -39,23 +39,6 @@ const cloudCover = computed({
   },
 });
 
-const showSiteOutline = computed({
-  get() {
-    return state.filters.showSiteOutline || false;
-  },
-  set(val: boolean) {
-    state.filters = { ...state.filters, showSiteOutline: val,  };
-  },
-});
-
-const showRegionPolygon = computed({
-  get() {
-    return state.filters.showRegionPolygon || false;
-  },
-  set(val: boolean) {
-    state.filters = { ...state.filters, showRegionPolygon: val };
-  },
-});
 
 const groundTruthPattern = computed({
   get() {
@@ -73,15 +56,6 @@ const otherPattern = computed({
     state.filters = { ...state.filters, otherPattern: val };
   },
 });
-const showText = computed({
-    get() {
-      return state.filters.showText || false;
-    },
-    set(val: boolean) {
-      state.filters = { ...state.filters, showText: val };
-    },
-
-  })
 
 const patternThickness = computed({
   get() {
@@ -270,16 +244,23 @@ watch(hiddenCanvas, () => {
           </div>
           <span> {{ info.date }}</span>
         </v-col>
-        <v-col>
-          <div style="font-weight: bold">
-            Hash:
-          </div>
-          <span> {{ info.hash }}</span>
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col cols="8">
-          <v-checkbox
+        <v-col>const drawSiteOutline = computed({
+  get() {
+    return state.filters.drawSiteOutline || false;
+  },
+  set(val: boolean) {
+    state.filters = { ...state.filters, drawSiteOutline: val,  };
+  },
+});
+
+const drawRegionPoly = computed({
+  get() {
+    return state.filters.drawRegionPoly || false;
+  },
+  set(val: boolean) {
+    state.filters = { ...state.filters, drawRegionPoly: val };
+  },
+});
             v-model="autoZoom"
             label="Auto Zoom"
             density="compact"
@@ -368,51 +349,6 @@ watch(hiddenCanvas, () => {
         </v-col>
         <v-col cols="2">
           <span class="label">&lt;{{ cloudCover }}%</span>
-        </v-col>
-      </v-row>
-
-
-      <v-row dense>
-        <v-col cols="8">
-          <v-checkbox
-            v-model="showText"
-            label="Site Label On"
-            density="compact"
-          />
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col cols="8">
-          <v-checkbox
-            v-model="showSiteOutline"
-            label="Site Outline:"
-            density="compact"
-          />
-        </v-col>
-        <v-col>
-          <img
-            ref="siteOutlineImg"
-            height="32"
-            width="32"
-          >
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col cols="8">
-          <v-checkbox
-            v-model="showRegionPolygon"
-            label="Region Polygon:"
-            density="compact"
-          />
-        </v-col>
-        <v-col>
-          <div
-            :style="{
-              border: '1px solid grey',
-              height: '32px',
-              width: '32px'
-            }"
-          />
         </v-col>
       </v-row>
       <v-row dense>

--- a/vue/src/components/SettingsPanel.vue
+++ b/vue/src/components/SettingsPanel.vue
@@ -244,23 +244,16 @@ watch(hiddenCanvas, () => {
           </div>
           <span> {{ info.date }}</span>
         </v-col>
-        <v-col>const drawSiteOutline = computed({
-  get() {
-    return state.filters.drawSiteOutline || false;
-  },
-  set(val: boolean) {
-    state.filters = { ...state.filters, drawSiteOutline: val,  };
-  },
-});
-
-const drawRegionPoly = computed({
-  get() {
-    return state.filters.drawRegionPoly || false;
-  },
-  set(val: boolean) {
-    state.filters = { ...state.filters, drawRegionPoly: val };
-  },
-});
+        <v-col>
+          <div style="font-weight: bold">
+            Hash:
+          </div>
+          <span> {{ info.hash }}</span>
+        </v-col>
+      </v-row>
+      <v-row dense>
+        <v-col cols="8">
+          <v-checkbox
             v-model="autoZoom"
             label="Auto Zoom"
             density="compact"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -146,44 +146,84 @@ const toggleRegion = () => {
         align="center"
         class="py-2"
       >
-        <v-chip
-          density="compact"
-          size="small"
-          :variant="state.filters.drawObservations ? 'elevated' : 'outlined'"
-          class="mx-1"
-          @click="toggleObs()"
+        <v-tooltip
+          open-delay="100"
+          location="top"
         >
-          Obs
-        </v-chip>
-        <v-chip
-          density="compact"
-          size="small"
-          :variant="state.filters.drawSiteOutline ? 'elevated' : 'outlined'"
-          class="mx-1"
-          @click="toggleSites()"
+          <template #activator="{ props:subProps }">
+            <v-chip
+              density="compact"
+              v-bind="subProps"
+              size="small"
+              :color="state.filters.drawObservations ? 'rgb(37, 99, 235)' : 'black'"
+              :variant="state.filters.drawObservations ? 'elevated' : 'outlined'"
+              class="mx-1"
+              @click="toggleObs()"
+            >
+              Obs
+            </v-chip>
+          </template>
+          <span>Toggle Site Observations on/off</span>
+        </v-tooltip>
+        <v-tooltip
+          open-delay="100"
+          location="top"
         >
-          Site
-        </v-chip>
+          <template #activator="{ props:subProps }">
+            <v-chip
+              density="compact"
+              v-bind="subProps"
+              size="small"
+              :color="state.filters.drawSiteOutline ? 'rgb(37, 99, 235)' : 'black'"
+              :variant="state.filters.drawSiteOutline ? 'elevated' : 'outlined'"
+              class="mx-1"
+              @click="toggleSites()"
+            >
+              Site
+            </v-chip>
+          </template>
+          <span> Toggle Site Outlines On/Off</span>
+        </v-tooltip>
 
-        <v-chip
-          v-if="scoringApp && (state.filters.drawObservations || state.filters.drawSiteOutline)"
-          density="compact"
-          size="small"
-          :variant="state.filters.drawGroundTruth ? 'elevated' : 'outlined'"
-          class="mx-1"
-          @click="toggleGroundTruth()"
+        <v-tooltip
+          open-delay="100"
+          location="top"
         >
-          GT
-        </v-chip>
-        <v-chip
-          density="compact"
-          size="small"
-          :variant="state.filters.drawRegionPoly ? 'elevated' : 'outlined'"
-          class="mx-1"
-          @click="toggleRegion()"
+          <template #activator="{ props:subProps }">
+            <v-chip
+              v-if="scoringApp && (state.filters.drawObservations || state.filters.drawSiteOutline)"
+              v-bind="subProps"
+              density="compact"
+              :color="state.filters.drawGroundTruth ? 'rgb(37, 99, 235)' : 'black'"
+              size="small"
+              :variant="state.filters.drawGroundTruth ? 'elevated' : 'outlined'"
+              class="mx-1"
+              @click="toggleGroundTruth()"
+            >
+              GT
+            </v-chip>
+          </template>
+          <span>Toggle associated Ground Truth On/Off</span>
+        </v-tooltip>
+        <v-tooltip
+          open-delay="100"
+          location="top"
         >
-          Region
-        </v-chip>
+          <template #activator="{ props:subProps }">
+            <v-chip
+              v-bind="subProps"
+              density="compact"
+              size="small"
+              :color="state.filters.drawRegionPoly ? 'rgb(37, 99, 235)' : 'black'"
+              :variant="state.filters.drawRegionPoly ? 'elevated' : 'outlined'"
+              class="mx-1"
+              @click="toggleRegion()"
+            >
+              Region
+            </v-chip>
+          </template>
+          <span>Toggle Region Polygons On/Off</span>
+        </v-tooltip>
 
         <v-spacer />
         <v-btn

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -6,7 +6,7 @@ import RegionFilter from "./filters/RegionFilter.vue";
 import SettingsPanel from "./SettingsPanel.vue";
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
-import type { Performer, QueryArguments, Region } from "../client";
+import { ApiService, Performer, QueryArguments, Region } from "../client";
 import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 
@@ -22,7 +22,7 @@ const queryFilters = computed<QueryArguments>(() => ({
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
-const showSiteOutline: Ref<boolean> = ref(false);
+const drawSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
@@ -49,8 +49,8 @@ const updateRegion = (val?: Region) => {
     scoringColoring: null,
   };
 };
-watch(showSiteOutline, (val) => {
-  state.filters = { ...state.filters, showSiteOutline: val, scoringColoring: null };
+watch(drawSiteOutline, (val) => {
+  state.filters = { ...state.filters, drawSiteOutline: val, scoringColoring: null };
 });
 const expandSettings = ref(false);
 
@@ -79,6 +79,33 @@ onMounted(() => {
     }
   });
 });
+const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
+
+const toggleGroundTruth = () => {
+  const val = !state.filters.drawGroundTruth;
+  state.filters = { ...state.filters, drawGroundTruth: val };
+}
+
+const toggleText = () => {
+  const val = !state.filters.showText;
+  state.filters = { ...state.filters, showText: val };
+}
+
+const toggleObs = () => {
+  const val = !state.filters.drawObservations;
+  state.filters = { ...state.filters, drawObservations: val };
+}
+
+const toggleSites = () => {
+  const val = !state.filters.drawSiteOutline;
+  state.filters = { ...state.filters, drawSiteOutline: val };
+}
+
+const toggleRegion = () => {
+  const val = !state.filters.drawRegionPoly;
+  state.filters = { ...state.filters, drawRegionPoly: val };
+}
+
 
 </script>
 
@@ -114,7 +141,50 @@ onMounted(() => {
           {{ new Date(state.timestamp * 1000).toLocaleString() }}
         </div>
       </v-row>
-      <v-row dense>
+      <v-row
+        dense
+        align="center"
+        class="py-2"
+      >
+        <v-chip
+          density="compact"
+          size="small"
+          :variant="state.filters.drawObservations ? 'elevated' : 'outlined'"
+          class="mx-1"
+          @click="toggleObs()"
+        >
+          Obs
+        </v-chip>
+        <v-chip
+          density="compact"
+          size="small"
+          :variant="state.filters.drawSiteOutline ? 'elevated' : 'outlined'"
+          class="mx-1"
+          @click="toggleSites()"
+        >
+          Site
+        </v-chip>
+
+        <v-chip
+          v-if="scoringApp && (state.filters.drawObservations || state.filters.drawSiteOutline)"
+          density="compact"
+          size="small"
+          :variant="state.filters.drawGroundTruth ? 'elevated' : 'outlined'"
+          class="mx-1"
+          @click="toggleGroundTruth()"
+        >
+          GT
+        </v-chip>
+        <v-chip
+          density="compact"
+          size="small"
+          :variant="state.filters.drawRegionPoly ? 'elevated' : 'outlined'"
+          class="mx-1"
+          @click="toggleRegion()"
+        >
+          Region
+        </v-chip>
+
         <v-spacer />
         <v-btn
           variant="text"
@@ -128,6 +198,14 @@ onMounted(() => {
           icon="mdi-image"
           @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
         />
+        <v-btn
+          :color="state.filters.showText ? 'rgb(37, 99, 235)' : 'gray'"
+          variant="text"
+          density="compact"
+          icon="mdi-format-text"
+          @click="toggleText()"
+        />
+
         <v-btn
           :color="expandSettings ? 'rgb(37, 99, 235)' : 'gray'"
           variant="text"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -222,7 +222,7 @@ const toggleRegion = () => {
         >
           <template #activator="{ props:subProps }">
             <v-chip
-              v-if="(state.filters.drawObservations || state.filters.drawSiteOutline)"
+              v-if="scoringApp || (state.filters.drawObservations || state.filters.drawSiteOutline)"
               v-bind="subProps"
               density="compact"
               :color="state.filters.drawGroundTruth ? 'rgb(37, 99, 235)' : 'black'"

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -21,7 +21,7 @@ const queryFilters = computed<QueryArguments>(() => ({
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
-const showSiteOutline: Ref<boolean> = ref(false);
+const drawSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
@@ -48,8 +48,8 @@ const updateRegion = (val?: Region) => {
     scoringColoring: null,
   };
 };
-watch(showSiteOutline, (val) => {
-  state.filters = { ...state.filters, showSiteOutline: val, scoringColoring: null };
+watch(drawSiteOutline, (val) => {
+  state.filters = { ...state.filters, drawSiteOutline: val, scoringColoring: null };
 });
 
 function nextPage() {

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -3,7 +3,7 @@ import { Ref, computed, ref, watch, withDefaults } from "vue";
 import { ApiService } from "../../client";
 import { EvaluationImage, EvaluationImageResults } from "../../types";
 import { getColorFromLabel, styles } from '../../mapstyle/annotationStyles';
-import { loadAndToggleSatelliteImages, state } from '../../store'
+import { ObsDetails, loadAndToggleSatelliteImages, state } from '../../store'
 import { VDatePicker } from 'vuetify/labs/VDatePicker'
 import { SiteModelStatus } from "../../client/services/ApiService";
 import { CanvasCapture } from 'canvas-capture';
@@ -16,6 +16,7 @@ interface Props {
   editable?: boolean;
   siteEvaluationName?: string | null;
   dateRange?: number[] | null
+  obsDetails?: ObsDetails;
 }
 
 
@@ -26,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
   editable: false,
   siteEvaluationName: null,
   dateRange: null,
+  obsDetails: undefined,
 });
 
 const emit = defineEmits<{
@@ -375,15 +377,24 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
     <v-row
       v-if="dialog"
       dense
+      class="top-bar"
     >
+      <v-col v-if="obsDetails">
+        <span>{{ obsDetails.performer }} {{ obsDetails.title }} : V{{ obsDetails.version }}</span>
+      </v-col>
+      <v-col v-if="obsDetails">
+        <span>{{ siteEvaluationName }}</span>
+      </v-col>
+
+      <v-col v-if="obsDetails">
+        <span>{{ startDate }}</span> to <span> {{ endDate }}</span>
+      </v-col>
+
       <v-spacer />
       <v-icon @click="emit('close')">
         mdi-close
       </v-icon>
     </v-row>
-    <v-card-title v-if="!editable">
-      Site Image Display
-    </v-card-title>
     <v-card-title
       v-else
       class="edit-title"
@@ -980,5 +991,9 @@ const setSiteModelStatus = async (status: SiteModelStatus) => {
 
 .edit-title {
   font-size: 0.75em;
+}
+.top-bar {
+  font-size:12px;
+  font-weight: bold;
 }
 </style>

--- a/vue/src/components/imageViewer/ImageViewerButton.vue
+++ b/vue/src/components/imageViewer/ImageViewerButton.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { ObsDetails } from "../../store";
 import ImageViewer from './ImageViewer.vue';
 
 defineProps<{
   siteEvalId: string;
   siteEvaluationName?: string;
+  dateRange?: number[] | null
+  obsDetails?: ObsDetails;
 }>();
 
 const displayImage = ref(false);
@@ -24,6 +27,8 @@ const displayImage = ref(false);
       <ImageViewer
         :site-eval-id="siteEvalId"
         :site-evaluation-name="siteEvaluationName"
+        :obs-details="obsDetails"
+        :date-range="dateRange"
         dialog
         @close="displayImage = false"
       />

--- a/vue/src/components/siteObservations/EvaluationDisplay.vue
+++ b/vue/src/components/siteObservations/EvaluationDisplay.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 
 const refresh = async () => {
-  await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.scoringBase);
+  await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.obsDetails);
 }
 const close = () => {
   const foundIndex = state.selectedObservations.findIndex((item) => item.id === props.siteObservation.id);
@@ -81,15 +81,6 @@ const goToTimestamp = (dir: number, loop = false) => {
   }
 }
 const noScore = ref(false);
-const hasScore = async () => {
-  try {
-    // const result = await ApiService.hasScores(props.siteObservation.scoringBase.configurationId, props.siteObservation.scoringBase.regionId)
-    // noScore.value = !result;
-  } catch {
-    noScore.value = true;
-  }
-}
-hasScore();
 
 const changeTimstamp = ({dir, loop}: {dir: number, loop: boolean}) => {
   goToTimestamp(dir, loop);
@@ -108,9 +99,9 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
         justify="center"
         align="center"
       >
-        <v-col v-if="siteObservation.scoringBase">
+        <v-col v-if="siteObservation.obsDetails">
           <span class="model-title">
-            {{ `${siteObservation.scoringBase.region}_${siteObservation.scoringBase.siteNumber.toString().padStart(4, '0')}` }}
+            {{ `${siteObservation.obsDetails.region}_${siteObservation.obsDetails.siteNumber.toString().padStart(4, '0')}` }}
           </span>
         </v-col>
         <v-col cols="1">
@@ -145,6 +136,15 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
           </v-icon>
         </v-col>
       </v-row>
+      <v-row
+        dense
+        justify="center"
+        align="center"
+      >
+        <v-col v-if="siteObservation.obsDetails">
+          <span>{{ `${siteObservation.obsDetails.performer} ${siteObservation.obsDetails.title}: V${siteObservation.obsDetails.version}` }}</span>
+        </v-col>
+      </v-row>
       <v-expansion-panels
         variant="accordion"
         class="pa-0 ma-0 mb-2"
@@ -160,7 +160,7 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
           </v-expansion-panel-text>
         </v-expansion-panel>
         <v-expansion-panel
-          v-if="siteObservation.scoringBase && siteObservation.scoringBase.version && !noScore"
+          v-if="siteObservation.obsDetails && siteObservation.obsDetails.version && !noScore"
           key="Scoring"
         >
           <v-expansion-panel-title>Scoring</v-expansion-panel-title>
@@ -267,9 +267,11 @@ const hasLoadedImages = computed(() => (Object.entries(props.siteObservation.ima
       </v-row>
       <v-row>
         <image-viewer-button
-          v-if="hasLoadedImages && siteObservation.scoringBase"
+          v-if="hasLoadedImages && siteObservation.obsDetails"
           :site-eval-id="siteObservation.id"
-          :site-evaluation-name="`${siteObservation.scoringBase.region}_${siteObservation.scoringBase.siteNumber.toString().padStart(4, '0')}`"
+          :obs-details="siteObservation.obsDetails"
+          :date-range="siteObservation.timerange ? [siteObservation.timerange?.min, siteObservation.timerange.max]: undefined"
+          :site-evaluation-name="`${siteObservation.obsDetails.region}_${siteObservation.obsDetails.siteNumber.toString().padStart(4, '0')}`"
         />
       </v-row>
     </v-card-text>

--- a/vue/src/components/siteObservations/EvaluationImages.vue
+++ b/vue/src/components/siteObservations/EvaluationImages.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 let loopingInterval: NodeJS.Timeout | null = null;
 
 const checkSiteObs = async () => {
-  await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.scoringBase);
+  await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.obsDetails);
   if (loopingInterval !== null && props.siteObservation.job && props.siteObservation.job.status !== 'Running') {
     clearInterval(loopingInterval);
     loopingInterval = null;
@@ -45,7 +45,7 @@ const startDownload = async (data: DownloadSettings) => {
   const id = props.siteObservation.id
   await ApiService.getObservationImages(id.toString(), data);
     // Now we get the results to see if the service is running
-    await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.scoringBase);
+    await getSiteObservationDetails(props.siteObservation.id.toString(), props.siteObservation.obsDetails);
     // The props should be updated now we start an interval to update until we exist, deselect or other
     if (loopingInterval !== null) {
       clearInterval(loopingInterval);

--- a/vue/src/components/siteObservations/EvaluationScoring.vue
+++ b/vue/src/components/siteObservations/EvaluationScoring.vue
@@ -17,7 +17,7 @@ const temporalIOU: Ref<null | {site_preparation: string; active_construction: st
 const statusAnnotated: Ref<null | string> = ref(null);
 const color: Ref<null | string> = ref(null);
 const retrieveScoring = async () => {
-    const scoreData = props.siteObservation.scoringBase;
+    const scoreData = props.siteObservation.obsDetails;
     if (!scoreData) {
       return;
     }

--- a/vue/src/components/siteObservations/EvaluationsSideBar.vue
+++ b/vue/src/components/siteObservations/EvaluationsSideBar.vue
@@ -54,7 +54,7 @@ onUnmounted(() => {
   >
     <v-row>
       <h1 class="mx-4 mt-2">
-        Selected Evaluations
+        Selected Site Models
       </h1>
     </v-row>
 

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -4,6 +4,7 @@ import { ShallowRef } from "vue";
 import { getSiteObservationDetails, selectedObservationList, state } from "../store";
 import  createPopup from '../main';
 import { PopUpData } from '../interactions/popUpType';
+import { styles } from "../mapstyle/annotationStyles";
 
 
   const hoveredInfo: Ref<{region: string[], siteId: string[]}> = ref({region: [], siteId:[]});
@@ -34,8 +35,9 @@ const popupLogic = async (mapArg: ShallowRef<null | Map>) => {
   });
   map.value = mapArg.value;
 };
-const drawPopup = async (e: MapLayerMouseEvent) => {
+const drawPopupObservation = async (e: MapLayerMouseEvent) => {
   if (e.features && e.features[0]?.properties && map.value) {
+    console.log(e.features[0].properties);
     const coordinates = e.lngLat;
     const ids = [];
     const htmlMap: Record<string, boolean> = {};
@@ -53,6 +55,10 @@ const drawPopup = async (e: MapLayerMouseEvent) => {
           const region: string = item.properties.region;
           const score = item.properties.score;
           const siteId = item.properties.siteeval_id;
+          const configName = item.properties.configuration_name;
+          const performerName = item.properties.performer_name;
+          const version = item.properties.version;
+          const siteLabel = item.properties.site_label;
           hoveredInfo.value.region.push(
             `${item.properties.configuration_id}_${region}_${item.properties.performer_id}`
           );
@@ -69,10 +75,15 @@ const drawPopup = async (e: MapLayerMouseEvent) => {
                   siteId: `${region}_${String(id).padStart(4, '0')}`,
                   score,
                   groundTruth: item.properties.groundtruth,
-                  siteColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
+                  obsColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
+                  siteColor: styles[siteLabel].color,
                   scoreColor: calculateScoreColor(score),
                   timestamp: item.properties.timestamp,
                   area,
+                  version,
+                  configName,
+                  performerName,
+                  siteLabel,
               })
             }
           }
@@ -136,10 +147,10 @@ const setPopupEvents = (map: ShallowRef<null | Map>) => {
     loadedFunctions = []
     for (const m of state.openedModelRuns) {
       const id = m.split('|')[0];
-      map.value.on("mouseenter", `observations-fill-${id}`, drawPopup);
-      map.value.on("mouseleave", `observations-fill-${id}`, drawPopup);
+      map.value.on("mouseenter", `observations-fill-${id}`, drawPopupObservation);
+      map.value.on("mouseleave", `observations-fill-${id}`, drawPopupObservation);
       map.value.on("click", `observations-fill-${id}`, clickObservation);
-      loadedFunctions.push({id, mouseenter: drawPopup, mouseleave: drawPopup, clickObservation});
+      loadedFunctions.push({id, mouseenter: drawPopupObservation, mouseleave: drawPopupObservation, clickObservation});
     }
   }
 }

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -37,7 +37,6 @@ const popupLogic = async (mapArg: ShallowRef<null | Map>) => {
 };
 const drawPopupObservation = async (e: MapLayerMouseEvent) => {
   if (e.features && e.features[0]?.properties && map.value) {
-    console.log(e.features[0].properties);
     const coordinates = e.lngLat;
     const ids = [];
     const htmlMap: Record<string, boolean> = {};
@@ -76,7 +75,7 @@ const drawPopupObservation = async (e: MapLayerMouseEvent) => {
                   score,
                   groundTruth: item.properties.groundtruth,
                   obsColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
-                  siteColor: styles[siteLabel].color,
+                  siteColor: styles[siteLabel]?.color,
                   scoreColor: calculateScoreColor(score),
                   timestamp: item.properties.timestamp,
                   area,
@@ -112,22 +111,23 @@ const drawPopupObservation = async (e: MapLayerMouseEvent) => {
 };
 const clickObservation = async (e: MapLayerMouseEvent) => {
   if (e.features && e.features[0]?.properties && map.value) {
-    const feature = e.features[0];
+    e.features.forEach(async (feature) => {
     if (feature.properties) {
-      const siteId = feature.properties.siteeval_id;
-      const obsDetails = {
-        region: feature.properties.region as string,
-        configurationId: feature.properties.configuration_id as number,
-        siteNumber: feature.properties.site_number as number,
-        version: feature.properties.version,
-        performer: feature.properties.performer_name,
-        title: feature.properties.configuration_name,
-      }
+        const siteId = feature.properties.siteeval_id;
+        const obsDetails = {
+          region: feature.properties.region as string,
+          configurationId: feature.properties.configuration_id as number,
+          siteNumber: feature.properties.site_number as number,
+          version: feature.properties.version,
+          performer: feature.properties.performer_name,
+          title: feature.properties.configuration_name,
+        }
 
-      if (siteId && !selectedObservationList.value.includes(siteId)) {
-        await getSiteObservationDetails(siteId, obsDetails);
+        if (siteId && !selectedObservationList.value.includes(siteId)) {
+          await getSiteObservationDetails(siteId, obsDetails);
+        }
       }
-    }
+    })
   }
 
 }

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -115,15 +115,17 @@ const clickObservation = async (e: MapLayerMouseEvent) => {
     const feature = e.features[0];
     if (feature.properties) {
       const siteId = feature.properties.siteeval_id;
-      const scoringBase = {
+      const obsDetails = {
         region: feature.properties.region as string,
         configurationId: feature.properties.configuration_id as number,
         siteNumber: feature.properties.site_number as number,
         version: feature.properties.version,
+        performer: feature.properties.performer_name,
+        title: feature.properties.configuration_name,
       }
 
       if (siteId && !selectedObservationList.value.includes(siteId)) {
-        await getSiteObservationDetails(siteId, scoringBase);
+        await getSiteObservationDetails(siteId, obsDetails);
       }
     }
   }

--- a/vue/src/interactions/popUpType.ts
+++ b/vue/src/interactions/popUpType.ts
@@ -1,10 +1,16 @@
 
 export interface PopUpData {
     siteId: string;
+    obsColor: string;
     siteColor: string;
     score: number;
     groundTruth: boolean;
     scoreColor: string;
     area: string;
     timestamp?: string;
+    version: string,
+    configName: string,
+    performerName: string,
+    siteLabel: string,
+
   }  

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -9,23 +9,23 @@ const defaultLabelText = '';
 
 const styles: AnnotationStyle = {
   active_construction: {
-    color: "#007DFF",
+    color: "#c00000",
     type: "observation",
   },
   post_construction: {
-    color: "#BE4EFF",
+    color: "#5b9bd5",
     type: "observation",
   },
   site_preparation: {
-    color: "#FFA100",
+    color: "#ffd966",
     type: "observation",
   },
   unknown: {
-    color: "#FFA100",
+    color: "#7030a0",
     type: "observation",
   },
   no_activity: {
-    color: "#228b22",
+    color: "#a6a6a6",
     type: "observation",
   },
   positive_annotated: {

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -33,9 +33,6 @@ export const buildObservationFilter = (
   timestamp: number,
   filters: MapFilters
 ): FilterSpecification => {
-  if (!filters.drawObservations) {
-    return false;
-  }
   const filter: FilterSpecification = [
     "all",
     [
@@ -69,8 +66,15 @@ export const buildObservationFilter = (
           "any",
           ["==", ["get", "groundtruth"], false]
         ]
-      );
+      ); 
+    } else if (!filters.drawObservations) {
+      filter.push([
+        "any",
+        ["==", ["get", "groundtruth"], true]
+      ]); 
     }
+  } else if (!filters.drawObservations) {
+    return false;
   }
 
   return filter;

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -21,9 +21,9 @@ const buildTextOffset = (
   type: "site" | "observation",
   filters: MapFilters
 ): [number, number] => {
-  if (filters.showSiteOutline && type === "site") {
+  if (filters.drawSiteOutline && type === "site") {
     return [0, 0.5];
-  } else if (filters.showSiteOutline && type === "observation") {
+  } else if (filters.drawSiteOutline && type === "observation") {
     return [0, -0.5];
   }
   return [0, 0];
@@ -33,6 +33,9 @@ export const buildObservationFilter = (
   timestamp: number,
   filters: MapFilters
 ): FilterSpecification => {
+  if (!filters.drawObservations) {
+    return false;
+  }
   const filter: FilterSpecification = [
     "all",
     [
@@ -59,6 +62,16 @@ export const buildObservationFilter = (
       [">", ["get", "timemax"], timestamp],
     ],
   ];
+  // If Scoring App and have ground truth we filter it out if the drawGT is false
+  if (ApiService.apiPrefix.includes('scoring')) {
+    if (!filters.drawGroundTruth) {
+      filter.push([
+          "any",
+          ["==", ["get", "groundtruth"], false]
+        ]
+      );
+    }
+  }
 
   return filter;
 };
@@ -83,15 +96,25 @@ export const buildSiteFilter = (
       // observations associated with this model run and that the main site polygon
       // should be rendered regardless of timestamp
       ["get", "site_polygon"],
-      ["literal", !!filters.showSiteOutline],
+      ["literal", !!filters.drawSiteOutline],
       ],
   ];
+
+  if (ApiService.apiPrefix.includes('scoring')) {
+    if (!filters.drawGroundTruth) {
+      filter.push([
+          "any",
+          ["==", ["get", "groundtruth"], false]
+        ]
+      );
+    }
+  }
 
   return filter;
 };
 
 export const buildRegionFilter = (filters: MapFilters): FilterSpecification => {
-  const filter: FilterSpecification = ["literal", !!filters.showRegionPolygon];
+  const filter: FilterSpecification = ["literal", !!filters.drawRegionPoly];
 
   return filter;
 };

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -6,10 +6,12 @@ export interface MapFilters {
   configuration_id?: string[];
   performer_ids?: number[];
   regions?: Region[];
-  showSiteOutline?: boolean;
+  drawSiteOutline?: boolean;
   groundTruthPattern?: boolean;
+  drawGroundTruth?: boolean;
+  drawObservations?: boolean;
+  drawRegionPoly?: boolean;
   otherPattern?: boolean;
-  showRegionPolygon?: boolean;
   hoverSiteId?: string;
   showText?: boolean;
   scoringColoring?: Record<string, Record<string, string>> | null;
@@ -161,6 +163,8 @@ export const state = reactive<{
     ymax: 90,
   },
   filters: {
+    drawObservations: true,
+    drawSiteOutline: false,
     groundTruthPattern: false,
     otherPattern: false,
     showText: false,

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -54,11 +54,13 @@ export interface SiteObservationImage {
   bbox: { xmin: number; ymin: number; xmax: number; ymax: number };
 }
 
-export interface ScoringBase {
+export interface ObsDetails {
   region: string;
   configurationId: number;
   siteNumber: number;
   version: string;
+  performer: string;
+  title: string;
 }
 
 export interface EnabledSiteObservations {
@@ -83,7 +85,7 @@ export interface SiteObservationJob {
 
 export interface SiteObservation {
   id: string;
-  scoringBase?: ScoringBase;
+  obsDetails?: ObsDetails;
   timerange: {
     min: number;
     max: number;
@@ -215,7 +217,7 @@ export const selectedObservationList = computed(() => {
 })
 
 
-export const getSiteObservationDetails = async (siteId: string, scoringBase?: ScoringBase, select=true) => {
+export const getSiteObservationDetails = async (siteId: string, obsDetails?: ObsDetails, select=true) => {
   const data = await ApiService.getSiteObservations(siteId);
   const { results } = data;
   const { images } = data;
@@ -256,7 +258,7 @@ export const getSiteObservationDetails = async (siteId: string, scoringBase?: Sc
   const foundIndex = state.selectedObservations.findIndex((item) => item.id === numId);
   const obsData =  {
     id: numId,
-    scoringBase,
+    obsDetails,
     timerange: data.timerange,
     imagesLoaded: false,
     imagesActive: false,


### PR DESCRIPTION
resolves #305 

- Moves some toggles out of the settings and into the main interface:
    - These toggles include toggling on/off Observations, Sites, Regions, and if in the scoring application the GroundTruth.
    - Also moved the Text toggle to the same location
- Popup Additions
    - Added the Performer/ModelRun/Version to the popup
    - Also added the site status with the proper coloring.
- Updated the Coloring for observations to follow the coloring given.
- Updated the legend so only the selected formats show up in the legend.  I.E if you have only observations selected those are what are displayed in the region, if both observations and sites are selected they will both be visible in the legend.
- Changed "Selected Site Evaluations" to "Selected Site Models"
- Added the Performer: ModelRun: Version to selected site Models.
- Image Viewer Updates:
    - Added the Performer, ModelRun to the top bar
    - Also added in the Region/Site Model Number and the beginning/End dates for the Site.
- Downloading images for a model run uses a true progress bar to indicate progress.
- Added support for selecting all items under the cursor when clicking.