### PR TITLE
Image Viewer Rescaling 

### DIFF
--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -954,7 +954,7 @@ onUnmounted(() => {
               min="1"
               max="5"
               step="0.1"
-              :label="`Rescale (${rescalingBBox.toFixed(2)})X`"
+              :label="`Zoom out (${rescalingBBox.toFixed(2)})X`"
             />
           </v-row>
 

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -74,6 +74,7 @@ const groundTruth: Ref<EvaluationImageResults['groundTruth'] | null > = ref(null
 const drawGroundTruth = ref(false);
 const siteEvaluationList = computed(() => Object.entries(styles).filter(([, { type }]) => type === 'sites').map(([label]) => label));
 const rescaleImage = ref(false);
+const rescalingBBox = ref(1);
 
 const playbackEnabled = ref(false); // Auto playback of images
 
@@ -199,7 +200,7 @@ function drawForDownload() {
       width = ratio * 500;
     }
   }
-  const offScreenCanvas = createCanvas(width, height);
+  const offScreenCanvas = createCanvas(width * rescalingBBox.value, height * rescalingBBox.value);
   downloadingGifState.value = 'drawing';
   CanvasCapture.init(offScreenCanvas, { verbose: false});
   CanvasCapture.beginGIFRecord({
@@ -223,6 +224,7 @@ function drawForDownload() {
         drawGroundTruth.value,
         rescaleImage.value,
         props.fullscreen,
+        rescalingBBox.value,
       );
       CanvasCapture.recordFrame();
       index += 1
@@ -261,6 +263,7 @@ const load = async (newValue?: string, oldValue?: string) => {
         drawGroundTruth.value,
         rescaleImage.value,
         props.fullscreen,
+        rescalingBBox.value,
         )
   }
   loading.value = false;
@@ -284,7 +287,7 @@ const copyURL = async (mytext: string) => {
   }
 
 
-watch([currentImage, imageRef, filteredImages, drawGroundTruth, rescaleImage], () => {
+watch([currentImage, imageRef, filteredImages, drawGroundTruth, rescaleImage, rescalingBBox], () => {
     if (currentImage.value < filteredImages.value.length && imageRef.value !== null) {
         imageRef.value.src = filteredImages.value[currentImage.value].image.image;
     }
@@ -301,6 +304,7 @@ watch([currentImage, imageRef, filteredImages, drawGroundTruth, rescaleImage], (
           drawGroundTruth.value,
           rescaleImage.value,
           props.fullscreen,
+          rescalingBBox.value,
         )
     }
     if (props.dialog === false && !props.fullscreen && filteredImages.value[currentImage.value]) {
@@ -944,6 +948,16 @@ onUnmounted(() => {
               :rules="[v => v > 0 || 'Value must be greater than 0']"
             />
           </v-row>
+          <v-row dense>
+            <v-slider
+              v-model="rescalingBBox"
+              min="1"
+              max="5"
+              step="0.1"
+              :label="`Rescale (${rescalingBBox.toFixed(2)})X`"
+            />
+          </v-row>
+
           <v-row dense>
             <v-slider
               v-model="downloadingGifQuality"


### PR DESCRIPTION
When using the rescaling function on the image-viewer there were complaints that it was difficult to see the S2/L8 images because they were scaled up to match the geospatial bounds of the WV images.

This PR adds an option in the settings to zoom out the rescaled images to provide more context for the S2/L8 images (up to 5X the size of the box).

Since we don't have any additional data for the WorldView image outside of it's bounds it is marked as gray outside of the area.

Note: 
- Zooming out on a mix of WV and S2 can result in a large GIF because I'm still displaying the WV at native resolution.  I.E if the WorldView resolution is 500x500 and you zoom out 2X then all images in the GIF sequence are now 1000x1000 with the S2/L8 images upscaled to fit there.