### PR TITLE
Include more error info in popup

### DIFF
--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -8,6 +8,8 @@ onErrorCaptured((err) => {
   for (const [key, val] of Object.entries(err)) {
     error[key] = JSON.stringify(val);
   }
+  // Also include a string-ified version of the exception object.
+  error['error_string'] = err.toString();
   state.errorText = JSON.stringify(error);
   throw err;
 });


### PR DESCRIPTION
Sometimes, Object.entries doesn't catch all exception properties. This seems to happen when the error is a pure JS error (like attempting access a property of a `null` variable), but not an API/request failure. This change includes a stringified version of the exception object in the popup to help rectify this.