### PR TITLE
Add global error handler/popup snackbar

### DIFF
--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,10 +1,24 @@
 <script setup lang="ts">
+import ErrorPopup from './components/ErrorPopup.vue';
+
+import { onErrorCaptured, ref } from "vue";
+
+const errorText = ref('');
+
+onErrorCaptured((err) => {
+  errorText.value = [err.name, err.message, err.stack, err.cause].join('\n\n');
+  throw err;
+});
 </script>
 
 <template>
-  <v-app
-    id="RGD"
-  >
-    <router-view />
-  </v-app>
+  <div>
+    <ErrorPopup
+      :error-text="errorText"
+      @close="errorText = ''"
+    />
+    <v-app id="RGD">
+      <router-view />
+    </v-app>
+  </div>
 </template>

--- a/vue/src/components/ErrorPopup.vue
+++ b/vue/src/components/ErrorPopup.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+defineProps<{
+  errorText: string
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+
+function copyToClipboard(text: string) {
+  navigator.clipboard.writeText(text);
+}
+</script>
+
+<template>
+  <v-snackbar
+    absolute
+    multi-line
+    location="top right"
+    :model-value="!!errorText"
+    vertical
+    :timeout="-1"
+    color="error"
+  >
+    <div class="mb-5">
+      <span class="text-h5">An error has occurred.</span>
+      <br>
+      <span class="text-body-1">If you'd like to file a bug report, please copy the error trace below by clicking the copy button and include it in your report.</span>
+    </div>
+    <v-divider />
+    <div class="d-flex">
+      <div class="d-flex align-center mr-3">
+        <v-tooltip
+          text="Copy to clipboard"
+          location="start"
+        >
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+              size="x-large"
+              icon="mdi-content-copy"
+              @click="copyToClipboard(errorText)"
+            />
+          </template>
+        </v-tooltip>
+      </div>
+      <div
+        class="overflow-auto"
+        style="max-height: 40vh; white-space: pre-line;"
+      >
+        {{ errorText }}
+      </div>
+    </div>
+    <template #actions>
+      <v-btn
+        color="info"
+        variant="text"
+        @click="emit('close')"
+      >
+        Close
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>

--- a/vue/src/components/ErrorPopup.vue
+++ b/vue/src/components/ErrorPopup.vue
@@ -54,7 +54,7 @@ function copyToClipboard(text: string) {
     <template #actions>
       <v-btn
         color="info"
-        variant="text"
+        variant="flat"
         @click="emit('close')"
       >
         Close


### PR DESCRIPTION
This configures the Vue app with a global error handler that will catch any JavaScript errors that are thrown and render them in a UI popup. A copy-to-clipboard button is included to make including these errors in bug reports easier.

Here's an example of a background request failing:

https://github.com/ResonantGeoData/RD-WATCH/assets/37340715/d94be735-5dca-4ac4-a9cf-d4f01e7d5631

And here's an example of an error with a longer stack trace to demonstrate the scrolling functionality (i inserted a `throw Error('...')` manually here)

https://github.com/ResonantGeoData/RD-WATCH/assets/37340715/2dd6ef66-2c57-43ed-8132-46c198df8ca4

