### PR TITLE
Client Filter Refactors

### DIFF
--- a/vue/src/client/models/ModelRun.ts
+++ b/vue/src/client/models/ModelRun.ts
@@ -17,7 +17,6 @@ export type ModelRun = {
     max: number;
   } | null;
   bbox: GeoJSON.Polygon | null;
-  hasScores?: boolean;
   created: string;
   expiration_time: string;
   proposal?: null | 'PROPOSAL' | 'APPROVED';

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -470,18 +470,6 @@ export class ApiService {
     });
   }
 
-  public static hasScores(
-    configurationId: number,
-    region: string,
-  ): CancelablePromise<boolean>
-  {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/api/scores/has-scores",
-      query: { configurationId, region },
-    });
-  }
-
   public static getEvaluationImages(id: string): CancelablePromise<EvaluationImageResults> {
     return __request(OpenAPI, {
       method: "GET",

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -16,7 +16,6 @@ import { useRoute } from "vue-router";
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
-const page = ref<number>(1);
 const route = useRoute();
 watch(() => route.path, (oldPath, newPath) => {
   if ((!oldPath.includes('/scoring') && newPath.includes('/scoring')) || (oldPath.includes('/scoring') && !newPath.includes('/scoring'))) {
@@ -37,7 +36,6 @@ const scoringApp = computed(()=> route.path.includes('scoring') && !route.path.i
 
 
 const queryFilters = computed<QueryArguments>(() => ({
-  page: page.value,
   performer: selectedPerformer.value.map((item) => item.short_code),
   region: selectedRegion.value,
   mode: selectedModes.value,
@@ -60,26 +58,6 @@ watch (() => state.filters.regions, () => {
   }
 });
 
-const updateRegion = (val?: Region) => {
-  page.value = 1;
-  if (selectedRegion.value === undefined) {
-    state.satellite.satelliteImagesOn = false;
-    state.enabledSiteObservations = [];
-    state.selectedObservations = [];
-  }
-  state.filters = {
-    ...state.filters,
-    regions: val === undefined ? undefined : [val],
-  };
-};
-
-const updateMode = (mode: string[]) => {
-  page.value = 1;
-  state.filters = {
-    ...state.filters,
-    mode,
-  };
-};
 
 const expandSettings = ref(false);
 
@@ -100,11 +78,6 @@ const drawMap = computed({
     state.filters = { ...state.filters, drawMap: val };
   },
 });
-
-
-function nextPage() {
-  page.value += 1;
-}
 
 onMounted(() => {
   window.document.addEventListener('keydown', (event) => {
@@ -247,7 +220,6 @@ const toggleText = () => {
           cols="6"
           class="px-1"
           hide-details
-          @update:model-value="updateRegion($event)"
         />
       </v-row>
       <v-row
@@ -259,7 +231,6 @@ const toggleText = () => {
           v-model="selectedModes"
           class="px-1"
           hide-details
-          @update:model-value="updateMode($event)"
         />
         <EvalFilter
           v-model="selectedEval"
@@ -277,7 +248,6 @@ const toggleText = () => {
       <ModelRunList
         :filters="queryFilters"
         class="flex-grow-1"
-        @next-page="nextPage"
         @update:timerange="
           (timerange) => {
             if (timerange !== null) {

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -11,10 +11,7 @@ import { changeTime } from "../../interactions/timeStepper";
 
 const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
-const page = ref<number>(1);
-
 const queryFilters = computed<QueryArguments>(() => ({
-  page: page.value,
   performer: selectedPerformer.value.map((item) => item.short_code),
   region: selectedRegion.value,
 }));
@@ -33,22 +30,6 @@ watch (() => state.filters.regions, () => {
   }
 });
 
-const updateRegion = (val?: Region) => {
-  page.value = 1;
-  if (selectedRegion.value === undefined) {
-    state.satellite.satelliteImagesOn = false;
-    state.enabledSiteObservations = [];
-    state.selectedObservations = [];
-  }
-  state.filters = {
-    ...state.filters,
-    regions: val === undefined ? undefined : [val],
-  };
-};
-
-function nextPage() {
-  page.value += 1;
-}
 
 onMounted(() => {
   window.document.addEventListener('keydown', (event) => {
@@ -98,7 +79,6 @@ onMounted(() => {
         <RegionFilter
           v-model="selectedRegion"
           cols="6"
-          @update:model-value="updateRegion($event)"
         />
       </v-row>
     </div>
@@ -110,7 +90,6 @@ onMounted(() => {
         :filters="queryFilters"
         class="flex-grow-1"
         compact
-        @next-page="nextPage"
         @update:timerange="
           (timerange) => {
             if (timerange !== null) {

--- a/vue/src/components/filters/EvalFilter.vue
+++ b/vue/src/components/filters/EvalFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, watchEffect } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { ApiService } from "../../client";
 import type { Ref } from "vue";
 import type { Eval } from "../../client";
@@ -14,13 +14,17 @@ const emit = defineEmits<{
 
 const evals: Ref<Eval[]> = ref([]);
 const selectedEvals: Ref<Eval[]> = ref(props.modelValue);
-watchEffect(async () => {
+const loadEvals = async () => {
   if (ApiService.getApiPrefix().includes('scoring')) {
     const evalList = await ApiService.getEvals();
     const evalResults = evalList.items
     evals.value = evalResults;
   }
-});
+};
+
+watch(() => ApiService.getApiPrefix(), loadEvals);
+
+onMounted(() => loadEvals());
 
 watch(() => props.modelValue, () => {
   if (props.modelValue) {
@@ -28,9 +32,9 @@ watch(() => props.modelValue, () => {
   }
 });
 
-watch(selectedEvals, (l) => {
-  if (l) {
-    emit("update:modelValue", l);
+watch(selectedEvals, (evals) => {
+  if (evals) {
+    emit("update:modelValue", evals);
     return;
   }
   emit("update:modelValue", []);

--- a/vue/src/components/filters/PerformerFilter.vue
+++ b/vue/src/components/filters/PerformerFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, watchEffect } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { ApiService, PerformerList } from "../../client";
 import type { Ref } from "vue";
 import type { Performer } from "../../client";
@@ -19,7 +19,7 @@ const performers: Ref<{value: number; title: string}[]> = ref([]);
 const selectedPerformers: Ref<number[]> = ref(props.modelValue.map((item) => item.id));
 const performerList: Ref<PerformerList | null> = ref(null);
 const performerIdMap: Record<number, Performer> = {}
-  watchEffect(async () => {
+const loadPerformers = async () => {
   performerList.value = await ApiService.getPerformers();
   const performerResults = performerList.value.items
   performerResults.sort((a, b) => (a.team_name > b.team_name ? 1 : -1))
@@ -29,8 +29,10 @@ const performerIdMap: Record<number, Performer> = {}
     performers.value.push({title: item.team_name, value: item.id });
   })
   state.performerMapping = performerIdMap;
-});
+};
+onMounted(() => loadPerformers());
 
+watch(() => ApiService.getPerformers(), loadPerformers);
 watch(() => props.modelValue, () => {
   selectedPerformers.value = props.modelValue.map((item) => item.id);
 });

--- a/vue/src/components/filters/RegionFilter.vue
+++ b/vue/src/components/filters/RegionFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, watchEffect } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { ApiService } from "../../client";
 import type { Ref } from "vue";
 import type { Region } from "../../client";
@@ -18,12 +18,15 @@ const emit = defineEmits<{
 
 const regions: Ref<Region[]> = ref([]);
 const selectedRegion: Ref<string | undefined> = ref(props.modelValue);
-watchEffect(async () => {
+const loadRegions =  async () => {
   const regionList = await ApiService.getRegions();
   const regionResults = regionList.items;
   regionResults.sort((a, b) => (a > b ? 1 : -1));
   regions.value = regionResults;
-});
+};
+onMounted(() => loadRegions());
+
+watch(() => ApiService.getRegions(), loadRegions);
 
 watch(() => props.modelValue, () => {
   if (props.modelValue) {

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -331,7 +331,7 @@ export const toggleSatelliteImages = (siteObs: SiteObservation, off= false) => {
   }
 }
 
-export const loadAndToggleSatelliteImages = async (siteId: string) => {
+const loadAndToggleSatelliteImages = async (siteId: string) => {
   const index = state.enabledSiteObservations.findIndex((item) => item.id === siteId);
   if (index !== -1) {
     const tempArr = [...state.enabledSiteObservations];
@@ -341,6 +341,8 @@ export const loadAndToggleSatelliteImages = async (siteId: string) => {
   const data = await getSiteObservationDetails(siteId, undefined, false);
   toggleSatelliteImages(data);
   }
+}
 
-
+export {
+  loadAndToggleSatelliteImages,
 }


### PR DESCRIPTION
- Swapped instances of `watchEffect` to `watch` to be more explicit about what values are triggering a request to gather more data.  I.E the filters only change when the value changes, this could be changed by the ApiPrefix switching from the standard `/` to `/scoring` or if the value changes outside of the component.  This happens in Regions due to the URL route for different regions.
- This resulted in removing some redundant calls to update values.
- I removed the `nextPage` emit signal loop from `ModelRunList.vue` up to `SideBar.vue`.  Now it's managed by the `ModelRunList.vue` instead of making that round trip.
- Removed references to `hasScores` it was the old way to connect data between the scoringDB and the RGD DB.  It's no longer needed so I removed some code that was there.