### PR TITLE
Add mode filter

### DIFF
--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from ninja import FilterSchema, Query
 from ninja.pagination import RouterPaginated
@@ -36,12 +36,13 @@ logger = logging.getLogger(__name__)
 
 router = RouterPaginated()
 
+Mode: TypeAlias = Literal['batch', 'incremental']
 
 class ModelRunFilterSchema(FilterSchema):
     performer: list[str] | None
     region: str | None
     # proposal: str | None = Field(q='proposal', ignore_none=False)
-    mode: Literal['batch', 'incremental'] | None
+    mode: list[Mode] | None
 
     def filter_performer(self, value: list[str] | None) -> Q:
         if value is None or not value:
@@ -50,6 +51,14 @@ class ModelRunFilterSchema(FilterSchema):
         for performer_slug in value:
             performer_q |= Q(performer=performer_slug)
         return performer_q
+
+    def filter_mode(self, value: list[Mode] | None) -> Q:
+        if value is None or not value:
+            return Q()
+        mode_q = Q()
+        for mode in value:
+            mode_q |= Q(mode=mode)
+        return mode_q
 
 
 def get_queryset():

--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -38,6 +38,7 @@ router = RouterPaginated()
 
 Mode: TypeAlias = Literal['batch', 'incremental']
 
+
 class ModelRunFilterSchema(FilterSchema):
     performer: list[str] | None
     region: str | None

--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 from ninja import FilterSchema, Query
 from ninja.pagination import RouterPaginated
@@ -40,6 +41,7 @@ class ModelRunFilterSchema(FilterSchema):
     performer: list[str] | None
     region: str | None
     # proposal: str | None = Field(q='proposal', ignore_none=False)
+    mode: Literal['batch', 'incremental'] | None
 
     def filter_performer(self, value: list[str] | None) -> Q:
         if value is None or not value:

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -1,6 +1,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import { ref } from 'vue';
+
 import type { ServerStatus } from "../models/ServerStatus";
 import type { SiteEvaluationList } from "../models/SiteEvaluationList";
 import type { SiteObservationList } from "../models/SiteObservationList";
@@ -112,14 +114,14 @@ export interface SiteDetails {
 type ApiPrefix = '/api' | '/api/scoring';
 
 export class ApiService {
-  private static apiPrefix: ApiPrefix = "/api";
+  private static apiPrefix = ref<ApiPrefix>("/api");
 
   public static getApiPrefix(): ApiPrefix {
-    return ApiService.apiPrefix;
+    return ApiService.apiPrefix.value;
   }
 
   public static setApiPrefix(prefix: ApiPrefix) {
-    ApiService.apiPrefix = prefix;
+    ApiService.apiPrefix.value = prefix;
   }
 
   /**
@@ -142,7 +144,7 @@ export class ApiService {
   ): CancelablePromise<SiteEvaluationList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/evaluations`,
+      url: `${this.getApiPrefix()}/evaluations`,
       query,
     });
   }
@@ -157,7 +159,7 @@ export class ApiService {
   ): CancelablePromise<SiteObservationList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/observations/{id}`,
+      url: `${this.getApiPrefix()}/observations/{id}`,
       path: {
         id: id,
       },
@@ -174,7 +176,7 @@ export class ApiService {
     ): CancelablePromise<SiteDetails> {
       return __request(OpenAPI, {
         method: "GET",
-        url: `${this.apiPrefix}/sites/{id}/details`,
+        url: `${this.getApiPrefix()}/sites/{id}/details`,
         path: {
           id: id,
         },
@@ -192,7 +194,7 @@ export class ApiService {
       ): CancelablePromise<boolean> {
         return __request(OpenAPI, {
           method: "POST",
-          url: `${this.apiPrefix}/observations/{id}/generate-images/`,
+          url: `${this.getApiPrefix()}/observations/{id}/generate-images/`,
           path: {
             id: id,
           },
@@ -214,7 +216,7 @@ export class ApiService {
       ): CancelablePromise<boolean> {
         return __request(OpenAPI, {
           method: "POST",
-          url: `${this.apiPrefix}/model-runs/{id}/generate-images/`,
+          url: `${this.getApiPrefix()}/model-runs/{id}/generate-images/`,
           path: {
             id: id,
           },
@@ -234,7 +236,7 @@ export class ApiService {
       ): CancelablePromise<boolean> {
         return __request(OpenAPI, {
           method: "PUT",
-          url: `${this.apiPrefix}/observations/{id}/cancel-generate-images/`,
+          url: `${this.getApiPrefix()}/observations/{id}/cancel-generate-images/`,
           path: {
             id: id,
           },
@@ -251,7 +253,7 @@ export class ApiService {
       ): CancelablePromise<boolean> {
         return __request(OpenAPI, {
           method: "PUT",
-          url: `${this.apiPrefix}/model-runs/{id}/cancel-generate-images/`,
+          url: `${this.getApiPrefix()}/model-runs/{id}/cancel-generate-images/`,
           path: {
             id: id,
           },
@@ -267,7 +269,7 @@ export class ApiService {
   ): CancelablePromise<ModelRunList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/model-runs`,
+      url: `${this.getApiPrefix()}/model-runs`,
       query: Object.fromEntries(
         Object.entries(query).filter(([key, value]) => value !== undefined)
       ),
@@ -281,7 +283,7 @@ export class ApiService {
     public static getModelRunEvaluations(id: string): CancelablePromise<ModelRunEvaluations> {
       return __request(OpenAPI, {
         method: "GET",
-        url: `${this.apiPrefix}/model-runs/{id}/evaluations`,
+        url: `${this.getApiPrefix()}/model-runs/{id}/evaluations`,
         path: {
           id: id,
         },
@@ -298,7 +300,7 @@ export class ApiService {
   public static getModelRun(id: string): CancelablePromise<ModelRun> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/model-runs/{id}`,
+      url: `${this.getApiPrefix()}/model-runs/{id}`,
       path: {
         id: id,
       },
@@ -312,7 +314,7 @@ export class ApiService {
   public static getPerformers(): CancelablePromise<PerformerList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/performers`,
+      url: `${this.getApiPrefix()}/performers`,
     });
   }
 
@@ -324,7 +326,7 @@ export class ApiService {
   public static getPerformer(id: number): CancelablePromise<Performer> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/performers/{id}`,
+      url: `${this.getApiPrefix()}/performers/{id}`,
       path: {
         id: id,
       },
@@ -338,7 +340,7 @@ export class ApiService {
   public static getRegions(): CancelablePromise<RegionList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/regions`,
+      url: `${this.getApiPrefix()}/regions`,
     });
   }
 
@@ -464,7 +466,7 @@ export class ApiService {
   public static getEvaluationImages(id: string): CancelablePromise<EvaluationImageResults> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.apiPrefix}/evaluations/images/{id}`,
+      url: `${this.getApiPrefix()}/evaluations/images/{id}`,
       path: {
         id: id,
       },
@@ -486,7 +488,7 @@ export class ApiService {
   public static patchSiteObservation(id: string, data: SiteObservationUpdateQuery): CancelablePromise<boolean> {
     return __request(OpenAPI, {
       method: 'PATCH',
-      url: `${this.apiPrefix}/observations/{id}/`,
+      url: `${this.getApiPrefix()}/observations/{id}/`,
       path: {
         id: id,
       },
@@ -508,7 +510,7 @@ export class ApiService {
   public static startModelRunDownload(id: string, mode: 'all' | 'approved' | 'rejected'='all'): CancelablePromise<string> {
     return __request(OpenAPI, {
       method: 'POST',
-      url: `${this.apiPrefix}/model-runs/{id}/download/`,
+      url: `${this.getApiPrefix()}/model-runs/{id}/download/`,
       path: {
         id: id,
       },
@@ -519,7 +521,7 @@ export class ApiService {
   public static getModelRunDownloadStatus(task_id: string): CancelablePromise<CeleryStates> {
     return __request(OpenAPI, {
       method: 'GET',
-      url: `${this.apiPrefix}/model-runs/download_status`,
+      url: `${this.getApiPrefix()}/model-runs/download_status`,
       query: {task_id},
     })
   }

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -109,12 +109,19 @@ export interface SiteDetails {
   timemax: number;
 }
 
-export class ApiService {
-  public static apiPrefix = "/api";
+type ApiPrefix = '/api' | '/api/scoring';
 
-  public static setApiPrefix(prefix: string) {
+export class ApiService {
+  private static apiPrefix: ApiPrefix = "/api";
+
+  public static getApiPrefix(): ApiPrefix {
+    return ApiService.apiPrefix;
+  }
+
+  public static setApiPrefix(prefix: ApiPrefix) {
     ApiService.apiPrefix = prefix;
   }
+
   /**
    * @returns ServerStatus
    * @throws ApiError
@@ -173,7 +180,7 @@ export class ApiService {
         },
       });
     }
-  
+
       /**
    * @param id
    * @returns boolean

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -124,6 +124,10 @@ export class ApiService {
     ApiService.apiPrefix.value = prefix;
   }
 
+  public static isScoring(): boolean {
+    return ApiService.apiPrefix.value === '/api/scoring';
+  }
+
   /**
    * @returns ServerStatus
    * @throws ApiError

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -22,6 +22,7 @@ import { EvaluationImageResults } from "../../types";
 export interface QueryArguments {
   performer?: string[];
   region?: string;
+  mode?: string[];
   page?: number;
   limit?: number;
   proposal?: 'PROPOSAL' | 'APPROVED';

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -5,13 +5,13 @@ import { state } from "../store";
 
 
 
-const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
+const scoringApp = computed(()=> ApiService.getApiPrefix().includes('scoring'));
 
 
 
 
 const checkGroundTruth = async () => {
-  if (scoringApp.value) { 
+  if (scoringApp.value) {
     return;
   } else {
     // We need to find the ground-truth model and add it to the visible items

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -81,7 +81,7 @@ const checkDownloadStatus = async () => {
   if (taskId.value) {
     const status = await ApiService.getModelRunDownloadStatus(taskId.value);
     if (status === 'SUCCESS') {
-      const url = `${ApiService.apiPrefix}/model-runs/${props.modelRun.id}/download?task_id=${taskId.value}`
+      const url = `${ApiService.getApiPrefix()}/model-runs/${props.modelRun.id}/download?task_id=${taskId.value}`
       window.location.assign(url);
       downloadingModelRun.value = false;
     } else if (['REVOKED', 'FAILURE'].includes(status)) {

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -45,10 +45,11 @@ async function loadMore() {
   if (request !== undefined) {
     request.cancel();
   }
-  const { performer } = props.filters; // unwrap performer array
+  const { mode, performer } = props.filters; // unwrap performer and mode arrays
   request = ApiService.getModelRuns({
     limit,
     ...props.filters,
+    mode,
     performer,
     proposal: props.compact ? 'PROPOSAL' : undefined, // if compact we are doing proposal adjudication
   });

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -40,10 +40,10 @@ const queryFilters = computed<QueryArguments>(() => ({
   page: page.value,
   performer: selectedPerformer.value.map((item) => item.short_code),
   region: selectedRegion.value,
-  mode: selectedMode.value,
+  mode: selectedModes.value,
 }));
 
-const selectedMode: Ref<string | undefined> = ref(undefined);
+const selectedModes: Ref<string[]> = ref([]);
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 watch(selectedPerformer, (val) => {
@@ -71,11 +71,11 @@ const updateRegion = (val?: Region) => {
   };
 };
 
-const updateMode = (mode?: string) => {
+const updateMode = (mode: string[]) => {
   page.value = 1;
   state.filters = {
     ...state.filters,
-    mode: mode,
+    mode,
   };
 };
 
@@ -250,7 +250,7 @@ const toggleText = () => {
         dense
       >
         <ModeFilter
-          v-model="selectedMode"
+          v-model="selectedModes"
           class="pr-2"
           @update:model-value="updateMode($event)"
         />

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -8,7 +8,7 @@ import SettingsPanel from "./SettingsPanel.vue";
 import ErrorPopup from './ErrorPopup.vue';
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
-import { Performer, QueryArguments, Region } from "../client";
+import { ApiService, Performer, QueryArguments, Region } from "../client";
 import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 import { useRoute } from "vue-router";
@@ -245,7 +245,10 @@ const toggleText = () => {
           @update:model-value="updateRegion($event)"
         />
       </v-row>
-      <v-row dense>
+      <v-row
+        v-if="ApiService.isScoring()"
+        dense
+      >
         <ModeFilter
           v-model="selectedMode"
           class="pr-2"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -3,6 +3,7 @@ import ModelRunList from "./ModelRunList.vue";
 import TimeSlider from "./TimeSlider.vue";
 import PerformerFilter from "./filters/PerformerFilter.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
+import ModeFilter from "./filters/ModeFilter.vue";
 import SettingsPanel from "./SettingsPanel.vue";
 import ErrorPopup from './ErrorPopup.vue';
 import { filteredSatelliteTimeList, state } from "../store";
@@ -39,8 +40,10 @@ const queryFilters = computed<QueryArguments>(() => ({
   page: page.value,
   performer: selectedPerformer.value.map((item) => item.short_code),
   region: selectedRegion.value,
+  mode: selectedMode.value,
 }));
 
+const selectedMode: Ref<string | undefined> = ref(undefined);
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 watch(selectedPerformer, (val) => {
@@ -67,6 +70,15 @@ const updateRegion = (val?: Region) => {
     regions: val === undefined ? undefined : [val],
   };
 };
+
+const updateMode = (mode?: string) => {
+  page.value = 1;
+  state.filters = {
+    ...state.filters,
+    mode: mode,
+  };
+};
+
 const expandSettings = ref(false);
 
 const imagesOn = computed({
@@ -231,6 +243,13 @@ const toggleText = () => {
           v-model="selectedRegion"
           cols="6"
           @update:model-value="updateRegion($event)"
+        />
+      </v-row>
+      <v-row dense>
+        <ModeFilter
+          v-model="selectedMode"
+          class="pr-2"
+          @update:model-value="updateMode($event)"
         />
       </v-row>
       <SettingsPanel v-if="expandSettings" />

--- a/vue/src/components/filters/ModeFilter.vue
+++ b/vue/src/components/filters/ModeFilter.vue
@@ -2,15 +2,15 @@
 import { ref, watch } from "vue";
 
 const props = defineProps<{
-  modelValue?: string;
+  modelValue: string[];
 }>();
 
 const emit = defineEmits<{
-  (e: "update:modelValue", mode?: string): void;
+  (e: "update:modelValue", mode: string[]): void;
 }>();
 
 const modes = ['batch', 'incremental'];
-const selectedMode = ref(props.modelValue);
+const selectedMode = ref<string[]>(props.modelValue);
 
 watch(() => props.modelValue, () => {
   if (props.modelValue) {
@@ -27,6 +27,7 @@ watch(selectedMode, () => {
   <v-select
     v-model="selectedMode"
     clearable
+    multiple
     persistent-clear
     density="compact"
     variant="outlined"

--- a/vue/src/components/filters/ModeFilter.vue
+++ b/vue/src/components/filters/ModeFilter.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+const props = defineProps<{
+  modelValue?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", mode?: string): void;
+}>();
+
+const modes = ['batch', 'incremental'];
+const selectedMode = ref(props.modelValue);
+
+watch(() => props.modelValue, () => {
+  if (props.modelValue) {
+    selectedMode.value = props.modelValue;
+  }
+});
+
+watch(selectedMode, () => {
+  emit('update:modelValue', selectedMode.value);
+});
+</script>
+
+<template>
+  <v-select
+    v-model="selectedMode"
+    clearable
+    persistent-clear
+    density="compact"
+    variant="outlined"
+    label="Mode"
+    placeholder="Mode"
+    :items="modes"
+    single-line
+    class="dropdown"
+  />
+</template>
+
+<style scoped>
+.dropdown {
+  max-width: 180px;
+}
+</style>

--- a/vue/src/components/imageViewer/ImageViewerButton.vue
+++ b/vue/src/components/imageViewer/ImageViewerButton.vue
@@ -14,7 +14,7 @@ defineProps<{
 const displayImage = ref(false);
 
 const openNewTab = (id: string) => {
-  const name = `#${ApiService.apiPrefix.replace('api/','').replace('/api','')}/imageViewer/${id}`
+  const name = `#${ApiService.getApiPrefix().replace('api/','').replace('/api','')}/imageViewer/${id}`
   window.open(name, '_blank');
 };
 

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -67,12 +67,12 @@ export const buildObservationFilter = (
         "any",
         ["==", ["get", "groundtruth"], false]
       ]
-    ); 
+    );
   } else if (!hasModel && hasGroundTruth) {
     filter.push([
       "any",
       ["==", ["get", "groundtruth"], true]
-    ]); 
+    ]);
   } else if (!hasModel && !hasGroundTruth) {
     return false;
   }
@@ -164,12 +164,12 @@ export const buildSiteFilter = (
         "any",
         ["==", ["get", "groundtruth"], false]
       ]
-    ); 
+    );
   } else if (!hasModel && hasGroundTruth) {
     filter.push([
       "any",
       ["==", ["get", "groundtruth"], true]
-    ]); 
+    ]);
   } else if (!hasModel && !hasGroundTruth && !filters.scoringColoring) {
     return false;
   }
@@ -223,7 +223,7 @@ export const buildSourceFilter = (modelRunIds: string[]) => {
     const source = `vectorTileSource_${id}`;
     results[source] = {
       type: "vector",
-      tiles: [`${urlRoot}${ApiService.apiPrefix}/model-runs/${id}/vector-tile/{z}/{x}/{y}.pbf/`],
+      tiles: [`${urlRoot}${ApiService.getApiPrefix()}/model-runs/${id}/vector-tile/{z}/{x}/{y}.pbf/`],
       minzoom: 0,
       maxzoom: 14,
     };

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -6,7 +6,7 @@ export interface MapFilters {
   configuration_id?: string[];
   performer_ids?: number[];
   regions?: Region[];
-  mode?: string;
+  mode?: string[];
   drawSiteOutline?: string[]; //looking for either 'model' | 'groundtruth'
   drawObservations?: string[]; //looking for either 'model' | 'groundtruth'
   scoringColoring?: 'simple' | 'detailed';

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -6,6 +6,7 @@ export interface MapFilters {
   configuration_id?: string[];
   performer_ids?: number[];
   regions?: Region[];
+  mode?: string;
   drawSiteOutline?: string[]; //looking for either 'model' | 'groundtruth'
   drawObservations?: string[]; //looking for either 'model' | 'groundtruth'
   scoringColoring?: 'simple' | 'detailed';


### PR DESCRIPTION
Adds a new filter for evaluation run modes.

![mode](https://github.com/ResonantGeoData/RD-WATCH/assets/37340715/5ef23405-f066-4f5c-bcfa-3f704840a442)

Depends on #336 being merged first.