### PR TITLE
Fix date picker on download image prompt

### DIFF
--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -24,7 +24,7 @@ const bboxScale: Ref<number> = ref(1.2);
 const validForm = ref(true);
 
 const download = () => {
-    
+
     emit('download', {
         constellation: selectedSource.value,
         dayRange: dayRange.value,
@@ -89,7 +89,7 @@ const display = ref(true);
                 hint="Force redownloading all images"
                 persistent-hint
               />
-            </v-row>        
+            </v-row>
             <v-row
               dense
               align="center"
@@ -102,7 +102,7 @@ const display = ref(true);
                 label="Bit Scaling"
                 persistent-hint
               />
-            </v-row>    
+            </v-row>
             <v-row
               v-if="scale==='custom'"
               dense
@@ -122,7 +122,7 @@ const display = ref(true);
                 label="high"
                 class="mx-2"
               />
-            </v-row>    
+            </v-row>
             <v-row
               dense
               align="center"
@@ -150,7 +150,7 @@ const display = ref(true);
                   Adds a scaling factor to the calculating bounding box to provide more image area around site
                 </span>
               </v-tooltip>
-            </v-row>    
+            </v-row>
 
             <v-row
               dense
@@ -214,6 +214,7 @@ const display = ref(true);
               <v-row dense>
                 <v-menu
                   open-delay="20"
+                  :close-on-content-click="false"
                 >
                   <template #activator="{ props }">
                     <v-btn
@@ -233,6 +234,7 @@ const display = ref(true);
                 </v-menu>
                 <v-menu
                   open-delay="20"
+                  :close-on-content-click="false"
                 >
                   <template #activator="{ props }">
                     <v-btn


### PR DESCRIPTION
Fix the date picker closing the menu if anything except a day on the calendar was clicked