### PR TITLE
Scoring Coloring from T&E Database

### DIFF
--- a/django/src/rdwatch/views/vector_tile.py
+++ b/django/src/rdwatch/views/vector_tile.py
@@ -106,11 +106,13 @@ def vector_tile(request: HttpRequest, model_run_id: UUID4, z: int, x: int, y: in
                 id=F('pk'),
                 mvtgeom=mvtgeom,
                 configuration_id=F('configuration_id'),
+                configuration_name=F('configuration__title'),
                 label=F('label__slug'),
                 timestamp=ExtractEpoch('timestamp'),
                 timemin=ExtractEpoch(Min('observations__timestamp')),
                 timemax=ExtractEpoch(Max('observations__timestamp')),
                 performer_id=F('configuration__performer_id'),
+                performer_name=F('configuration__performer__slug'),
                 region=F('region__name'),
                 groundtruth=Case(
                     When(
@@ -119,6 +121,7 @@ def vector_tile(request: HttpRequest, model_run_id: UUID4, z: int, x: int, y: in
                     ),
                     default=False,
                 ),
+                site_number=F('number'),
                 site_polygon=Case(
                     When(
                         observation_count=0,

--- a/django/src/rdwatch_scoring/views/vector_tile.py
+++ b/django/src/rdwatch_scoring/views/vector_tile.py
@@ -109,6 +109,17 @@ def vector_tile(
                 id=F('base_site_id'),
                 mvtgeom=mvtgeom,
                 configuration_id=F('evaluation_run_uuid'),
+                configuration_name=ExpressionWrapper(
+                    Concat(
+                        Value('Eval '),
+                        F('evaluation_run_uuid__evaluation_number'),
+                        Value(' '),
+                        F('evaluation_run_uuid__evaluation_run_number'),
+                        Value(' '),
+                        F('evaluation_run_uuid__performer'),
+                    ),
+                    output_field=CharField(),
+                ),
                 label=Case(
                     When(
                         Q(status_annotated__isnull=False),
@@ -121,6 +132,7 @@ def vector_tile(
                 timemin=ExtractEpoch('start_date'),
                 timemax=ExtractEpoch('end_date'),
                 performer_id=F('originator'),
+                performer_name=F('originator'),
                 region=F('region_id'),
                 groundtruth=Case(
                     When(
@@ -130,6 +142,7 @@ def vector_tile(
                     default=False,
                 ),
                 site_polygon=Value(False, output_field=BooleanField()),
+                site_number=Substr(F('site_id'), 9),  # pos is 1 indexed
                 color_code=Case(
                     When(
                         Q(originator='te') | Q(originator='iMERIT'),

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -424,17 +424,6 @@ export class ApiService {
       query: { configurationId, region },
     });
   }
-  public static getScoreColoring(
-    configurationId: string,
-    region: string,
-  ): CancelablePromise<Record<string, string>>
-  {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/api/scores/region-colors",
-      query: { configurationId, region, },
-    });
-  }
 
   public static getEvaluationImages(id: string): CancelablePromise<EvaluationImageResults> {
     return __request(OpenAPI, {

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -127,7 +127,6 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           class="px-2 mx-2"
           v-bind="props"
           size="large"
-          :variant="!state.filters.drawObservations ? 'outlined' : undefined"
           :color="state.filters.drawObservations ? 'rgb(37, 99, 235)' : ''"
           @click="toggleObs()"
         >
@@ -177,7 +176,6 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           class="px-2 mx-2"
           v-bind="props"
           size="large"
-          :variant="!state.filters.drawSiteOutline ? 'outlined' : undefined"
           :color="state.filters.drawSiteOutline ? 'rgb(37, 99, 235)' : ''"
           @click="toggleSite()"
         >
@@ -222,7 +220,6 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
     <v-btn
       class="px-2 mx-2"
       size="large"
-      :variant="!state.filters.drawRegionPoly ? 'outlined' : undefined"
       :color="state.filters.drawRegionPoly ? 'rgb(37, 99, 235)' : ''"
       @click="toggleRegion()"
     >
@@ -237,7 +234,6 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           class="px-2 mx-2"
           v-bind="props"
           size="large"
-          :variant="!state.filters.scoringColoring ? 'outlined' : undefined"
           :color="state.filters.scoringColoring ? 'rgb(37, 99, 235)' : ''"
           @click="toggleScoring()"
         >

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -1,0 +1,294 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { ApiService } from "../client";
+import { state } from "../store";
+
+
+
+const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
+
+
+
+
+const checkGroundTruth = async () => {
+  if (scoringApp.value) { 
+    return;
+  } else {
+    // We need to find the ground-truth model and add it to the visible items
+    const performer = state.filters.performer_ids?.map((item) => state.performerMapping[item].short_code)
+    const request = await ApiService.getModelRuns({
+      limit: 10,
+      performer,
+      region: state.filters.regions? state.filters.regions[0] : '',
+      groundtruth: true
+    });
+    if (request.items.length) {
+      const id = request.items[0].id;
+      if (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth')) {
+        if (state.openedModelRuns) {
+          state.openedModelRuns.add(id);
+        }
+        const configuration_id = Array.from(state.openedModelRuns);
+        state.filters = { ...state.filters, configuration_id};
+      }
+      else if (!state.filters.drawObservations?.includes('groundtruth') && !state.filters.drawSiteOutline?.includes('groundtruth')) {
+        if (state.openedModelRuns) {
+          if (state.openedModelRuns.has(id)) {
+            state.openedModelRuns.delete(id);
+          }
+        }
+        const configuration_id = Array.from(state.openedModelRuns);
+        state.filters = { ...state.filters, configuration_id};
+      }
+    }
+  }
+}
+
+const toggleObs = (type?: undefined | 'model' | 'groundtruth') => {
+  let val;
+  let copy = state.filters.drawObservations;
+  if (type === undefined) {
+    val = !state.filters.drawObservations ? ['model', 'groundtruth'] : undefined;
+  } else {
+    if (copy) {
+        const index = copy.indexOf(type);
+        if (index !== -1 ) {
+            copy.splice(index, 1);
+        } else {
+            copy.push(type);
+        }
+    } else {
+        copy = [type];
+    }
+    val = copy;
+    if (val?.length === 0) {
+        val = undefined;
+    }
+  }
+  state.filters = { ...state.filters, drawObservations: val, scoringColoring: undefined };
+  checkGroundTruth();
+}
+
+const toggleSite = (type?: undefined | 'model' | 'groundtruth') => {
+    let val;
+  let copy = state.filters.drawSiteOutline;
+  if (type === undefined) {
+    val = !state.filters.drawSiteOutline ? ['model', 'groundtruth'] : undefined;
+  } else {
+    if (copy) {
+        const index = copy.indexOf(type);
+        if (index !== -1 ) {
+            copy.splice(index, 1);
+        } else {
+            copy.push(type);
+        }
+    } else {
+        copy = [type];
+    }
+    val = copy;
+    if (val?.length === 0) {
+        val = undefined;
+    }
+  }
+  state.filters = { ...state.filters, drawSiteOutline: val, scoringColoring: undefined };
+  checkGroundTruth();
+}
+
+const toggleRegion = () => {
+  const val = !state.filters.drawRegionPoly;
+  state.filters = { ...state.filters, drawRegionPoly: val };
+}
+
+const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
+  let val = state.filters.scoringColoring ? undefined : 'simple';
+  if (data) {
+    val = data;
+  }
+  if (val !== undefined) {
+    // We turn off other state;
+    state.filters = { ...state.filters, drawObservations: undefined, drawSiteOutline: undefined}
+
+  }
+  state.filters = { ...state.filters, scoringColoring: val as 'simple' | 'detailed' | undefined };
+}
+
+</script>
+
+<template>
+  <v-row
+    dense
+    class="base"
+  >
+    <v-menu
+      open-on-hover
+    >
+      <template #activator="{ props }">
+        <v-btn
+          class="px-2 mx-2"
+          v-bind="props"
+          size="large"
+          :variant="!state.filters.drawObservations ? 'outlined' : undefined"
+          :color="state.filters.drawObservations ? 'rgb(37, 99, 235)' : ''"
+          @click="toggleObs()"
+        >
+          <span>
+            Observations
+          </span>
+          <v-icon
+            v-if="state.filters.drawObservations?.includes('model')"
+          >
+            mdi-alpha-m-box
+          </v-icon>
+          <v-icon
+            v-if="state.filters.drawObservations?.includes('groundtruth')"
+          >
+            mdi-alpha-t-box
+          </v-icon>
+        </v-btn>
+      </template>
+      <v-card outlined>
+        <v-list>
+          <v-list-item
+            value="Model"
+            @click="toggleObs('model')"
+          >
+            Model
+            <v-icon>
+              mdi-alpha-m-box
+            </v-icon>
+          </v-list-item>
+          <v-list-item
+            value="GroundTruth"
+            @click="toggleObs('groundtruth')"
+          >
+            GroundTruth
+            <v-icon>
+              mdi-alpha-t-box
+            </v-icon>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </v-menu>
+    <v-menu
+      open-on-hover
+    >
+      <template #activator="{ props }">
+        <v-btn
+          class="px-2 mx-2"
+          v-bind="props"
+          size="large"
+          :variant="!state.filters.drawSiteOutline ? 'outlined' : undefined"
+          :color="state.filters.drawSiteOutline ? 'rgb(37, 99, 235)' : ''"
+          @click="toggleSite()"
+        >
+          <span>
+            Sites
+          </span>
+          <v-icon
+            v-if="state.filters.drawSiteOutline?.includes('model')"
+          >
+            mdi-alpha-m-box
+          </v-icon>
+          <v-icon
+            v-if="state.filters.drawSiteOutline?.includes('groundtruth')"
+          >
+            mdi-alpha-t-box
+          </v-icon>
+        </v-btn>
+      </template>
+      <v-card outlined>
+        <v-list>
+          <v-list-item
+            value="Model"
+            @click="toggleSite('model')"
+          >
+            Model
+            <v-icon>
+              mdi-alpha-m-box
+            </v-icon>
+          </v-list-item>
+          <v-list-item
+            value="GroundTruth"
+            @click="toggleSite('groundtruth')"
+          >
+            GroundTruth
+            <v-icon>
+              mdi-alpha-t-box
+            </v-icon>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </v-menu>
+    <v-btn
+      class="px-2 mx-2"
+      size="large"
+      :variant="!state.filters.drawRegionPoly ? 'outlined' : undefined"
+      :color="state.filters.drawRegionPoly ? 'rgb(37, 99, 235)' : ''"
+      @click="toggleRegion()"
+    >
+      Region
+    </v-btn>
+    <v-menu
+      open-on-hover
+    >
+      <template #activator="{ props }">
+        <v-btn
+          v-if="scoringApp"
+          class="px-2 mx-2"
+          v-bind="props"
+          size="large"
+          :variant="!state.filters.scoringColoring ? 'outlined' : undefined"
+          :color="state.filters.scoringColoring ? 'rgb(37, 99, 235)' : ''"
+          @click="toggleScoring()"
+        >
+          <span>
+            Scoring
+          </span>
+          <v-icon
+            v-if="state.filters.scoringColoring == 'simple'"
+          >
+            mdi-alpha-s-box
+          </v-icon>
+          <v-icon
+            v-if="state.filters.scoringColoring == 'detailed'"
+          >
+            mdi-alpha-d-box
+          </v-icon>
+        </v-btn>
+      </template>
+      <v-card outlined>
+        <v-list>
+          <v-list-item
+            value="Simple"
+            @click="toggleScoring('simple')"
+          >
+            Simple
+            <v-icon>
+              mdi-alpha-s-box
+            </v-icon>
+          </v-list-item>
+          <v-list-item
+            value="Detailed"
+            @click="toggleScoring('detailed')"
+          >
+            Detailed
+            <v-icon>
+              mdi-alpha-d-box
+            </v-icon>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </v-menu>
+  </v-row>
+</template>
+
+<style scoped>
+.base {
+    position: absolute;
+    left: 400px;
+    margin-left: 10px;
+}
+.button-label {
+    font-size: 8px;
+}
+</style>

--- a/vue/src/components/MapLegend.vue
+++ b/vue/src/components/MapLegend.vue
@@ -7,7 +7,7 @@ import { state } from '../store';
 
 <template>
   <div
-    v-if="state.mapLegend && (state.filters.drawGroundTruth || state.filters.drawObservations || state.filters.drawSiteOutline)"
+    v-if="state.mapLegend && (state.filters.drawObservations || state.filters.drawSiteOutline)"
     class="legend"
   >
     <v-card density="compact">
@@ -19,7 +19,7 @@ import { state } from '../store';
       <v-card-text>
         <v-row dense>
           <v-card
-            v-if="state.filters.drawSiteOutline"
+            v-if="state.filters.drawSiteOutline && !state.filters.scoringColoring"
             density="compact"
           >
             <v-card-title
@@ -54,7 +54,7 @@ import { state } from '../store';
           </v-card>
 
           <v-card
-            v-if="state.filters.drawObservations || (state.filters.drawGroundTruth && !state.filters.drawSiteOutline)"
+            v-if="state.filters.drawObservations"
             density="compact"
           >
             <v-card-title

--- a/vue/src/components/MapLegend.vue
+++ b/vue/src/components/MapLegend.vue
@@ -7,7 +7,7 @@ import { state } from '../store';
 
 <template>
   <div
-    v-if="state.mapLegend && (state.filters.drawObservations || state.filters.drawSiteOutline)"
+    v-if="state.mapLegend && (state.filters.drawObservations || state.filters.drawSiteOutline || state.filters.scoringColoring)"
     class="legend"
   >
     <v-card density="compact">
@@ -24,7 +24,6 @@ import { state } from '../store';
           >
             <v-card-title
               class="legend-title"
-              :class="{'legend-title-single': !state.filters.scoringColoring}"
             >
               Site Models
             </v-card-title>
@@ -43,7 +42,6 @@ import { state } from '../store';
                     />
                     <span
                       class="pl-1 legend-label"
-                      :class="{'legend-label-single': !state.filters.scoringColoring}"
                     >
                       :{{ item.name }}
                     </span>
@@ -59,7 +57,6 @@ import { state } from '../store';
           >
             <v-card-title
               class="legend-title"
-              :class="{'legend-title-single': !state.filters.scoringColoring}"
             >
               Site Observations
             </v-card-title>
@@ -78,7 +75,6 @@ import { state } from '../store';
                     />
                     <span
                       class="pl-1 legend-label"
-                      :class="{'legend-label-single': !state.filters.scoringColoring}"
                     >
                       :{{ item.name }}
                     </span>

--- a/vue/src/components/MapLegend.vue
+++ b/vue/src/components/MapLegend.vue
@@ -54,7 +54,7 @@ import { state } from '../store';
           </v-card>
 
           <v-card
-            v-if="state.filters.drawObservations || state.filters.drawGroundTruth"
+            v-if="state.filters.drawObservations || (state.filters.drawGroundTruth && !state.filters.drawSiteOutline)"
             density="compact"
           >
             <v-card-title

--- a/vue/src/components/MapLegend.vue
+++ b/vue/src/components/MapLegend.vue
@@ -122,16 +122,10 @@ import { state } from '../store';
   max-width: 400px;
 }
 .legend-title {
-  font-size:0.50em !important;
+  font-size:1.0em !important;
 }
 .legend-label {
-  font-size: 0.50em;
-}
-.legend-title-single {
-  font-size:1em !important;
-}
-.legend-label-single {
-  font-size: .75em;
+  font-size: 0.75em;
 }
 .color-icon {
   min-width: 15px;

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import TimeSlider from "./TimeSlider.vue";
 import { ApiService, ModelRun } from "../client";
-import { state } from "../store";
 import { Ref, computed, onBeforeMount, onBeforeUnmount, ref, withDefaults } from "vue";
 import { timeRangeFormat } from "../utils";
 import ImagesDownloadDialog from "./ImagesDownloadDialog.vue";
@@ -27,7 +26,6 @@ async function handleClick() {
 
 const route = useRoute();
 const scoringApp = computed(() => route.path.includes('scoring'));
-const useScoring = ref(false);
 const downloadImages = ref(false);
 
 let loopingInterval: NodeJS.Timeout | null = null;

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -32,30 +32,7 @@ const downloadImages = ref(false);
 
 let loopingInterval: NodeJS.Timeout | null = null;
 
-async function getScoringColoring() {
-  if (!useScoring.value) { // inverted value because of the delay
-    const results = await ApiService.getScoreColoring(props.modelRun.id, props.modelRun.region || '')
-    let tempResults = state.filters.scoringColoring;
-    if (!tempResults) {
-      tempResults = {};
-    }
-    if (tempResults !== undefined && tempResults !== null)  {
-      tempResults[`${props.modelRun.id}_${props.modelRun.region}`] = results;
-    }
-    state.filters = { ...state.filters, scoringColoring: tempResults };
-  } else {
-    let tempResults = state.filters.scoringColoring;
-    if (tempResults) {
-      if (Object.keys(tempResults).includes(`${props.modelRun.id}_${props.modelRun.region}`)) {
-        delete tempResults[`${props.modelRun.id}_${props.modelRun.region}`];
-      }
-      if (Object.values(tempResults).length === 0) {
-        tempResults = null;
-      }
-    }
-    state.filters = { ...state.filters, scoringColoring: tempResults };
-  }
-}
+
 const downloading = ref(props.modelRun.downloading);
 
 const updateDownloading = async () => {
@@ -223,18 +200,6 @@ const determineDownload = () => {
             All Proposals Adjudicated
           </v-chip>
         </div>
-      </v-row>
-
-      <v-row
-        v-if="!compact && modelRun.hasScores && props.open"
-        dense
-      >
-        <input
-          v-model="useScoring"
-          type="checkbox"
-          @click.stop="getScoringColoring()"
-        >
-        <span class="ml-2"> Scoring Coloring</span>
       </v-row>
       <v-row dense>
         <v-icon

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -232,13 +232,11 @@ function handleToggle(modelRun: KeyedModelRun) {
       ...state.filters,
       configuration_id: Array.from(configurationIds),
       regions: Array.from(regions),
-      scoringColoring: null,
     };
   } else {
     state.filters = {
       ...state.filters,
       configuration_id: undefined,
-      scoringColoring: null,
     };
     updateCameraBounds(false);
   }
@@ -268,7 +266,6 @@ watch([() => props.filters.region, () => props.filters.performer], () => {
   state.filters = {
     ...state.filters,
     configuration_id: [],
-    scoringColoring: null,
   };
 });
 </script>

--- a/vue/src/components/PopUpComponent.vue
+++ b/vue/src/components/PopUpComponent.vue
@@ -1,9 +1,10 @@
 
 
 <script setup lang="ts">
-import { PopUpData } from '../interactions/popUpType';
+import { PopUpData, PopUpSiteData } from '../interactions/popUpType';
 const props = defineProps<{
-  data:PopUpData[]
+  data:Record<string, PopUpData>;
+  siteData:Record<string, PopUpSiteData>;
 }>();
 
 </script>
@@ -104,6 +105,90 @@ const props = defineProps<{
           <v-icon size="x-small">
             mdi-clock
           </v-icon>: NULL
+        </v-chip>
+      </v-row>
+    </v-row>
+    <v-row
+      v-for="item in props.siteData"
+      :key="item.siteId"
+      dense
+      align="center"
+      justify="center"
+      class="my-1"
+    >
+      <v-row
+        dense
+        align="center"
+        justify="center"
+      >
+        <v-chip
+          label
+          size="small"
+          density="compact"
+          class="mx-1 mb-1"
+        >
+          {{ item.performerName }} : {{ item.configName }}: V{{ item.version }}
+        </v-chip>
+      </v-row>
+      <v-row
+        dense
+        align="center"
+        justify="center"
+        class="mb-1"
+      >
+        <v-chip
+          label
+          :color="item.siteColor"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon
+            v-if="item.groundTruth"
+            size="small"
+            :color="item.siteColor"
+          >
+            mdi-check-decagram
+          </v-icon>
+          {{ item.siteLabel }}
+        </v-chip>
+
+        <v-chip
+          label
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon
+            v-if="item.groundTruth"
+            size="small"
+          >
+            mdi-check-decagram
+          </v-icon>
+          SiteId: {{ item.siteId }}
+        </v-chip>
+        <v-chip
+          v-if="item.timeRange"
+          label
+          variant="elevated"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          <v-icon size="x-small">
+            mdi-clock
+          </v-icon>: {{ item.timeRange }}
+        </v-chip>
+        <v-chip
+          v-if="item.scoreLabel && item.scoreColor"
+          label
+          variant="elevated"
+          :color="item.scoreColor"
+          size="small"
+          density="compact"
+          class="mx-1"
+        >
+          Score: {{ item.scoreLabel }}
         </v-chip>
       </v-row>
     </v-row>

--- a/vue/src/components/PopUpComponent.vue
+++ b/vue/src/components/PopUpComponent.vue
@@ -73,15 +73,6 @@ const props = defineProps<{
         </v-chip>
         <v-chip
           label
-          :color="item.scoreColor"
-          size="small"
-          density="compact"
-          class="mx-1"
-        >
-          Score: {{ item.score?.toFixed(2) }}
-        </v-chip>
-        <v-chip
-          label
           color="black"
           variant="elevated"
           size="small"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -27,7 +27,6 @@ watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
     performer_ids: !val.length ? undefined : val.map((item) => item.id),
-    scoringColoring: null,
   };
 });
 watch (() => state.filters.regions, () => {
@@ -46,11 +45,10 @@ const updateRegion = (val?: Region) => {
   state.filters = {
     ...state.filters,
     regions: val === undefined ? undefined : [val],
-    scoringColoring: null,
   };
 };
 watch(drawSiteOutline, (val) => {
-  state.filters = { ...state.filters, drawSiteOutline: val, scoringColoring: null };
+  state.filters = { ...state.filters, drawSiteOutline: val };
 });
 const expandSettings = ref(false);
 
@@ -135,6 +133,11 @@ const toggleSites = () => {
 const toggleRegion = () => {
   const val = !state.filters.drawRegionPoly;
   state.filters = { ...state.filters, drawRegionPoly: val };
+}
+
+const toggleScoring = () => {
+  const val = state.filters.scoringColoring ? undefined : 'simple';
+  state.filters = { ...state.filters, scoringColoring: val };
 }
 
 
@@ -251,6 +254,26 @@ const toggleRegion = () => {
               @click="toggleRegion()"
             >
               Region
+            </v-chip>
+          </template>
+          <span>Toggle Region Polygons On/Off</span>
+        </v-tooltip>
+        <v-tooltip
+          v-if="scoringApp && state.filters.drawSiteOutline"
+          open-delay="100"
+          location="top"
+        >
+          <template #activator="{ props:subProps }">
+            <v-chip
+              v-bind="subProps"
+              density="compact"
+              size="small"
+              :color="state.filters.scoringColoring ? 'rgb(37, 99, 235)' : 'black'"
+              :variant="state.filters.scoringColoring ? 'elevated' : 'outlined'"
+              class="mx-1"
+              @click="toggleScoring()"
+            >
+              Scores
             </v-chip>
           </template>
           <span>Toggle Region Polygons On/Off</span>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -6,7 +6,7 @@ import RegionFilter from "./filters/RegionFilter.vue";
 import SettingsPanel from "./SettingsPanel.vue";
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
-import { ApiService, Performer, QueryArguments, Region } from "../client";
+import { Performer, QueryArguments, Region } from "../client";
 import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 
@@ -22,7 +22,6 @@ const queryFilters = computed<QueryArguments>(() => ({
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
-const drawSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
@@ -47,9 +46,6 @@ const updateRegion = (val?: Region) => {
     regions: val === undefined ? undefined : [val],
   };
 };
-watch(drawSiteOutline, (val) => {
-  state.filters = { ...state.filters, drawSiteOutline: val };
-});
 const expandSettings = ref(false);
 
 const imagesOn = computed({
@@ -77,67 +73,10 @@ onMounted(() => {
     }
   });
 });
-const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
-
-const toggleGroundTruth = async () => {
-  if (scoringApp.value) { 
-    const val = !state.filters.drawGroundTruth;
-    state.filters = { ...state.filters, drawGroundTruth: val };
-  } else {
-    // We need to find the ground-truth model and add it to the visible items
-    const request = await ApiService.getModelRuns({
-      limit: 10,
-      performer: queryFilters.value.performer,
-      region: queryFilters.value.region,
-      groundtruth: true
-    });
-    if (request.items.length) {
-      const id = request.items[0].id;
-      if (!state.filters.drawGroundTruth) {
-        if (state.openedModelRuns) {
-          state.openedModelRuns.add(id);
-        }
-        const configuration_id = Array.from(state.openedModelRuns);
-        state.filters = { ...state.filters, configuration_id};
-        state.filters = { ...state.filters, drawGroundTruth: true };
-      }
-      else if (state.filters.drawGroundTruth) {
-        if (state.openedModelRuns) {
-          if (state.openedModelRuns.has(id)) {
-            state.openedModelRuns.delete(id);
-          }
-        }
-        const configuration_id = Array.from(state.openedModelRuns);
-        state.filters = { ...state.filters, configuration_id};
-        state.filters = { ...state.filters, drawGroundTruth: false };
-      }
-    }
-  }
-}
 
 const toggleText = () => {
   const val = !state.filters.showText;
   state.filters = { ...state.filters, showText: val };
-}
-
-const toggleObs = () => {
-  const val = !state.filters.drawObservations;
-  state.filters = { ...state.filters, drawObservations: val };
-}
-
-const toggleSites = () => {
-  const val = !state.filters.drawSiteOutline;
-  state.filters = { ...state.filters, drawSiteOutline: val };
-}
-
-const toggleRegion = () => {
-  const val = !state.filters.drawRegionPoly;
-  state.filters = { ...state.filters, drawRegionPoly: val };
-}
-
-const toggleScoring = () => {
-  const val = state.filters.scoringColoring ? undefined : 'simple';
-  state.filters = { ...state.filters, scoringColoring: val };
 }
 
 
@@ -153,6 +92,7 @@ const toggleScoring = () => {
         dense
       >
         <img
+          height="50"
           class="mx-auto pb-4"
           src="../assets/logo.svg"
           alt="Resonant GeoData"
@@ -180,104 +120,6 @@ const toggleScoring = () => {
         align="center"
         class="py-2"
       >
-        <v-tooltip
-          open-delay="100"
-          location="top"
-        >
-          <template #activator="{ props:subProps }">
-            <v-chip
-              density="compact"
-              v-bind="subProps"
-              size="small"
-              :color="state.filters.drawObservations ? 'rgb(37, 99, 235)' : 'black'"
-              :variant="state.filters.drawObservations ? 'elevated' : 'outlined'"
-              class="mx-1"
-              @click="toggleObs()"
-            >
-              Obs
-            </v-chip>
-          </template>
-          <span>Toggle Site Observations on/off</span>
-        </v-tooltip>
-        <v-tooltip
-          open-delay="100"
-          location="top"
-        >
-          <template #activator="{ props:subProps }">
-            <v-chip
-              density="compact"
-              v-bind="subProps"
-              size="small"
-              :color="state.filters.drawSiteOutline ? 'rgb(37, 99, 235)' : 'black'"
-              :variant="state.filters.drawSiteOutline ? 'elevated' : 'outlined'"
-              class="mx-1"
-              @click="toggleSites()"
-            >
-              Site
-            </v-chip>
-          </template>
-          <span> Toggle Site Outlines On/Off</span>
-        </v-tooltip>
-
-        <v-tooltip
-          open-delay="100"
-          location="top"
-        >
-          <template #activator="{ props:subProps }">
-            <v-chip
-              v-if="state.filters.regions?.length"
-              v-bind="subProps"
-              density="compact"
-              :color="state.filters.drawGroundTruth ? 'rgb(37, 99, 235)' : 'black'"
-              size="small"
-              :variant="state.filters.drawGroundTruth ? 'elevated' : 'outlined'"
-              class="mx-1"
-              @click="toggleGroundTruth()"
-            >
-              GT
-            </v-chip>
-          </template>
-          <span>Toggle associated Ground Truth On/Off</span>
-        </v-tooltip>
-        <v-tooltip
-          open-delay="100"
-          location="top"
-        >
-          <template #activator="{ props:subProps }">
-            <v-chip
-              v-bind="subProps"
-              density="compact"
-              size="small"
-              :color="state.filters.drawRegionPoly ? 'rgb(37, 99, 235)' : 'black'"
-              :variant="state.filters.drawRegionPoly ? 'elevated' : 'outlined'"
-              class="mx-1"
-              @click="toggleRegion()"
-            >
-              Region
-            </v-chip>
-          </template>
-          <span>Toggle Region Polygons On/Off</span>
-        </v-tooltip>
-        <v-tooltip
-          v-if="scoringApp && state.filters.drawSiteOutline"
-          open-delay="100"
-          location="top"
-        >
-          <template #activator="{ props:subProps }">
-            <v-chip
-              v-bind="subProps"
-              density="compact"
-              size="small"
-              :color="state.filters.scoringColoring ? 'rgb(37, 99, 235)' : 'black'"
-              :variant="state.filters.scoringColoring ? 'elevated' : 'outlined'"
-              class="mx-1"
-              @click="toggleScoring()"
-            >
-              Scores
-            </v-chip>
-          </template>
-          <span>Toggle Region Polygons On/Off</span>
-        </v-tooltip>
         <v-spacer />
         <v-btn
           variant="text"
@@ -367,4 +209,22 @@ const toggleScoring = () => {
 .animate-flicker {
   animation: flicker-animation 1s infinite;
 }
+.layer-button {
+  border: 1px solid black;
+  padding-top:5px;
+  padding-bottom: 5px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.layer-header {
+  border: 2px solid black;
+  border-bottom: 2px double black;
+  padding-top:5px;
+  padding-bottom: 5px;
+  margin-left: auto;
+  margin-right: auto;
+
+}
+
 </style>

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -26,7 +26,6 @@ watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
     performer_ids: !val.length ? undefined : val.map((item) => item.id),
-    scoringColoring: null,
   };
 });
 watch (() => state.filters.regions, () => {
@@ -45,11 +44,10 @@ const updateRegion = (val?: Region) => {
   state.filters = {
     ...state.filters,
     regions: val === undefined ? undefined : [val],
-    scoringColoring: null,
   };
 };
 watch(drawSiteOutline, (val) => {
-  state.filters = { ...state.filters, drawSiteOutline: val, scoringColoring: null };
+  state.filters = { ...state.filters, drawSiteOutline: val };
 });
 
 function nextPage() {

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -21,7 +21,6 @@ const queryFilters = computed<QueryArguments>(() => ({
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
-const drawSiteOutline: Ref<boolean> = ref(false);
 watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
@@ -46,9 +45,6 @@ const updateRegion = (val?: Region) => {
     regions: val === undefined ? undefined : [val],
   };
 };
-watch(drawSiteOutline, (val) => {
-  state.filters = { ...state.filters, drawSiteOutline: val };
-});
 
 function nextPage() {
   page.value += 1;

--- a/vue/src/components/filters/PerformerFilter.vue
+++ b/vue/src/components/filters/PerformerFilter.vue
@@ -3,6 +3,7 @@ import { ref, watch, watchEffect } from "vue";
 import { ApiService, PerformerList } from "../../client";
 import type { Ref } from "vue";
 import type { Performer } from "../../client";
+import { state } from "../../store";
 
 type SelectedPerformers = Performer[];
 
@@ -27,6 +28,7 @@ watchEffect(async () => {
     performerIdMap[item.id] = item;
     performers.value.push({title: item.team_name, value: item.id });
   })
+  state.performerMapping = performerIdMap;
 });
 
 watch(selectedPerformers, () => {

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -131,11 +131,18 @@ const clickObservation = async (e: MapLayerMouseEvent) => {
   }
 
 }
+const drawSitePopupObservation = async (e: MapLayerMouseEvent) => {
+  if (e.features && e.features[0]?.properties && map.value) {
+    console.log(e.features);
+  }
+}
 
 let loadedFunctions: {
   id: string,
   mouseenter: (e: MapLayerMouseEvent) => Promise<void>;
   mouseleave: (e: MapLayerMouseEvent) => Promise<void>;
+  mouseenterSite: (e: MapLayerMouseEvent) => Promise<void>;
+  mouseleaveSite: (e: MapLayerMouseEvent) => Promise<void>;
   clickObservation: (e: MapLayerMouseEvent) => Promise<void>;
 }[] = []
 const setPopupEvents = (map: ShallowRef<null | Map>) => {
@@ -144,6 +151,8 @@ const setPopupEvents = (map: ShallowRef<null | Map>) => {
       const data = loadedFunctions[i];
       map.value.off("mouseenter", `observations-fill-${data.id}`, data.mouseenter);
       map.value.off("mouseleave", `observations-fill-${data.id}`, data.mouseleave);
+      map.value.on("mouseenter", `sites-outline-${data.id}`, data.mouseenterSite);
+      map.value.on("mouseleave", `sites-outline-${data.id}`, data.mouseenterSite);
       map.value.off("click", `observations-fill-${data.id}`, data.clickObservation);
     }
     loadedFunctions = []
@@ -151,8 +160,17 @@ const setPopupEvents = (map: ShallowRef<null | Map>) => {
       const id = m.split('|')[0];
       map.value.on("mouseenter", `observations-fill-${id}`, drawPopupObservation);
       map.value.on("mouseleave", `observations-fill-${id}`, drawPopupObservation);
+      map.value.on("mouseenter", `sites-outline-${id}`, drawSitePopupObservation);
+      map.value.on("mouseleave", `sites-outline-${id}`, drawSitePopupObservation);
+
       map.value.on("click", `observations-fill-${id}`, clickObservation);
-      loadedFunctions.push({id, mouseenter: drawPopupObservation, mouseleave: drawPopupObservation, clickObservation});
+      loadedFunctions.push({
+        id,
+        mouseenter: drawPopupObservation,
+        mouseleave: drawPopupObservation,
+        mouseenterSite: drawSitePopupObservation,
+        mouseleaveSite: drawSitePopupObservation,
+          clickObservation});
     }
   }
 }

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -1,15 +1,18 @@
-import { App, Ref,   nextTick, ref } from "vue";
+import { App, Ref,   nextTick, reactive, ref } from "vue";
 import { Color, Map, MapLayerMouseEvent, Popup } from "maplibre-gl";
 import { ShallowRef } from "vue";
 import { getSiteObservationDetails, selectedObservationList, state } from "../store";
 import  createPopup from '../main';
-import { PopUpData } from '../interactions/popUpType';
-import { styles } from "../mapstyle/annotationStyles";
+import { PopUpData, PopUpSiteData } from '../interactions/popUpType';
+import { scoringColors, scoringColorsKeys, styles } from "../mapstyle/annotationStyles";
 
 
   const hoveredInfo: Ref<{region: string[], siteId: string[]}> = ref({region: [], siteId:[]});
 
 let app: App | null = null;
+const popUpProps: Record<string, PopUpData> = reactive({});
+const popUpSiteProps: Record<string, PopUpSiteData> = reactive({});
+
 const calculateScoreColor = (score: number) => {
   if (score <= 0.25) {
     return "red";
@@ -35,7 +38,11 @@ const popupLogic = async (mapArg: ShallowRef<null | Map>) => {
   });
   map.value = mapArg.value;
 };
-const drawPopupObservation = async (e: MapLayerMouseEvent) => {
+
+const leavePopupObservation = async (e: MapLayerMouseEvent) => {
+ drawPopupObservation(e, true); 
+};
+const drawPopupObservation = async (e: MapLayerMouseEvent, remove=false) => {
   if (e.features && e.features[0]?.properties && map.value) {
     const coordinates = e.lngLat;
     const ids = [];
@@ -52,39 +59,45 @@ const drawPopupObservation = async (e: MapLayerMouseEvent) => {
         if (item.properties && item.properties.id) {
           const id = item.properties.site_number;
           const region: string = item.properties.region;
-          const score = item.properties.score;
-          const siteId = item.properties.siteeval_id;
-          const configName = item.properties.configuration_name;
-          const performerName = item.properties.performer_name;
-          const version = item.properties.version;
-          const siteLabel = item.properties.site_label;
-          hoveredInfo.value.region.push(
-            `${item.properties.configuration_id}_${region}_${item.properties.performer_id}`
-          );
-          hoveredInfo.value.siteId.push(siteId);
-          if (!htmlMap[id]) {
-            if (item.layer?.paint) {
-              const fillColor = item.layer?.paint["fill-color"] as Color;
-              if (fillColor) {
-                ids.push(id);
-                htmlMap[id] = true;
+          if (!remove) {
+            const score = item.properties.score;
+            const siteId = item.properties.siteeval_id;
+            const configName = item.properties.configuration_name;
+            const performerName = item.properties.performer_id;
+            const version = item.properties.version;
+            const siteLabel = item.properties.site_label;
+            hoveredInfo.value.region.push(
+              `${item.properties.configuration_id}_${region}_${item.properties.performer_id}`
+            );
+            hoveredInfo.value.siteId.push(siteId);
+            if (!htmlMap[id]) {
+              if (item.layer?.paint) {
+                const fillColor = item.layer?.paint["fill-color"] as Color;
+                if (fillColor) {
+                  ids.push(id);
+                  htmlMap[id] = true;
+                  }
+                  const area = Math.round(item.properties.area).toLocaleString('en-US');
+                  const data = {
+                    siteId: `${region}_${String(id).padStart(4, '0')}`,
+                    score,
+                    groundTruth: item.properties.groundtruth,
+                    obsColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
+                    siteColor: styles[siteLabel]?.color,
+                    scoreColor: calculateScoreColor(score),
+                    timestamp: item.properties.timestamp,
+                    area,
+                    version,
+                    configName,
+                    performerName,
+                    siteLabel,
                 }
-                const area = Math.round(item.properties.area).toLocaleString('en-US');
-                popupData.push({
-                  siteId: `${region}_${String(id).padStart(4, '0')}`,
-                  score,
-                  groundTruth: item.properties.groundtruth,
-                  obsColor: `rgb(${fillColor.r *255}, ${fillColor.g * 255}, ${fillColor.b * 255})`,
-                  siteColor: styles[siteLabel]?.color,
-                  scoreColor: calculateScoreColor(score),
-                  timestamp: item.properties.timestamp,
-                  area,
-                  version,
-                  configName,
-                  performerName,
-                  siteLabel,
-              })
+                popupData.push(data);
+                popUpProps[`${region}_${String(id).padStart(4, '0')}`] = data;
+              }
             }
+          } else {
+            delete popUpProps[`${region}_${String(id).padStart(4, '0')}`];
           }
         }
       }
@@ -95,12 +108,15 @@ const drawPopupObservation = async (e: MapLayerMouseEvent) => {
         app.unmount();
         app = null;
       }
-      app = createPopup(popupData);
+      app = createPopup(popUpProps, popUpSiteProps);
       app.mount('#popup-content');
     });
   } else if (map.value) {
     hoveredInfo.value.region = [];
     hoveredInfo.value.siteId = [];
+    for (const item in popUpProps) {
+      delete popUpProps[item];
+    }
     if (app !== null) {
       app.unmount();
       app = null;
@@ -131,11 +147,91 @@ const clickObservation = async (e: MapLayerMouseEvent) => {
   }
 
 }
-const drawSitePopupObservation = async (e: MapLayerMouseEvent) => {
-  if (e.features && e.features[0]?.properties && map.value) {
-    console.log(e.features);
-  }
+const removeSitePopupObservation = async (e: MapLayerMouseEvent) => {
+  drawSitePopupObservation(e, true);
 }
+
+const drawSitePopupObservation = async (e: MapLayerMouseEvent, remove=false) => {
+  if (e.features && e.features[0]?.properties && map.value) {
+    const coordinates = e.lngLat;
+    const ids = [];
+    const htmlMap: Record<string, boolean> = {};
+    hoveredInfo.value.region = [];
+    hoveredInfo.value.siteId = [];
+    const popupData: PopUpSiteData[] = [];
+    e.features.forEach(
+      (
+        item: GeoJSON.GeoJsonProperties & {
+          layer?: { paint?: { "fill-color"?: Color, 'line-color'?: Color } };
+        }
+      ) => {
+        if (item.properties && item.properties.id) {
+          const id = item.properties.site_number;
+          const region: string = item.properties.region;
+          if (!remove) {
+            const siteId = item.properties.siteeval_id;
+            const configName = item.properties.configuration_name;
+            const performerName = item.properties.performer_name;
+            const version = item.properties.version;
+            const siteLabel = item.properties.label;
+            hoveredInfo.value.region.push(
+              `${item.properties.configuration_id}_${region}_${item.properties.performer_id}`
+            );
+            hoveredInfo.value.siteId.push(siteId);
+            if (!htmlMap[id]) {
+              if (item.layer?.paint) {
+                  ids.push(id);
+                  htmlMap[id] = true;
+                  }
+                  const start_date = item.properties.start_date ? item.properties.start_date .substring(0, 10) : 'null';
+                  const end_date = item.properties.end_date ? item.properties.end_date.substring(0, 10) : 'null';
+                  const colorCode = item.properties.color_code as scoringColorsKeys;
+                  const scoreColor  = scoringColors[colorCode] ? scoringColors[colorCode].hex : undefined
+                  const scoreLabel  = scoringColors[colorCode] ? scoringColors[colorCode].title : undefined
+                  const data = {
+                    siteId: `${region}_${String(id).padStart(4, '0')}`,
+                    groundTruth: item.properties.groundtruth,
+                    siteColor: styles[siteLabel]?.color,
+                    timeRange: `${start_date} to ${end_date}`,
+                    version,
+                    configName,
+                    performerName,
+                    scoreColor,
+                    scoreLabel,
+                    siteLabel,
+                }
+                popupData.push(data);
+                popUpSiteProps[`${region}_${String(id).padStart(4, '0')}`] = data;
+            }
+          } else {
+            delete popUpSiteProps[`${region}_${String(id).padStart(4, '0')}`];
+          }
+        }
+      }
+    );
+    popup.setLngLat(coordinates).setHTML('<div id="popup-content"></div>').addTo(map.value);
+    nextTick(() => {
+      if (app !== null) {
+        app.unmount();
+        app = null;
+      }
+      app = createPopup(popUpProps, popUpSiteProps);
+      app.mount('#popup-content');
+    });
+  } else if (map.value) {
+    hoveredInfo.value.region = [];
+    hoveredInfo.value.siteId = [];
+    for (const item in popUpSiteProps) {
+      delete popUpSiteProps[item];
+    }
+    if (app !== null) {
+      app.unmount();
+      app = null;
+    }
+    map.value.getCanvas().style.cursor = "";
+    popup.remove();
+  }
+};
 
 let loadedFunctions: {
   id: string,
@@ -151,25 +247,25 @@ const setPopupEvents = (map: ShallowRef<null | Map>) => {
       const data = loadedFunctions[i];
       map.value.off("mouseenter", `observations-fill-${data.id}`, data.mouseenter);
       map.value.off("mouseleave", `observations-fill-${data.id}`, data.mouseleave);
-      map.value.on("mouseenter", `sites-outline-${data.id}`, data.mouseenterSite);
-      map.value.on("mouseleave", `sites-outline-${data.id}`, data.mouseenterSite);
+      map.value.off("mouseenter", `sites-fill-${data.id}`, data.mouseenterSite);
+      map.value.off("mouseleave", `sites-fill-${data.id}`, data.mouseenterSite);
       map.value.off("click", `observations-fill-${data.id}`, data.clickObservation);
     }
     loadedFunctions = []
     for (const m of state.openedModelRuns) {
       const id = m.split('|')[0];
       map.value.on("mouseenter", `observations-fill-${id}`, drawPopupObservation);
-      map.value.on("mouseleave", `observations-fill-${id}`, drawPopupObservation);
-      map.value.on("mouseenter", `sites-outline-${id}`, drawSitePopupObservation);
-      map.value.on("mouseleave", `sites-outline-${id}`, drawSitePopupObservation);
+      map.value.on("mouseleave", `observations-fill-${id}`, leavePopupObservation);
+      map.value.on("mouseenter", `sites-fill-${id}`, drawSitePopupObservation);
+      map.value.on("mouseleave", `sites-fill-${id}`, removeSitePopupObservation);
 
       map.value.on("click", `observations-fill-${id}`, clickObservation);
       loadedFunctions.push({
         id,
         mouseenter: drawPopupObservation,
-        mouseleave: drawPopupObservation,
+        mouseleave: leavePopupObservation,
         mouseenterSite: drawSitePopupObservation,
-        mouseleaveSite: drawSitePopupObservation,
+        mouseleaveSite: removeSitePopupObservation,
           clickObservation});
     }
   }

--- a/vue/src/interactions/popUpType.ts
+++ b/vue/src/interactions/popUpType.ts
@@ -12,5 +12,17 @@ export interface PopUpData {
     configName: string,
     performerName: string,
     siteLabel: string,
-
   }  
+
+export interface PopUpSiteData {
+  siteId: string,
+  groundTruth: boolean,
+  performerName: string,
+  timeRange: string;
+  version: string,
+  configName: string;
+  siteLabel: string;
+  siteColor: string;
+  scoreLabel?: string;
+  scoreColor?:string;
+}

--- a/vue/src/main.ts
+++ b/vue/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from "vue";
 import "./index.css";
 import App from "./App.vue";
 import PopupComponent from "./components/PopUpComponent.vue";
-import { PopUpData } from './interactions/popUpType';
+import { PopUpData, PopUpSiteData } from './interactions/popUpType';
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
@@ -17,8 +17,8 @@ const vuetify = createVuetify({
 createApp(App).use(vuetify).use(router).mount('#app')
 
 
-const createPopup = (data: PopUpData[]) =>  {
-return createApp(PopupComponent, {data}).use(vuetify);
+const createPopup = (data: Record<string, PopUpData>, siteData: Record<string, PopUpSiteData>) =>  {
+return createApp(PopupComponent, {data, siteData}).use(vuetify);
 }
 
 export default createPopup;

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -101,26 +101,121 @@ const styles: AnnotationStyle = {
   },
 };
 
+const scoringColors = {
+  2: {
+    color: 'lime',
+    title: 'True Positive (GT)',
+    hex: '#2AFF00',
+    description:'Positive site successfully detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  3: {
+    color: 'black',
+    hex: '#000000',
+    title: 'False Negative (GT)',
+    description:'Positive site not detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  5: {
+    color: 'red',
+    hex: '#FF0000',
+    title: 'False Positive (GT)',
+    description:'Negative annotation detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  7: {
+    color: 'thistle',
+    hex: '#CAA7FF',
+    title: 'Positive Site - Unbounded (GT)',
+    description:'Positive site - incomplete activity (GT)',
+    simple: false,
+    detailed: true,
+  },
+  10: {
+    color: 'salmon',
+    hex: '#FF8686',
+    title: 'Ignore Area (GT)',
+    description:'Ignore Area (GT)',
+    simple: false,
+    detailed: true,
+  },
+  14: {
+    color: 'lime',
+    title: 'True Positive (GT)',
+    hex: '#2AFF00',
+    description:'Positive site successfully detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  15: {
+    color: 'black',
+    hex: '#000000',
+    title: 'False Negative (GT)',
+    description:'Positive site not detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  17: {
+    hex: '#FF0000',
+    title: 'False Positive (GT)',
+    description:'Negative annotation detected (GT)',
+    simple: true,
+    detailed: true,
+  },
+  19: {
+    color: 'salmon',
+    hex: '#FF8686',
+    title: 'Ignore Area (GT)',
+    description:'Ignore Area (GT)',
+    simple: false,
+    detailed: true,
+  },
+  22: {
+    color: 'magenta',
+    hex: '#D53FFF',
+    title: 'False Positive (Proposal)',
+    description:'False Positive (Proposal)',
+    simple: true,
+    detailed: true,
+  },
+  23: {
+    color: 'orange',
+    title: 'Partial Positive (Proposal)',
+    hex: '#FF9033',
+    description:'Partial positive - Associates with both a positive site and a negative site (Proposal)',
+    simple: false,
+    detailed: true,
+  },
+  24: {
+    color: 'aquamarine',
+    hex: '#33FFEF',
+    title: 'True Positive (Proposal)',
+    description:'True Positive (Proposal)',
+    simple: false,
+    detailed: true,
+  },
+  25: {
+    color: 'magenta',
+    hex: '#D53FFF',
+    title: 'False Positive (Proposal)',
+    description:'False Positive (Proposal)',
+    simple: false,
+    detailed: true,
+  },
+}
+
 const getAnnotationColor = (filters: MapFilters) => {
     const result = [];
     result.push('case');
     if (filters.scoringColoring) {
-        const baseScore = Object.values(filters.scoringColoring)
-        baseScore.forEach((base) => {
-            Object.entries(base).forEach(([key, value]) => {
-                const splits = key.split('_').map((item) => parseInt(item));
-                if (splits.length === 4) {
-                    result.push(['all',
-                        ['==', ['get', 'configuration_id'], splits[0]],
-                        ['==', ['get', 'region'], splits[1]],
-                        ['==', ['get', 'performer_id'], splits[2]],
-                        ['==', ['get', 'site_number'], splits[3]],
-                    ]);
-                    result.push(value);
-                }
-            });
-        });
-    }
+      Object.entries(scoringColors).forEach(([id, { hex }]) => {
+        result.push(['==', ['get', 'color_code'], parseInt(id, 10)])
+        result.push(hex)
+      })
+    } 
     Object.entries(styles).forEach(([label, { color }]) => {
         result.push(['==', ['get', 'label'], label]);
         result.push(color);
@@ -155,12 +250,12 @@ const createAnnotationLegend = () => {
             siteLegend.push({color: color, name: label})
         }
     });
-    const scoringLegend = [
-        { name:'Ignore', color:'lightsalmon' },
-        { name:'Positive Match', color:'#66CCAA' },
-        { name:'Partially Wrong', color:'orange' },
-        { name:'Completely Wrong', color:'magenta' },
-    ]
+    const scoringLegend: {color: string, name: string}[] = [];
+    Object.values(scoringColors).forEach((data) => {
+      if (scoringLegend.findIndex((item) => item.color === data.hex && item.name === data.title) === -1) {
+          scoringLegend.push({ name: data.title, color: data.hex});
+      }
+    })
     return { observationLegend, scoringLegend, siteLegend }
 }
 const annotationLegend = createAnnotationLegend();
@@ -172,6 +267,8 @@ const getColorFromName = ((label: string) => {
 })
 
 const getColorFromLabel = ((label: string) => styles[label]?.color || getColorFromName(label) || 'white');
+
+
 
 export {
     annotationColors,

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -101,6 +101,7 @@ const styles: AnnotationStyle = {
   },
 };
 
+export type scoringColorsKeys = keyof typeof scoringColors;
 const scoringColors = {
   2: {
     color: 'lime',

--- a/vue/src/mapstyle/annotationStyles.ts
+++ b/vue/src/mapstyle/annotationStyles.ts
@@ -109,6 +109,7 @@ const scoringColors = {
     description:'Positive site successfully detected (GT)',
     simple: true,
     detailed: true,
+    id: 2,
   },
   3: {
     color: 'black',
@@ -117,6 +118,7 @@ const scoringColors = {
     description:'Positive site not detected (GT)',
     simple: true,
     detailed: true,
+    id: 3,
   },
   5: {
     color: 'red',
@@ -125,6 +127,7 @@ const scoringColors = {
     description:'Negative annotation detected (GT)',
     simple: true,
     detailed: true,
+    id: 5,
   },
   7: {
     color: 'thistle',
@@ -133,6 +136,7 @@ const scoringColors = {
     description:'Positive site - incomplete activity (GT)',
     simple: false,
     detailed: true,
+    id: 7,
   },
   10: {
     color: 'salmon',
@@ -141,6 +145,7 @@ const scoringColors = {
     description:'Ignore Area (GT)',
     simple: false,
     detailed: true,
+    id: 10,
   },
   14: {
     color: 'lime',
@@ -149,6 +154,7 @@ const scoringColors = {
     description:'Positive site successfully detected (GT)',
     simple: true,
     detailed: true,
+    id: 14,
   },
   15: {
     color: 'black',
@@ -157,6 +163,7 @@ const scoringColors = {
     description:'Positive site not detected (GT)',
     simple: true,
     detailed: true,
+    id: 15,
   },
   17: {
     hex: '#FF0000',
@@ -164,6 +171,7 @@ const scoringColors = {
     description:'Negative annotation detected (GT)',
     simple: true,
     detailed: true,
+    id: 17,
   },
   19: {
     color: 'salmon',
@@ -172,6 +180,7 @@ const scoringColors = {
     description:'Ignore Area (GT)',
     simple: false,
     detailed: true,
+    id: 19,
   },
   22: {
     color: 'magenta',
@@ -180,6 +189,7 @@ const scoringColors = {
     description:'False Positive (Proposal)',
     simple: true,
     detailed: true,
+    id: 22,
   },
   23: {
     color: 'orange',
@@ -188,6 +198,7 @@ const scoringColors = {
     description:'Partial positive - Associates with both a positive site and a negative site (Proposal)',
     simple: false,
     detailed: true,
+    id: 23,
   },
   24: {
     color: 'aquamarine',
@@ -196,6 +207,7 @@ const scoringColors = {
     description:'True Positive (Proposal)',
     simple: false,
     detailed: true,
+    id: 24,
   },
   25: {
     color: 'magenta',
@@ -204,6 +216,7 @@ const scoringColors = {
     description:'False Positive (Proposal)',
     simple: false,
     detailed: true,
+    id: 25,
   },
 }
 
@@ -277,4 +290,5 @@ export {
     siteText,
     getColorFromLabel,
     styles,
+    scoringColors,
 }

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -264,6 +264,18 @@ export const buildLayerFilter = (
         },
         filter: buildSiteFilter(timestamp, filters),
       },
+      // Site fill is added for Hover Popup to work on the area inside the polygon
+      {
+        id: `sites-fill-${id}`,
+        type: "fill",
+        source: `vectorTileSource_${id}`,
+        "source-layer": `sites-${id}`,
+        paint: {
+          "fill-color": annotationColors(filters),
+          "fill-opacity": 0,
+        },
+        filter: buildSiteFilter(timestamp, filters),
+      },
     ]);
     if (filters.showText) {
       results = results.concat([{

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -13,6 +13,7 @@ import type { MapFilters } from "../store";
 import {
   annotationColors,
   observationText,
+  scoringColors,
   siteText,
 } from "./annotationStyles";
 import { ApiService } from '../client/services/ApiService';
@@ -59,24 +60,20 @@ export const buildObservationFilter = (
       [">", ["get", "timemax"], timestamp],
     ],
   ];
-  // If Scoring App and have ground truth we filter it out if the drawGT is false
-  if (ApiService.apiPrefix.includes('scoring')) {
-    if (!filters.drawGroundTruth && filters.drawObservations) {
-      filter.push([
-          "any",
-          ["==", ["get", "groundtruth"], false]
-        ]
-      ); 
-    } else if (!filters.drawObservations && filters.drawGroundTruth && !filters.drawSiteOutline) {
-      filter.push([
+  const hasGroundTruth = filters.drawObservations?.includes('groundtruth');
+  const hasModel = filters.drawObservations?.includes('model');
+  if (!hasGroundTruth && hasModel) {
+    filter.push([
         "any",
-        ["==", ["get", "groundtruth"], true]
-      ]); 
-    }
-    else if ((!filters.drawObservations && !filters.drawGroundTruth) || (!filters.drawObservations  && filters.drawGroundTruth && filters.drawSiteOutline)) {
-      return false;
-    }
-  } else if (!filters.drawObservations) {
+        ["==", ["get", "groundtruth"], false]
+      ]
+    ); 
+  } else if (!hasModel && hasGroundTruth) {
+    filter.push([
+      "any",
+      ["==", ["get", "groundtruth"], true]
+    ]); 
+  } else if (!hasModel && !hasGroundTruth) {
     return false;
   }
 
@@ -97,24 +94,64 @@ export const buildSiteFilter = (
         filters.configuration_id?.length ? filters.configuration_id : [""],
       ],
     ],
-    [
+  ];
+
+  const hasGroundTruth = filters.drawSiteOutline?.includes('groundtruth');
+  const hasModel = filters.drawSiteOutline?.includes('model');
+  if (!filters.drawSiteOutline && !filters.scoringColoring) {
+    return false;
+  }
+  // Scoring:  we need to draw ground truth and sites but filter based on simple/detailed coloring props
+  if (filters.scoringColoring) {
+    filter.push([
+      "any",
+      ["get", "site_polygon"],
+      ["literal", true],
+      ]
+    );
+    // Next filter on the color_code being either simple or detailed
+    const filtered = Object.values(scoringColors).filter((item) => (item.simple && filters.scoringColoring === 'simple') || (item.detailed && filters.scoringColoring === 'detailed'))
+    const renderColorCodes = filtered.map((item) => item.id)
+    // Now we only display items with matching colorcode;
+    filter.push(
+      [
+        "in",
+        ["get", "color_code"],
+        [
+          "literal",
+          renderColorCodes
+        ],
+      ],
+    )
+    return filter;
+
+  }
+
+  if (hasModel) {
+    filter.push([
       "any",
       // When the site_polygon attribute is present, that indicates that there are no
       // observations associated with this model run and that the main site polygon
       // should be rendered regardless of timestamp
       ["get", "site_polygon"],
       ["literal", !!filters.drawSiteOutline],
-      ],
-  ];
+      ]
+    )
+  }
 
-  if (ApiService.apiPrefix.includes('scoring')) {
-    if (!filters.drawGroundTruth) {
-      filter.push([
-          "any",
-          ["==", ["get", "groundtruth"], false]
-        ]
-      );
-    }
+  if (!hasGroundTruth && hasModel) {
+    filter.push([
+        "any",
+        ["==", ["get", "groundtruth"], false]
+      ]
+    ); 
+  } else if (!hasModel && hasGroundTruth) {
+    filter.push([
+      "any",
+      ["==", ["get", "groundtruth"], true]
+    ]); 
+  } else if (!hasModel && !hasGroundTruth && !filters.scoringColoring) {
+    return false;
   }
 
   return filter;

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -1,20 +1,19 @@
 import { computed, reactive } from "vue";
 
-import { ApiService, ModelRun, Region } from "./client";
+import { ApiService, ModelRun, Performer, Region } from "./client";
 
 export interface MapFilters {
   configuration_id?: string[];
   performer_ids?: number[];
   regions?: Region[];
-  drawSiteOutline?: boolean;
+  drawSiteOutline?: string[]; //looking for either 'model' | 'groundtruth'
+  drawObservations?: string[]; //looking for either 'model' | 'groundtruth'
+  scoringColoring?: 'simple' | 'detailed';
   groundTruthPattern?: boolean;
-  drawGroundTruth?: boolean;
-  drawObservations?: boolean;
   drawRegionPoly?: boolean;
   otherPattern?: boolean;
   hoverSiteId?: string;
   showText?: boolean;
-  scoringColoring?: 'simple' | 'detailed';
 }
 
 export interface SatelliteTimeStamp {
@@ -152,6 +151,7 @@ export const state = reactive<{
   modelRuns: KeyedModelRun[],
   openedModelRuns: Set<KeyedModelRun["key"]>
   gifSettings: { fps: number, quality: number},
+  performerMapping: Record<number, Performer>,
 }>({
   timestamp: Math.floor(Date.now() / 1000),
   timeMin: new Date(0).valueOf(),
@@ -165,8 +165,8 @@ export const state = reactive<{
     ymax: 90,
   },
   filters: {
-    drawObservations: true,
-    drawSiteOutline: false,
+    drawObservations: ['model'],
+    drawSiteOutline: undefined,
     groundTruthPattern: false,
     otherPattern: false,
     showText: false,
@@ -199,7 +199,8 @@ export const state = reactive<{
   loopingId: null,
   modelRuns: [],
   openedModelRuns: new Set<KeyedModelRun["key"]>(),
-  gifSettings: { fps: 1, quality: 1}
+  gifSettings: { fps: 1, quality: 1},
+  performerMapping: {},
 });
 
 export const filteredSatelliteTimeList = computed(() => {

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -14,7 +14,7 @@ export interface MapFilters {
   otherPattern?: boolean;
   hoverSiteId?: string;
   showText?: boolean;
-  scoringColoring?: Record<string, Record<string, string>> | null;
+  scoringColoring?: 'simple' | 'detailed';
 }
 
 export interface SatelliteTimeStamp {

--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -30,7 +30,6 @@ onMounted(() => {
     state.filters = {
       ...state.filters,
       regions: [props.region],
-      scoringColoring: null,
     };
   }
 });

--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -2,6 +2,7 @@
 import SideBar from "../components/SideBar.vue"
 import MapLibre from "../components/MapLibre.vue";
 import RightBar from "../components/RightBar.vue"
+import LayerSelection from "../components/LayerSelection.vue";
 import { onMounted } from "vue";
 import { state } from "../store";
 
@@ -37,6 +38,7 @@ onMounted(() => {
     <SideBar />
   </v-navigation-drawer>
   <v-main style="z-index:1">
+    <layer-selection />
     <MapLibre />
   </v-main>
   <RightBar />

--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -19,7 +19,6 @@ onMounted(() => {
     state.filters = {
       ...state.filters,
       regions: [props.region],
-      scoringColoring: null,
     };
   }
 });


### PR DESCRIPTION

Notes:

- Added a `Case(` to the scoring vector_tile endpoint for the color_code parameter.  It needs to check two different tables based on if it is ground truth or not.
- Modified Vector Tile to also return more data for the `sites` so a popup can be used properly.  This included stuff like configuraiton_name, and performer_name
- I removed a lot of the older ScoreColoring logic from the front-end because it is no longer needed.
- Refactored the `drawObservations` and `drawSitePolygons` to be undefined or an array consisting of 'model or 'groundtruth'.  This allows for different combinations of the 4 states to be drawn at once.
- LayerSelection.vue component is used to manage the layers being shown.
- I added the performerMap to the store because I needed a reference to the performer name instead of the ID for some stuff being used in LayerSelection.
- I had to add a site-fille-layer to the rendering for popup windows to work properly with sites themsevles.
- I modified the Popup rendering to pass props from both the site observations and the sit models.  In the future I may modify it further to make it a bit more performant and work with mousemove inside of sites. 
