### PR TITLE
Adding iMERIT as a valid originator for ground truth

### DIFF
--- a/django/src/rdwatch_scoring/views/vector_tile.py
+++ b/django/src/rdwatch_scoring/views/vector_tile.py
@@ -178,7 +178,8 @@ def vector_tile(
                 score=F('confidence_score'),
                 groundtruth=Case(
                     When(
-                        Q(site_uuid__originator='te') | Q(site_uuid__originator='iMERIT'),
+                        Q(site_uuid__originator='te')
+                        | Q(site_uuid__originator='iMERIT'),
                         True,
                     ),
                     default=False,

--- a/django/src/rdwatch_scoring/views/vector_tile.py
+++ b/django/src/rdwatch_scoring/views/vector_tile.py
@@ -114,7 +114,7 @@ def vector_tile(
                 region=F('region_id'),
                 groundtruth=Case(
                     When(
-                        Q(originator='te'),
+                        Q(originator='te') | Q(originator='iMERIT'),
                         True,
                     ),
                     default=False,
@@ -178,7 +178,7 @@ def vector_tile(
                 score=F('confidence_score'),
                 groundtruth=Case(
                     When(
-                        Q(site_uuid__originator='te'),
+                        Q(site_uuid__originator='te') | Q(site_uuid__originator='iMERIT'),
                         True,
                     ),
                     default=False,


### PR DESCRIPTION
Add iMERIT as a valid originator for a ground truth label, as requested by T&E team.