### PR TITLE
1.3 eval filter

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -103,10 +103,11 @@ class ModelRunAdjudicated(Schema):
 class ModelRunDetailSchema(Schema):
     id: UUID4
     title: str
+    eval: str | None = None
     region: str | None = None
     performer: PerformerSchema
     parameters: dict
-    numsites: int
+    numsites: int | None = 0
     downloading: int | None = None
     score: float | None = None
     timestamp: int | None = None
@@ -123,10 +124,11 @@ class ModelRunDetailSchema(Schema):
 class ModelRunListSchema(Schema):
     id: UUID4
     title: str
+    eval: str | None = None
     region: str | None = None
     performer: PerformerSchema
     parameters: dict
-    numsites: int
+    numsites: int | None = 0
     downloading: int | None = None
     score: float | None = None
     timestamp: int | None = None

--- a/django/src/rdwatch/views/region.py
+++ b/django/src/rdwatch/views/region.py
@@ -1,12 +1,14 @@
-from ninja.pagination import RouterPaginated
+from ninja import Router
+from ninja.pagination import PageNumberPagination, paginate
 
 from django.http import HttpRequest
 
 from rdwatch.models import Region
 
-router = RouterPaginated()
+router = Router()
 
 
 @router.get('/', response=list[str])
+@paginate(PageNumberPagination, page_size=1000)
 def list_regions(request: HttpRequest):
     return Region.objects.values_list('name', flat=True)

--- a/django/src/rdwatch_scoring/api.py
+++ b/django/src/rdwatch_scoring/api.py
@@ -14,7 +14,6 @@ api.add_router('/sites/', views.site.router)
 api.add_router('/evals/', views.eval.router)
 
 
-
 # useful for getting information back about validation errors
 @api.exception_handler(ValidationError)
 def custom_validation_errors(request, exc):

--- a/django/src/rdwatch_scoring/api.py
+++ b/django/src/rdwatch_scoring/api.py
@@ -11,7 +11,7 @@ api.add_router('/observations/', views.observation.router)
 api.add_router('/performers/', views.performer.router)
 api.add_router('/regions/', views.region.router)
 api.add_router('/sites/', views.site.router)
-api.add_router('/evals/', views.eval.router)
+api.add_router('/eval-numbers/', views.eval.router)
 
 
 # useful for getting information back about validation errors

--- a/django/src/rdwatch_scoring/api.py
+++ b/django/src/rdwatch_scoring/api.py
@@ -11,6 +11,8 @@ api.add_router('/observations/', views.observation.router)
 api.add_router('/performers/', views.performer.router)
 api.add_router('/regions/', views.region.router)
 api.add_router('/sites/', views.site.router)
+api.add_router('/evals/', views.eval.router)
+
 
 
 # useful for getting information back about validation errors

--- a/django/src/rdwatch_scoring/views/__init__.py
+++ b/django/src/rdwatch_scoring/views/__init__.py
@@ -1,4 +1,4 @@
-from . import model_run, observation, performer, region, site, site_image, vector_tile
+from . import eval, model_run, observation, performer, region, site, site_image, vector_tile
 
 __all__ = [
     'model_run',
@@ -8,4 +8,5 @@ __all__ = [
     'site_image',
     'vector_tile',
     'site',
+    'eval'
 ]

--- a/django/src/rdwatch_scoring/views/__init__.py
+++ b/django/src/rdwatch_scoring/views/__init__.py
@@ -1,4 +1,13 @@
-from . import eval, model_run, observation, performer, region, site, site_image, vector_tile
+from . import (
+    eval,
+    model_run,
+    observation,
+    performer,
+    region,
+    site,
+    site_image,
+    vector_tile,
+)
 
 __all__ = [
     'model_run',
@@ -8,5 +17,5 @@ __all__ = [
     'site_image',
     'vector_tile',
     'site',
-    'eval'
+    'eval',
 ]

--- a/django/src/rdwatch_scoring/views/eval.py
+++ b/django/src/rdwatch_scoring/views/eval.py
@@ -20,7 +20,7 @@ def list_evals(request: HttpRequest):
                 output_field=CharField(),
             )
         )
-        .order_by('evaluation_number', 'evaluation_run_number')
+        .order_by('-evaluation_number', '-evaluation_run_number')
         .values_list('eval', flat=True)
         .distinct()
     )

--- a/django/src/rdwatch_scoring/views/eval.py
+++ b/django/src/rdwatch_scoring/views/eval.py
@@ -1,25 +1,26 @@
 from ninja.pagination import RouterPaginated
 
+from django.db.models import CharField, Value
+from django.db.models.functions import Concat
 from django.http import HttpRequest
 
 from rdwatch_scoring.models import EvaluationRun
-
-from django.db.models import (
-    CharField,
-    Value,
-)
-from django.db.models.functions import Concat
 
 router = RouterPaginated()
 
 
 @router.get('/', response=list[str])
 def list_evals(request: HttpRequest):
-    return EvaluationRun.objects.annotate(
-        eval=Concat(
-            'evaluation_number',
-            Value('.'),
-            'evaluation_run_number',
-            output_field=CharField()
+    return (
+        EvaluationRun.objects.annotate(
+            eval=Concat(
+                'evaluation_number',
+                Value('.'),
+                'evaluation_run_number',
+                output_field=CharField(),
+            )
         )
-    ).order_by('evaluation_number', 'evaluation_run_number').values_list('eval', flat=True).distinct()
+        .order_by('evaluation_number', 'evaluation_run_number')
+        .values_list('eval', flat=True)
+        .distinct()
+    )

--- a/django/src/rdwatch_scoring/views/eval.py
+++ b/django/src/rdwatch_scoring/views/eval.py
@@ -1,0 +1,25 @@
+from ninja.pagination import RouterPaginated
+
+from django.http import HttpRequest
+
+from rdwatch_scoring.models import EvaluationRun
+
+from django.db.models import (
+    CharField,
+    Value,
+)
+from django.db.models.functions import Concat
+
+router = RouterPaginated()
+
+
+@router.get('/', response=list[str])
+def list_evals(request: HttpRequest):
+    return EvaluationRun.objects.annotate(
+        eval=Concat(
+            'evaluation_number',
+            Value('.'),
+            'evaluation_run_number',
+            output_field=CharField()
+        )
+    ).order_by('evaluation_number', 'evaluation_run_number').values_list('eval', flat=True).distinct()

--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -74,6 +74,8 @@ def get_queryset():
                 'evaluation_number',
                 Value('.'),
                 'evaluation_run_number',
+                Value('.'),
+                'evaluation_increment_number',
                 Value(' '),
                 'performer',
                 output_field=CharField(),
@@ -127,7 +129,7 @@ def list_model_runs(
     page = int(request.GET.get('page', 1))
 
     qs = filters.filter(EvaluationRun.objects.all()
-                        .order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number')))
+                        .order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number'), F('evaluation_increment_number')))
 
     ids = qs[((page - 1) * page_size) : (page * page_size)].values_list(
         'uuid', flat=True
@@ -148,6 +150,8 @@ def list_model_runs(
                 'evaluation_number',
                 Value('.'),
                 'evaluation_run_number',
+                Value('.'),
+                'evaluation_increment_number',
                 Value(' '),
                 'performer',
                 output_field=CharField(),
@@ -189,7 +193,7 @@ def list_model_runs(
                 output_field=JSONField(),
             ),
         )
-    ).order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number'))
+    ).order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number'), F('evaluation_increment_number'))
 
     print(qs.query)
     aggregate_kwargs = {

--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -74,10 +74,12 @@ class ModelRunFilterSchema(FilterSchema):
 
 
 def get_queryset():
-    return (EvaluationRun.objects
-        .filter(evaluationbroadareasearchmetric__activity_type='overall',
-                evaluationbroadareasearchmetric__tau=0.2,
-                evaluationbroadareasearchmetric__rho=0.5)
+    return (
+        EvaluationRun.objects.filter(
+            evaluationbroadareasearchmetric__activity_type='overall',
+            evaluationbroadareasearchmetric__tau=0.2,
+            evaluationbroadareasearchmetric__rho=0.5,
+        )
         .values()
         .annotate(
             id=F('uuid'),
@@ -96,16 +98,20 @@ def get_queryset():
                 'evaluation_number',
                 Value('.'),
                 'evaluation_run_number',
-                output_field=CharField()
+                output_field=CharField(),
             ),
             region=F('region'),
             performer_slug=F('performer'),
-            performer=JSONObject(id=0, team_name=F('performer'), short_code=F('performer')),
+            performer=JSONObject(
+                id=0, team_name=F('performer'), short_code=F('performer')
+            ),
             parameters=Value({}, output_field=JSONField()),
             numsites=F('evaluationbroadareasearchmetric__proposed_sites'),
             downloading=Value(0),
             score=Avg(
-                NullIf('site__confidence_score', Value('NaN'), output_field=FloatField())
+                NullIf(
+                    'site__confidence_score', Value('NaN'), output_field=FloatField()
+                )
             ),
             timestamp=ExtractEpoch(Max('site__end_date')),
             timerange=JSONObject(
@@ -140,8 +146,15 @@ def list_model_runs(
     page_size: int = 10  # TODO: use settings.NINJA_PAGINATION_PER_PAGE?
     page = int(request.GET.get('page', 1))
 
-    qs = filters.filter(EvaluationRun.objects.all()
-                        .order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number'), F('evaluation_increment_number')))
+    qs = filters.filter(
+        EvaluationRun.objects.all().order_by(
+            F('region'),
+            F('performer'),
+            F('evaluation_number'),
+            F('evaluation_run_number'),
+            F('evaluation_increment_number'),
+        )
+    )
 
     ids = qs[((page - 1) * page_size) : (page * page_size)].values_list(
         'uuid', flat=True
@@ -149,11 +162,12 @@ def list_model_runs(
     total_count = qs.count()
 
     qs = (
-        EvaluationRun.objects
-        .filter(uuid__in=ids,
-                evaluationbroadareasearchmetric__activity_type='overall',
-                evaluationbroadareasearchmetric__tau=0.2,
-                evaluationbroadareasearchmetric__rho=0.5)
+        EvaluationRun.objects.filter(
+            uuid__in=ids,
+            evaluationbroadareasearchmetric__activity_type='overall',
+            evaluationbroadareasearchmetric__tau=0.2,
+            evaluationbroadareasearchmetric__rho=0.5,
+        )
         .values()
         .annotate(
             id=F('uuid'),
@@ -172,7 +186,7 @@ def list_model_runs(
                 'evaluation_number',
                 Value('.'),
                 'evaluation_run_number',
-                output_field=CharField()
+                output_field=CharField(),
             ),
             performer=JSONObject(
                 id=0, team_name=F('performer'), short_code=F('performer')
@@ -205,7 +219,13 @@ def list_model_runs(
                 output_field=JSONField(),
             ),
         )
-    ).order_by(F('region'), F('performer'), F('evaluation_number'), F('evaluation_run_number'), F('evaluation_increment_number'))
+    ).order_by(
+        F('region'),
+        F('performer'),
+        F('evaluation_number'),
+        F('evaluation_run_number'),
+        F('evaluation_increment_number'),
+    )
 
     aggregate_kwargs = {
         'timerange': JSONObject(

--- a/django/src/rdwatch_scoring/views/region.py
+++ b/django/src/rdwatch_scoring/views/region.py
@@ -1,12 +1,14 @@
-from ninja.pagination import RouterPaginated
+from ninja import Router
+from ninja.pagination import PageNumberPagination, paginate
 
 from django.http import HttpRequest
 
 from rdwatch_scoring.models import EvaluationRun
 
-router = RouterPaginated()
+router = Router()
 
 
 @router.get('/', response=list[str])
+@paginate(PageNumberPagination, page_size=1000)
 def list_regions(request: HttpRequest):
     return EvaluationRun.objects.order_by().values_list('region', flat=True).distinct()

--- a/vue/src/client/index.ts
+++ b/vue/src/client/index.ts
@@ -15,6 +15,8 @@ export type { PerformerList } from "./models/PerformerList";
 export type { Performer } from "./models/Performer";
 export type { RegionList } from "./models/RegionList";
 export type { Region } from "./models/Region";
+export type { EvalList } from "./models/EvalList";
+export type { Eval } from "./models/Eval";
 
 export type { QueryArguments } from "./services/ApiService";
 export { ApiService } from "./services/ApiService";

--- a/vue/src/client/models/Eval.ts
+++ b/vue/src/client/models/Eval.ts
@@ -1,0 +1,1 @@
+export type Eval = string;

--- a/vue/src/client/models/EvalList.ts
+++ b/vue/src/client/models/EvalList.ts
@@ -1,0 +1,6 @@
+import type { Eval } from "./Eval";
+
+export type EvalList = {
+  count: number;
+  items: Eval[];
+};

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -359,7 +359,7 @@ export class ApiService {
   public static getEvals(): CancelablePromise<EvalList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/evals`,
+      url: `${this.getApiPrefix()}/eval-numbers/`,
     });
   }
 

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -10,6 +10,8 @@ import type { PerformerList } from "../models/PerformerList";
 import type { Performer } from "../models/Performer";
 import type { RegionList } from "../models/RegionList";
 import type { Region } from "../models/Region";
+import type { EvalList } from "../models/EvalList";
+import type { Eval } from "../models/Eval";
 
 import type { CancelablePromise } from "../core/CancelablePromise";
 import { OpenAPI } from "../core/OpenAPI";
@@ -20,6 +22,7 @@ import { EvaluationImageResults } from "../../types";
 export interface QueryArguments {
   performer?: string[];
   region?: string;
+  eval?: string[];
   page?: number;
   limit?: number;
   proposal?: 'PROPOSAL' | 'APPROVED';
@@ -173,7 +176,7 @@ export class ApiService {
         },
       });
     }
-  
+
       /**
    * @param id
    * @returns boolean
@@ -332,6 +335,17 @@ export class ApiService {
     return __request(OpenAPI, {
       method: "GET",
       url: `${this.apiPrefix}/regions`,
+    });
+  }
+
+  /**
+   * @returns EvalList
+   * @throws ApiError
+   */
+  public static getEvals(): CancelablePromise<EvalList> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: `${this.apiPrefix}/evals`,
     });
   }
 

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -261,7 +261,7 @@ async function handleScroll(event: Event) {
 const hasSatelliteImages = computed(() => filteredSatelliteTimeList.value.length);
 
 watchEffect(loadMore);
-watch([() => props.filters.region, () => props.filters.performer], () => {
+watch([() => props.filters.region, () => props.filters.performer, () => props.filters.eval], () => {
   state.openedModelRuns.clear();
   state.filters = {
     ...state.filters,

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -20,7 +20,6 @@ const page = ref<number>(1);
 const route = useRoute();
 watch(() => route.path, (oldPath, newPath) => {
   if ((!oldPath.includes('/scoring') && newPath.includes('/scoring')) || (oldPath.includes('/scoring') && !newPath.includes('/scoring'))) {
-    console.log(`Resetting path:  old:${oldPath}  new:${newPath}`);
     selectedPerformer.value = [];
     selectedRegion.value = undefined;
     state.enabledSiteObservations = [];

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -2,14 +2,17 @@
 import ModelRunList from "./ModelRunList.vue";
 import TimeSlider from "./TimeSlider.vue";
 import PerformerFilter from "./filters/PerformerFilter.vue";
+import EvalFilter from "./filters/EvalFilter.vue";
 import RegionFilter from "./filters/RegionFilter.vue";
 import SettingsPanel from "./SettingsPanel.vue";
 import ErrorPopup from './ErrorPopup.vue';
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
-import { Performer, QueryArguments, Region } from "../client";
+import { ApiService, Performer, QueryArguments, Region, Eval } from "../client";
 import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
+
+const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
@@ -19,10 +22,12 @@ const queryFilters = computed<QueryArguments>(() => ({
   page: page.value,
   performer: selectedPerformer.value.map((item) => item.short_code),
   region: selectedRegion.value,
+  eval: selectedEval.value,
 }));
 
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
+const selectedEval: Ref<Eval[]> = ref([]);
 watch(selectedPerformer, (val) => {
   state.filters = {
     ...state.filters,
@@ -162,15 +167,27 @@ const toggleText = () => {
         dense
         class="mt-3"
       >
-        <PerformerFilter
-          v-model="selectedPerformer"
-          class="pr-2"
-          cols="6"
-        />
         <RegionFilter
           v-model="selectedRegion"
           cols="6"
+          hide-details
           @update:model-value="updateRegion($event)"
+        />
+        <PerformerFilter
+          v-model="selectedPerformer"
+          cols="6"
+          hide-details
+        />
+      </v-row>
+      <v-row
+        dense
+        class="mt-3"
+        v-if="scoringApp"
+      >
+        <EvalFilter
+          cols="6"
+          hide-details
+          v-model="selectedEval"
         />
       </v-row>
       <SettingsPanel v-if="expandSettings" />
@@ -229,4 +246,7 @@ const toggleText = () => {
 
 }
 
+.modelRuns {
+  margin-top: 2em
+}
 </style>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -8,12 +8,10 @@ import SettingsPanel from "./SettingsPanel.vue";
 import ErrorPopup from './ErrorPopup.vue';
 import { filteredSatelliteTimeList, state } from "../store";
 import { computed, onMounted, ref, watch } from "vue";
-import { ApiService, Performer, QueryArguments, Region, Eval } from "../client";
+import { Eval, Performer, QueryArguments, Region} from "../client";
 import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 import { useRoute } from "vue-router";
-
-const scoringApp = computed(()=> ApiService.apiPrefix.includes('scoring'));
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
@@ -241,13 +239,13 @@ const toggleText = () => {
       </v-row>
       <v-row
         dense
-        class="mt-3"
         v-if="scoringApp"
+        class="mt-3"
       >
         <EvalFilter
           cols="6"
-          hide-details
           v-model="selectedEval"
+          hide-details
         />
       </v-row>
       <SettingsPanel v-if="expandSettings" />

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -237,37 +237,35 @@ const toggleText = () => {
         dense
         class="mt-3"
       >
-        <RegionFilter
-          v-model="selectedRegion"
-          cols="6"
-          hide-details
-          @update:model-value="updateRegion($event)"
-        />
         <PerformerFilter
           v-model="selectedPerformer"
           cols="6"
+          class="px-1"
           hide-details
         />
-      </v-row>
-      <v-row
-        dense
-        v-if="scoringApp"
-        class="mt-3"
-      >
-        <EvalFilter
+        <RegionFilter
+          v-model="selectedRegion"
           cols="6"
-          v-model="selectedEval"
+          class="px-1"
           hide-details
+          @update:model-value="updateRegion($event)"
         />
       </v-row>
       <v-row
         v-if="ApiService.isScoring()"
+        class="pt-2"
         dense
       >
         <ModeFilter
           v-model="selectedModes"
-          class="pr-2"
+          class="px-1"
+          hide-details
           @update:model-value="updateMode($event)"
+        />
+        <EvalFilter
+          v-model="selectedEval"
+          class="px-1"
+          hide-details
         />
       </v-row>
       <SettingsPanel v-if="expandSettings" />

--- a/vue/src/components/filters/EvalFilter.vue
+++ b/vue/src/components/filters/EvalFilter.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref, watch, watchEffect } from "vue";
+import { ApiService, EvalList } from "../../client";
+import type { Ref } from "vue";
+import type { Eval } from "../../client";
+import { state } from "../../store";
+
+const props = defineProps<{
+  modelValue: Eval[];
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", eval?: Eval[]): void;
+}>();
+
+const evals: Ref<Eval[]> = ref([]);
+const selectedEvals: Ref<Eval[]> = ref(props.modelValue);
+watchEffect(async () => {
+  const evalList = await ApiService.getEvals();
+  const evalResults = evalList.items
+  evals.value = evalResults;
+});
+
+watch(() => props.modelValue, () => {
+  if (props.modelValue) {
+    selectedEvals.value = props.modelValue;
+  }
+});
+
+watch(selectedEvals, (l) => {
+  if (l) {
+    emit("update:modelValue", l);
+    return;
+  }
+  emit("update:modelValue", []);
+});
+</script>
+
+<template>
+  <v-select
+    v-model="selectedEvals"
+    clearable
+    persistent-clear
+    multiple
+    density="compact"
+    variant="outlined"
+    :label="`Evaluation (${evals.length})`"
+    :placeholder="`Evaluation (${evals.length})`"
+    :items="evals"
+    single-line
+    class="dropdown"
+  />
+</template>
+<style scoped>
+.dropdown {
+  max-width: 180px;
+}
+</style>

--- a/vue/src/components/filters/EvalFilter.vue
+++ b/vue/src/components/filters/EvalFilter.vue
@@ -9,15 +9,17 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: "update:modelValue", eval?: Eval[]): void;
+  (e: "update:modelValue", evaluation?: Eval[]): void;
 }>();
 
 const evals: Ref<Eval[]> = ref([]);
 const selectedEvals: Ref<Eval[]> = ref(props.modelValue);
 watchEffect(async () => {
-  const evalList = await ApiService.getEvals();
-  const evalResults = evalList.items
-  evals.value = evalResults;
+  if (ApiService.getApiPrefix().includes('scoring')) {
+    const evalList = await ApiService.getEvals();
+    const evalResults = evalList.items
+    evals.value = evalResults;
+  }
 });
 
 watch(() => props.modelValue, () => {
@@ -39,8 +41,8 @@ watch(selectedEvals, (l) => {
   <v-select
     v-model="selectedEvals"
     clearable
-    persistent-clear
     multiple
+    persistent-clear
     density="compact"
     variant="outlined"
     :label="`Evaluation (${evals.length})`"

--- a/vue/src/components/filters/EvalFilter.vue
+++ b/vue/src/components/filters/EvalFilter.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { ref, watch, watchEffect } from "vue";
-import { ApiService, EvalList } from "../../client";
+import { ApiService } from "../../client";
 import type { Ref } from "vue";
 import type { Eval } from "../../client";
-import { state } from "../../store";
 
 const props = defineProps<{
   modelValue: Eval[];

--- a/vue/src/components/filters/PerformerFilter.vue
+++ b/vue/src/components/filters/PerformerFilter.vue
@@ -19,7 +19,7 @@ const performers: Ref<{value: number; title: string}[]> = ref([]);
 const selectedPerformers: Ref<number[]> = ref(props.modelValue.map((item) => item.id));
 const performerList: Ref<PerformerList | null> = ref(null);
 const performerIdMap: Record<number, Performer> = {}
-watchEffect(async () => {
+  watchEffect(async () => {
   performerList.value = await ApiService.getPerformers();
   const performerResults = performerList.value.items
   performerResults.sort((a, b) => (a.team_name > b.team_name ? 1 : -1))
@@ -36,21 +36,21 @@ watch(() => props.modelValue, () => {
 });
 
 
-watch(selectedPerformers, () => {
-  if (performerList.value !== null) {
-    const newPerformers = selectedPerformers.value.map((item) => performerIdMap[item])
+const updateSelected =  (data: number[]) => {
+  if (selectedPerformers.value !== null) {
+    const newPerformers = data.map((item) => performerIdMap[item]);
     if (newPerformers.length) {
       emit("update:modelValue", newPerformers);
       return;
     }
   }
   emit("update:modelValue", []);
-});
+};
 </script>
 
 <template>
   <v-select
-    v-model="selectedPerformers"
+    :value="selectedPerformers"
     clearable
     multiple
     persistent-clear
@@ -61,6 +61,7 @@ watch(selectedPerformers, () => {
     :items="performers"
     single-line
     class="dropdown"
+    @update:model-value="updateSelected($event)"
   />
 </template>
 

--- a/vue/src/components/filters/RegionFilter.vue
+++ b/vue/src/components/filters/RegionFilter.vue
@@ -52,8 +52,6 @@ watch(selectedRegion, (val) => {
 <template>
   <v-select
     v-model="selectedRegion"
-    clearable
-    persistent-clear
     density="compact"
     variant="outlined"
     :label="`Region (${regions.length})`"

--- a/vue/src/components/filters/RegionFilter.vue
+++ b/vue/src/components/filters/RegionFilter.vue
@@ -57,6 +57,8 @@ watch(selectedRegion, (val) => {
     v-model="selectedRegion"
     density="compact"
     variant="outlined"
+    clearable
+    persistent-clear
     :label="`Region (${regions.length})`"
     :placeholder="`Region (${regions.length})`"
     :items="regions"


### PR DESCRIPTION
Taking #338 and made some changes for the UI and fixing some Warnings/errors

- No Eval for RGD endpoint error
- fixes Performer warnings for recursive lookups
- ran pre-commit and linting
- Added page sizes for region endpoints of 1000 (when loading all annotations in RGD you get more than 100 regions).

Changed some vuetify logic to make the filters look like this: 
![image](https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/0f972e97-e3b3-4582-9224-3a8c569b5c10)
