### PR TITLE
Fix memory usage in delete task

### DIFF
--- a/django/poetry.lock
+++ b/django/poetry.lock
@@ -1165,6 +1165,17 @@ certifi = "*"
 urllib3 = "*"
 
 [[package]]
+name = "more-itertools"
+version = "10.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "more-itertools-10.1.0.tar.gz", hash = "sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a"},
+    {file = "more_itertools-10.1.0-py3-none-any.whl", hash = "sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6"},
+]
+
+[[package]]
 name = "morecantile"
 version = "4.3.0"
 description = "Construct and use map tile grids (a.k.a TileMatrixSet / TMS)."
@@ -2277,4 +2288,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11.0"
-content-hash = "5a11d84a01dd97d5a90d8d0da4c6e2df36b8cffab6b5ab836afca4d6d898ac98"
+content-hash = "91ef4c85a33698e49f59cccd2f7aab4152d35c37c481ef6f0f7d427177284469"

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -41,6 +41,7 @@ django-configurations = {extras = ["database", "email"], version = "^2.4.1"}
 django-storages = {extras = ["boto3"], version = "^1.13.2"}
 django-celery-results = "^2.5.1"
 pystac-client = "^0.7.5"
+more-itertools = "^10.1.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
I noticed model runs with an expiration time on them weren't being deleted as expected. Looking at the AWS container logs, something is causing a OOMKilled error to occur. I didn't know this was a thing, but apparently calling `.delete()` on a QuerySet will (most of the time at least) cause Django to load each object into memory. I expected it to just do a `DELETE` query, but I guess Django has to do some extra housekeeping with signals and cascades (see [here](https://stackoverflow.com/questions/31477723/how-to-prevent-django-from-loading-objects-in-memory-when-using-delete) for more info).

This PR refactors that task to do deletions in batches, to avoid loading every model run/site evalutation/site observation that's being deleted into memory at once.