### PR TITLE
Redesign error popup UI

### DIFF
--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import ErrorPopup from './components/ErrorPopup.vue';
 import { state } from './store';
 
 import { onErrorCaptured } from "vue";
@@ -15,10 +14,7 @@ onErrorCaptured((err) => {
 </script>
 
 <template>
-  <div>
-    <ErrorPopup />
-    <v-app id="RGD">
-      <router-view />
-    </v-app>
-  </div>
+  <v-app id="RGD">
+    <router-view />
+  </v-app>
 </template>

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -6,7 +6,11 @@ import { onErrorCaptured, ref } from "vue";
 const errorText = ref('');
 
 onErrorCaptured((err) => {
-  errorText.value = [err.name, err.message, err.stack, err.cause].join('\n\n');
+  const error: Record<string, string> = {};
+  for (const [key, val] of Object.entries(err)) {
+    error[key] = JSON.stringify(val);
+  }
+  errorText.value = JSON.stringify(error);
   throw err;
 });
 </script>

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,26 +1,22 @@
 <script setup lang="ts">
 import ErrorPopup from './components/ErrorPopup.vue';
+import { state } from './store';
 
-import { onErrorCaptured, ref } from "vue";
-
-const errorText = ref('');
+import { onErrorCaptured } from "vue";
 
 onErrorCaptured((err) => {
   const error: Record<string, string> = {};
   for (const [key, val] of Object.entries(err)) {
     error[key] = JSON.stringify(val);
   }
-  errorText.value = JSON.stringify(error);
+  state.errorText = JSON.stringify(error);
   throw err;
 });
 </script>
 
 <template>
   <div>
-    <ErrorPopup
-      :error-text="errorText"
-      @close="errorText = ''"
-    />
+    <ErrorPopup />
     <v-app id="RGD">
       <router-view />
     </v-app>

--- a/vue/src/components/ErrorPopup.vue
+++ b/vue/src/components/ErrorPopup.vue
@@ -10,9 +10,10 @@ function copyToClipboard(text: string) {
   <v-dialog width="500">
     <template #activator="{ props }">
       <v-btn
+        v-show="state.errorText"
         v-bind="props"
         icon="mdi-alert"
-        location="top right"
+        location="top left"
         position="absolute"
         class="ma-4"
         :color="state.errorText ? 'warning' : 'default'"

--- a/vue/src/components/ErrorPopup.vue
+++ b/vue/src/components/ErrorPopup.vue
@@ -13,52 +13,61 @@ function copyToClipboard(text: string) {
 </script>
 
 <template>
-  <v-snackbar
-    absolute
-    multi-line
-    location="top right"
-    :model-value="!!errorText"
-    vertical
-    :timeout="-1"
-    color="error"
-  >
-    <div class="mb-5">
-      <span class="text-h5">An error has occurred.</span>
-      <br>
-      <span class="text-body-1">If you'd like to file a bug report, please copy the error trace below by clicking the copy button and include it in your report.</span>
-    </div>
-    <v-divider />
-    <div class="d-flex">
-      <div class="d-flex align-center mr-3">
-        <v-tooltip
-          text="Copy to clipboard"
-          location="start"
-        >
-          <template #activator="{ props }">
-            <v-btn
-              v-bind="props"
-              size="x-large"
-              icon="mdi-content-copy"
-              @click="copyToClipboard(errorText)"
-            />
-          </template>
-        </v-tooltip>
-      </div>
-      <div
-        class="overflow-auto"
-        style="max-height: 40vh; white-space: pre-line;"
-      >
-        {{ errorText }}
-      </div>
-    </div>
-    <template #actions>
+  <v-dialog width="500">
+    <template #activator="{ props }">
       <v-btn
-        color="info"
-        variant="flat"
-        @click="emit('close')"
-      >
-        Close
-      </v-btn>
+        v-bind="props"
+        icon="mdi-alert"
+        location="top right"
+        position="absolute"
+        class="ma-4"
+        :color="errorText ? 'warning' : 'default'"
+        style="z-index: 2;"
+        :disabled="!errorText"
+      />
     </template>
-  </v-snackbar>
+
+    <template #default="{ isActive }">
+      <v-card title="Error">
+        <v-card-text>
+          <div class="mb-5">
+            <span class="text-body-1">If you'd like to file a bug report, please copy the error trace below by clicking the copy button and include it in your report.</span>
+          </div>
+          <v-divider />
+          <div class="d-flex">
+            <div class="d-flex align-center mr-3">
+              <v-tooltip
+                text="Copy to clipboard"
+                location="start"
+              >
+                <template #activator="{ props }">
+                  <v-btn
+                    v-bind="props"
+                    size="x-large"
+                    icon="mdi-content-copy"
+                    @click="copyToClipboard(errorText)"
+                  />
+                </template>
+              </v-tooltip>
+            </div>
+            <div
+              class="overflow-auto"
+              style="max-height: 40vh; white-space: pre-line;"
+            >
+              {{ errorText }}
+            </div>
+          </div>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+
+          <v-btn
+            text="Close"
+            @click="isActive.value = false; emit('close')"
+          />
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-dialog>
 </template>

--- a/vue/src/components/ErrorPopup.vue
+++ b/vue/src/components/ErrorPopup.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-defineProps<{
-  errorText: string
-}>();
-
-const emit = defineEmits<{
-  (e: "close"): void;
-}>();
+import { state } from '../store';
 
 function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
@@ -21,9 +15,9 @@ function copyToClipboard(text: string) {
         location="top right"
         position="absolute"
         class="ma-4"
-        :color="errorText ? 'warning' : 'default'"
+        :color="state.errorText ? 'warning' : 'default'"
         style="z-index: 2;"
-        :disabled="!errorText"
+        :disabled="!state.errorText"
       />
     </template>
 
@@ -45,7 +39,7 @@ function copyToClipboard(text: string) {
                     v-bind="props"
                     size="x-large"
                     icon="mdi-content-copy"
-                    @click="copyToClipboard(errorText)"
+                    @click="copyToClipboard(state.errorText)"
                   />
                 </template>
               </v-tooltip>
@@ -54,7 +48,7 @@ function copyToClipboard(text: string) {
               class="overflow-auto"
               style="max-height: 40vh; white-space: pre-line;"
             >
-              {{ errorText }}
+              {{ state.errorText }}
             </div>
           </div>
         </v-card-text>
@@ -64,7 +58,7 @@ function copyToClipboard(text: string) {
 
           <v-btn
             text="Close"
-            @click="isActive.value = false; emit('close')"
+            @click="isActive.value = false; state.errorText = ''"
           />
         </v-card-actions>
       </v-card>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -4,6 +4,7 @@ import TimeSlider from "./TimeSlider.vue";
 import PerformerFilter from "./filters/PerformerFilter.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
 import SettingsPanel from "./SettingsPanel.vue";
+import ErrorPopup from './ErrorPopup.vue';
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
 import { Performer, QueryArguments, Region } from "../client";
@@ -91,6 +92,7 @@ const toggleText = () => {
       <v-row
         dense
       >
+        <ErrorPopup />
         <img
           height="50"
           class="mx-auto pb-4"

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -131,6 +131,7 @@ export interface KeyedModelRun extends ModelRun {
 }
 
 export const state = reactive<{
+  errorText: string;
   timestamp: number;
   timeMin: number;
   settings: {
@@ -154,6 +155,7 @@ export const state = reactive<{
   gifSettings: { fps: number, quality: number},
   performerMapping: Record<number, Performer>,
 }>({
+  errorText: '',
   timestamp: Math.floor(Date.now() / 1000),
   timeMin: new Date(0).valueOf(),
   settings: {


### PR DESCRIPTION
Moves the error popup into a dialog that the user must open themselves. When an error occurs, the button in the top right corner will become clickable. If the user clicks it, a popup dialog will appear with the error text. 

Demo:

![error1](https://github.com/ResonantGeoData/RD-WATCH/assets/37340715/e901b976-d7d7-4b0d-86c1-10e932e0b541)

