### PR TITLE
Fix scoring DB query error

### DIFF
--- a/tileserver/package.json
+++ b/tileserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resonantgeodata/rdwatch-vector-tileserver",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/resonantgeodata/RD-WATCH.git"

--- a/tileserver/scoring.mjs
+++ b/tileserver/scoring.mjs
@@ -110,6 +110,7 @@ const QUERY = `
               AND U0."site_truth" = ("site"."site_id")
               AND U0."tau" = 0.2
             )
+          LIMIT 1
         )
         WHEN (
           NOT ("site"."originator" = 'te')
@@ -127,6 +128,7 @@ const QUERY = `
               AND U0."site_proposal" = ("site"."site_id")
               AND U0."tau" = 0.2
             )
+          LIMIT 1
         )
         ELSE NULL
       END AS "color_code"


### PR DESCRIPTION
It seems it's possible for the scoring DB to have the same color code repeated in the DB, which was causing a subquery error message in the vector tile generation.