### PR TITLE
TimeRange Downloading Bug

### DIFF
--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -265,7 +265,6 @@ def get_siteobservations_images(
         timebuffer = (
             (max_time + timedelta(days=30)) - (min_time - timedelta(days=30))
         ) / 2
-        # print(timebuffer)
         timestamp = (min_time - timedelta(days=30)) + timebuffer
 
     # Now we get a list of all the timestamps and captures that fall in this range.

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -259,9 +259,14 @@ def get_siteobservations_images(
     if overrideDates and len(overrideDates) == 2:
         min_time = datetime.strptime(overrideDates[0], '%Y-%m-%d')
         max_time = datetime.strptime(overrideDates[1], '%Y-%m-%d')
-
-    timebuffer = ((max_time + timedelta(days=30)) - (min_time - timedelta(days=30))) / 2
-    timestamp = (min_time + timedelta(days=30)) + timebuffer
+        timebuffer = (max_time - min_time) / 2
+        timestamp = min_time + timebuffer
+    else:
+        timebuffer = (
+            (max_time + timedelta(days=30)) - (min_time - timedelta(days=30))
+        ) / 2
+        # print(timebuffer)
+        timestamp = (min_time - timedelta(days=30)) + timebuffer
 
     # Now we get a list of all the timestamps and captures that fall in this range.
     worldView = baseConstellation == 'WV'

--- a/django/src/rdwatch_scoring/tasks/__init__.py
+++ b/django/src/rdwatch_scoring/tasks/__init__.py
@@ -240,10 +240,14 @@ def get_siteobservations_images(
     if overrideDates and len(overrideDates) == 2:
         min_time = datetime.strptime(overrideDates[0], '%Y-%m-%d')
         max_time = datetime.strptime(overrideDates[1], '%Y-%m-%d')
-
-    timebuffer = ((max_time + timedelta(days=30)) - (min_time - timedelta(days=30))) / 2
-    # print(timebuffer)
-    timestamp = (min_time + timedelta(days=30)) + timebuffer
+        timebuffer = (max_time - min_time) / 2
+        timestamp = min_time + timebuffer
+    else:
+        timebuffer = (
+            (max_time + timedelta(days=30)) - (min_time - timedelta(days=30))
+        ) / 2
+        # print(timebuffer)
+        timestamp = (min_time - timedelta(days=30)) + timebuffer
 
     # Now we get a list of all the timestamps and captures that fall in this range.
     worldView = baseConstellation == 'WV'

--- a/django/src/rdwatch_scoring/tasks/__init__.py
+++ b/django/src/rdwatch_scoring/tasks/__init__.py
@@ -246,7 +246,6 @@ def get_siteobservations_images(
         timebuffer = (
             (max_time + timedelta(days=30)) - (min_time - timedelta(days=30))
         ) / 2
-        # print(timebuffer)
         timestamp = (min_time - timedelta(days=30)) + timebuffer
 
     # Now we get a list of all the timestamps and captures that fall in this range.

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -154,7 +154,7 @@ const toggleText = () => {
           size="x-small"
           class="mx-2"
         >
-          RGD
+          RD-WATCH
         </v-btn>
         <v-btn
           to="/scoring"


### PR DESCRIPTION
This fixes a bug in the time range downloading of satellite images.

 Background:
- The timerange feature for downloading images would usually take the Site Start/End date and add 30 days to each end to grab more information.
- Our internal functions rely on a timestamp + time buffer to determine what to request from the STAC server.  So after adding the 30 days to max and substracting the 30 days from the min we could get a date range and divide that by 2 to get a time buffer.
- This time buffer was then added to the min_time - 30 days to get a central date in the range.  That central date was given to the function with time buffer.

Bug:
The bug happened in calculating the central timestamp.  Instead of `min_time - 30 days` it was `min_time + 30 days` this would set the whole time range off and have it further ahead in time than it should be.
https://github.com/ResonantGeoData/RD-WATCH/blob/main/django/src/rdwatch_scoring/tasks/__init__.py#L246

Fixes:

- I fixed the bug so that is is now `min_time - 30 days` in both the RGD and Scoring apps
- I updated it so if the user specifies and overrides those are now the cutoff points.  Meaning it doesn't +/- 30 days to the time range when you override the default dates for downloading.
- Swapped RGD to RD-WATCH in the UI for the buttons selecting where to be.



