### PR TITLE
Redesign model run mode display

### DIFF
--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -127,6 +127,7 @@ const getModeIcon = (mode: ModelRun['mode']) => (mode ? {
     :class="{selectedCard: props.open}"
   >
     <v-card-actions
+      v-if="modelRun.mode"
       class="pa-2"
       style="position: absolute; top: 0; right: 0;"
     >

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -113,6 +113,10 @@ const determineDownload = () => {
   }
 }
 
+const getModeIcon = (mode: ModelRun['mode']) => (mode ? {
+  batch: 'mdi-checkbox-multiple-blank',
+  incremental: 'mdi-trending-up',
+}[mode] : null);
 
 </script>
 
@@ -122,6 +126,20 @@ const determineDownload = () => {
     class="my-3 modelRunCard"
     :class="{selectedCard: props.open}"
   >
+    <v-card-actions
+      class="pa-2"
+      style="position: absolute; top: 0; right: 0;"
+    >
+      <v-chip
+        label
+        size="x-small"
+      >
+        <span class="text-caption mx-2">{{ modelRun.mode?.toUpperCase() }}</span>
+        <v-icon>
+          {{ getModeIcon(modelRun.mode) }}
+        </v-icon>
+      </v-chip>
+    </v-card-actions>
     <v-card-text
       @click.prevent="handleClick"
     >
@@ -136,14 +154,6 @@ const determineDownload = () => {
         </div>
         <div>
           {{ modelRun.region || "(none)" }}
-        </div>
-      </v-row>
-      <v-row dense>
-        <div>
-          mode:
-        </div>
-        <div>
-          {{ modelRun.mode || "(none)" }}
         </div>
       </v-row>
       <v-row dense>


### PR DESCRIPTION
Moves the `mode` of a model run to the corner of its card and includes a visual icon to indicate whether its "batch" or "incremental". If a model run doesn't have a `mode` or its `mode` is `null`, nothing is displayed (as is the case for non-scoring model runs)

I'm open to suggestions on icons to use.

![Screenshot from 2023-12-11 21-14-12](https://github.com/ResonantGeoData/RD-WATCH/assets/37340715/5d172287-d4fa-4fc8-bfbf-3b6fe934e25b)
