### PR TITLE
Notes Update

### DIFF
--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -629,15 +629,22 @@ onUnmounted(() => {
           </div>
         </v-col>
         <v-col>
-          <div class="ml-3">
+          <div class="notesPreview">
             <b>Notes:</b>
-            <span> {{ siteEvaluationNotes }}</span>
             <v-icon
               v-if="editMode"
               @click="setEditingMode('SiteEvaluationNotes')"
             >
               mdi-pencil
             </v-icon>
+            <v-tooltip
+              :text="siteEvaluationNotes"
+              location="bottom center"
+            >
+              <template #activator="{ props:subProps }">
+                <span v-bind="subProps"> {{ siteEvaluationNotes }}</span>
+              </template>
+            </v-tooltip>
           </div>
         </v-col>
         <v-spacer />
@@ -1121,13 +1128,14 @@ onUnmounted(() => {
       <v-card v-if="currentEditMode === 'SiteEvaluationNotes'">
         <v-card-title>Edit Site Model Notes</v-card-title>
         <v-card-text>
-          <v-text-field
+          <v-textarea
             v-model="siteEvaluationNotes"
             label="Notes"
           />
         </v-card-text>
         <v-card-actions>
           <v-row dense>
+            <v-spacer />
             <v-btn
               color="error"
               class="mx-3"
@@ -1172,5 +1180,13 @@ onUnmounted(() => {
 .top-bar {
   font-size:12px;
   font-weight: bold;
+}
+
+.notesPreview {
+  min-width: 150px;
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
Per an issue in gitlab about notes overflowing and not having enough room to type notes.

- switched to truncate: ellipsis for the notes with a tooltip hover to show the full note
- The v-text-field was change to a v-textarea to allow easier editing.

![image](https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/aa22c635-5979-4350-b5a0-cb16698ec51b)

![image](https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/bbff6684-98a3-4db5-bedc-4b37b9b3548f)
