### PR TITLE
Docker Client Dev Service

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,14 +13,15 @@ This is the simplest configuration for developers to start with.
 5. Run `docker compose run --rm django poetry run django-admin loaddata lookups` to initialize your database with required data.
 6. Optionally, populate your database with test data by running `docker compose run --rm django poetry run django-admin loaddata testdata`
 7. Optionally, create an account for the Django admin (http://localhost:8000/admin) by running `docker compose run --rm django poetry --directory django run django-admin createsuperuser`
-8. Start the client development server:
+8. If running the docker compose by default a client development server should be started at http://localhost:8080/
+9. If doing local Client Development, start the client development server:
    ```sh
    cd vue
    npm install
    npm run dev
    ```
-9. Access the site, starting at http://localhost:8080/
-10. When finished, use `Ctrl+C`
+   The server will be started at http://localhost:3000 as to not conflict with the docker compose development service
+   When finished, use `Ctrl+C`
 
 ## Develop Natively (advanced)
 This configuration still uses Docker to run attached services in the background,

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -91,7 +91,7 @@ services:
     container_name: rd-watch-client
     working_dir: /usr/src/app
     environment:
-      VITE_DOCKER_DEVELOPMENT: "true" # tells vite.config to use django:8000 instead of localhost:8000
+      VITE_DEV_PROXY_TARGET: "django" # tells vite.config to use django:8000 instead of localhost:8000
     volumes:
       - ./:/usr/src/source:ro # entire directory needs to be mounted for git reference
     ports:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -86,3 +86,30 @@ services:
       RDWATCH_CELERY_BROKER_URL: amqp://rdwatch:secretkey@rabbitmq:5672/
     volumes:
       - ./django:/app/django
+  rdwatch-client:
+    image: node:20
+    container_name: rd-watch-client
+    working_dir: /usr/src/app
+    environment:
+      VITE_DOCKER_DEVELOPMENT: "true" # tells vite.config to use django:8000 instead of localhost:8000
+    volumes:
+      - ./:/usr/src/source # entire directory needs to be mounted for git reference
+    ports:
+      - "8080:8080"
+      # required for the git display of the commit hash
+    command: >
+      sh -c "
+        # Copy the contents of /usr/src/source to /usr/src/app to prevent overwriting local node_modules
+        cp -r /usr/src/source /usr/src/app &&
+        # Configure git to treat /usr/src/app/source/ as a safe directory for client hash displaying
+        git config --global --add safe.directory /usr/src/app/source/ &&
+
+        # Change directory to /usr/src/app/source/vue
+        cd /usr/src/app/source/vue &&
+
+        # Install npm dependencies
+        npm install &&
+
+        # Run the npm development script
+        npm run dev
+      "

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -93,7 +93,7 @@ services:
     environment:
       VITE_DOCKER_DEVELOPMENT: "true" # tells vite.config to use django:8000 instead of localhost:8000
     volumes:
-      - ./:/usr/src/source # entire directory needs to be mounted for git reference
+      - ./:/usr/src/source:ro # entire directory needs to be mounted for git reference
     ports:
       - "8080:8080"
       # required for the git display of the commit hash

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -16,14 +16,14 @@ export default ({ mode}) => {
     .toString()
     .trimEnd();
 
-    process.env.VITE_GIT_COMMIT_DATE = commitDate;
-    process.env.VITE_GIT_BRANCH_NAME = branchName;
-    process.env.VITE_GIT_COMMIT_HASH = commitHash;
-    process.env.VITE_GIT_LAST_COMMIT_MESSAGE = lastCommitMessage;
-    const dockerDev = process.env.VITE_DOCKER_DEVELOPMENT;
-    // Change host to django when running vite inside docker
-    const devHost = dockerDev ? 'django' : 'localhost';
-    const devPort = dockerDev ? 8080 : 3000;
+  process.env.VITE_GIT_COMMIT_DATE = commitDate;
+  process.env.VITE_GIT_BRANCH_NAME = branchName;
+  process.env.VITE_GIT_COMMIT_HASH = commitHash;
+  process.env.VITE_GIT_LAST_COMMIT_MESSAGE = lastCommitMessage;
+  const dockerDev = process.env.VITE_DOCKER_DEVELOPMENT;
+  // Change host to django when running vite inside docker
+  const devHost = dockerDev ? 'django' : 'localhost';
+  const devPort = dockerDev ? 8080 : 3000;
   return defineConfig({
       plugins: [vue()],
       server: {

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -1,35 +1,41 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { execSync } from "child_process";
 
-export default defineConfig(() => {
-  // Load env file based on `mode` in the current working directory.
-  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-  const commitDate = execSync("git log -1 --format=%cI").toString().trimEnd();
-  const branchName = execSync("git rev-parse --abbrev-ref HEAD")
-    .toString()
-    .trimEnd();
-  const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
-  const lastCommitMessage = execSync("git show -s --format=%s")
-    .toString()
-    .trimEnd();
+export default ({ mode}) => {
+  // Loads all environment variables to see if we are in VITE_DOCKER_DEVELOPMENT
+  process.env = {...process.env, ...loadEnv(mode, process.cwd())};
+    // Load env file based on `mode` in the current working directory.
+    // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+    const commitDate = execSync("git log -1 --format=%cI").toString().trimEnd();
+    const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+      .toString()
+      .trimEnd();
+    const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
+    const lastCommitMessage = execSync("git show -s --format=%s")
+      .toString()
+      .trimEnd();
 
-  process.env.VITE_GIT_COMMIT_DATE = commitDate;
-  process.env.VITE_GIT_BRANCH_NAME = branchName;
-  process.env.VITE_GIT_COMMIT_HASH = commitHash;
-  process.env.VITE_GIT_LAST_COMMIT_MESSAGE = lastCommitMessage;
-  return {
-    plugins: [vue()],
-    server: {
-      host: "0.0.0.0",
-      port: 8080,
-      proxy: {
-        "/api": {
-          target: "http://localhost:8000",
-          xfwd: true,
+    process.env.VITE_GIT_COMMIT_DATE = commitDate;
+    process.env.VITE_GIT_BRANCH_NAME = branchName;
+    process.env.VITE_GIT_COMMIT_HASH = commitHash;
+    process.env.VITE_GIT_LAST_COMMIT_MESSAGE = lastCommitMessage;
+    const dockerDev = process.env.VITE_DOCKER_DEVELOPMENT;
+    // Change host to django when running vite inside docker
+    const devHost = dockerDev ? 'django' : 'localhost';
+    const devPort = dockerDev ? 8080 : 3000;
+  return defineConfig({
+      plugins: [vue()],
+      server: {
+        host: "0.0.0.0",
+        port: devPort,
+        proxy: {
+          "/api": {
+            target: `http://${devHost}:8000`,
+            xfwd: true,
+          },
         },
+        strictPort: true,
       },
-      strictPort: true,
-    },
-  };
-});
+    });
+}

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -3,7 +3,7 @@ import vue from "@vitejs/plugin-vue";
 import { execSync } from "child_process";
 
 export default ({ mode}) => {
-  // Loads all environment variables to see if we are in VITE_DOCKER_DEVELOPMENT
+  // Loads all environment variables to see if we are in VITE_DEV_PROXY_TARGET
   process.env = {...process.env, ...loadEnv(mode, process.cwd())};
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
@@ -20,10 +20,9 @@ export default ({ mode}) => {
   process.env.VITE_GIT_BRANCH_NAME = branchName;
   process.env.VITE_GIT_COMMIT_HASH = commitHash;
   process.env.VITE_GIT_LAST_COMMIT_MESSAGE = lastCommitMessage;
-  const dockerDev = process.env.VITE_DOCKER_DEVELOPMENT;
+  const devHost = process.env.VITE_DEV_PROXY_TARGET || 'localhost';
   // Change host to django when running vite inside docker
-  const devHost = dockerDev ? 'django' : 'localhost';
-  const devPort = dockerDev ? 8080 : 3000;
+  const devPort = process.env.VITE_DEV_PROXY_TARGET ? 8080 : 3000;
   return defineConfig({
       plugins: [vue()],
       server: {

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -5,16 +5,16 @@ import { execSync } from "child_process";
 export default ({ mode}) => {
   // Loads all environment variables to see if we are in VITE_DOCKER_DEVELOPMENT
   process.env = {...process.env, ...loadEnv(mode, process.cwd())};
-    // Load env file based on `mode` in the current working directory.
-    // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-    const commitDate = execSync("git log -1 --format=%cI").toString().trimEnd();
-    const branchName = execSync("git rev-parse --abbrev-ref HEAD")
-      .toString()
-      .trimEnd();
-    const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
-    const lastCommitMessage = execSync("git show -s --format=%s")
-      .toString()
-      .trimEnd();
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const commitDate = execSync("git log -1 --format=%cI").toString().trimEnd();
+  const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+    .toString()
+    .trimEnd();
+  const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
+  const lastCommitMessage = execSync("git show -s --format=%s")
+    .toString()
+    .trimEnd();
 
     process.env.VITE_GIT_COMMIT_DATE = commitDate;
     process.env.VITE_GIT_BRANCH_NAME = branchName;


### PR DESCRIPTION
- Adds a rdwatch-client service to the docker-compose.override.yml
- I need to mount the full app because we need the git information for the client to display the hash.
- I copy over the folder (mounted as read only) so npm can install node_modules without messing with the user's local permissions
- There is a git config setting to allow it to read data that isn't owned by the user for the client hash displaying
- NPM install is ran and then npm run dev to launch the server
- vite config is modified with an environment variable `VITE_DOCKER_DEVELOPMENT` which tells it to proxy to the `django` container instead of `localhost`.
- If the `VITE_DOCKER_DEVELOPMENT` is false it will instead run the dev server at `localhost:3000` so it isn't conflicting with the docker compose service port.

I'm all for any argument you have about making another Dockerfile and using that to build the container instead of doing it at launch each time through the commands like I am.   I just figured that this would mainly be used for demoing and development so having an up-to-date version of the client code would always make sense.  We could always build another image and make it part of our Github container registry.