### PR TITLE
Add support for PlanetLab imagery

### DIFF
--- a/django/src/rdwatch/schemas/site_observation.py
+++ b/django/src/rdwatch/schemas/site_observation.py
@@ -9,7 +9,7 @@ class SiteObservationRequest(Schema):
     geom: dict | None = None  # TODO: Replace with pydantics geoJSON
     score: float | None
     timestamp: datetime
-    constellation: str  # WV, S8, L8
+    constellation: str  # WV, S8, L8, PL
     spectrum: str | None
     notes: str | None
 

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -195,7 +195,7 @@ def get_siteobservations_images(
                 source=baseConstellation,
             )
             if (
-                baseConstellation in ('S2', 'L8')
+                baseConstellation in ('S2', 'L8', 'PL')
                 and dayRange > -1
                 and is_inside_range(
                     found_timestamps.keys(), observation.timestamp, dayRange
@@ -308,11 +308,8 @@ def get_siteobservations_images(
         )
 
     logger.warning(f'Found {num_of_captures} captures')
-    for (
-        capture
-    ) in (
-        captures
-    ):  # Now we go through the list and add in a timestmap if it doesn't exist
+    # Now we go through the list and add in a timestamp if it doesn't exist
+    for capture in captures:
         self.update_state(
             state='PROGRESS',
             meta={
@@ -324,7 +321,7 @@ def get_siteobservations_images(
         )
         capture_timestamp = capture.timestamp.replace(microsecond=0)
         if (
-            (baseConstellation == 'S2' or baseConstellation == 'L8')
+            baseConstellation in ('S2', 'L8', 'PL')
             and dayRange > -1
             and is_inside_range(found_timestamps.keys(), capture_timestamp, dayRange)
         ):

--- a/django/src/rdwatch/utils/satellite_bands.py
+++ b/django/src/rdwatch/utils/satellite_bands.py
@@ -28,7 +28,7 @@ def get_bands(
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,
 ) -> Iterator[Band]:
-    if constellation != 'S2' and constellation != 'L8':
+    if constellation not in ('S2', 'L8', 'PL'):
         raise ValueError(f'Unsupported constellation {constellation}')
 
     results = stac_search(
@@ -77,6 +77,7 @@ def get_bands(
                     )
                     or collection.startswith('ta1-s2-acc-')
                     or collection.startswith('ta1-ls-acc-')
+                    or collection.startswith('ta1-pd-acc-')
                 ):
                     level, _ = ProcessingLevel.objects.get_or_create(
                         slug='2A',

--- a/django/src/rdwatch/utils/stac_search.py
+++ b/django/src/rdwatch/utils/stac_search.py
@@ -53,15 +53,17 @@ def _fmt_time(time: datetime):
 COLLECTIONS: dict[str, list[str]] = {
     'L8': [],
     'S2': [],
+    'PL': [],
 }
 
 if settings.ACCENTURE_VERSION is not None:
     COLLECTIONS['S2'].append(f'ta1-s2-acc-{settings.ACCENTURE_VERSION}')
     COLLECTIONS['L8'].append(f'ta1-ls-acc-{settings.ACCENTURE_VERSION}')
+    COLLECTIONS['PL'].append(f'ta1-pd-acc-{settings.ACCENTURE_VERSION}')
 
 
 def stac_search(
-    source: Literal['S2', 'L8'],
+    source: Literal['S2', 'L8', 'PL'],
     timestamp: datetime,
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -447,6 +447,7 @@ def get_proposals_query(model_run_id: UUID4):
             S2=Count(Case(When(siteimage__source='S2', then=1))),
             WV=Count(Case(When(siteimage__source='WV', then=1))),
             L8=Count(Case(When(siteimage__source='L8', then=1))),
+            PL=Count(Case(When(siteimage__source='PL', then=1))),
             time=ExtractEpoch('timestamp'),
             site_id=F('id'),
             downloading=Exists(

--- a/django/src/rdwatch/views/site_observation.py
+++ b/django/src/rdwatch/views/site_observation.py
@@ -171,7 +171,7 @@ def site_observations(request: HttpRequest, evaluation_id: UUID4):
 
 
 class GenerateImagesSchema(Schema):
-    constellation: list[Literal['WV', 'S2', 'L8']] = ['WV']
+    constellation: list[Literal['WV', 'S2', 'L8', 'PL']] = ['WV']
     dayRange: int = 14
     noData: int = 50
     overrideDates: None | list[str] = None

--- a/django/src/rdwatch_scoring/tasks/__init__.py
+++ b/django/src/rdwatch_scoring/tasks/__init__.py
@@ -111,7 +111,7 @@ def get_siteobservations_images(
         baseSiteEval.union_geometry
     ).extent
 
-    # if width | height is too small we pad S2/L8 regions for more context
+    # if width | height is too small we pad S2/L8/PL regions for more context
     bbox_width = (bbox[2] - bbox[0]) * ToMeters
     bbox_height = (bbox[3] - bbox[1]) * ToMeters
     logger.warning('BBOX')
@@ -178,7 +178,7 @@ def get_siteobservations_images(
                 source=baseConstellation,
             )
             if (
-                baseConstellation in ('S2', 'L8')
+                baseConstellation in ('S2', 'L8', 'PL')
                 and dayRange > -1
                 and is_inside_range(found_timestamps.keys(), observation.date, dayRange)
             ):
@@ -298,7 +298,7 @@ def get_siteobservations_images(
         )
         capture_timestamp = capture.timestamp.replace(microsecond=0)
         if (
-            (baseConstellation == 'S2' or baseConstellation == 'L8')
+            baseConstellation in ('S2', 'L8', 'PL')
             and dayRange > -1
             and is_inside_range(found_timestamps.keys(), capture_timestamp, dayRange)
         ):

--- a/django/src/rdwatch_scoring/views/observation.py
+++ b/django/src/rdwatch_scoring/views/observation.py
@@ -27,7 +27,7 @@ router = Router()
 
 
 class GenerateImagesSchema(Schema):
-    constellation: list[Literal['WV', 'S2', 'L8']] = ['WV']
+    constellation: list[Literal['WV', 'S2', 'L8', 'PL']] = ['WV']
     dayRange: int = 14
     noData: int = 50
     overrideDates: None | list[str] = None

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -59,6 +59,7 @@ export interface Proposals {
     S2: number,
     WV: number,
     L8: number,
+    PL: number,
     number: number,
     start_date: number;
     end_date: number;
@@ -91,7 +92,7 @@ export interface SiteObservationUpdateQuery {
 
 }
 
-export type Constellation  = 'S2' | 'WV' | 'L8';
+export type Constellation  = 'S2' | 'WV' | 'L8' | 'PL';
 export interface DownloadSettings {
   constellation: Constellation[];
   dayRange?: number;

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
     (e: "cancel"): void;
 }>();
 
-const baseList = ref(['S2', 'WV', 'L8'])
+const baseList = ref(['S2', 'WV', 'L8', 'PL'])
 const selectedSource: Ref<Constellation[]> = ref(['WV']);
 const dayRange = ref(14);
 const noData = ref(50)
@@ -194,7 +194,7 @@ const display = ref(true);
                   </v-icon>
                 </template>
                 <span>
-                  Day Limit applies to S2/L8 imagery to grab one image every X days.  This is to prevent loading hundreds of images
+                  Day Limit applies to S2/L8/PL imagery to grab one image every X days.  This is to prevent loading hundreds of images
                 </span>
               </v-tooltip>
             </v-row>

--- a/vue/src/components/annotationViewer/ProposalList.vue
+++ b/vue/src/components/annotationViewer/ProposalList.vue
@@ -23,6 +23,7 @@ export interface ProposalDisplay {
   S2: number;
   WV: number;
   L8: number;
+  PL: number;
   status: SiteModelStatus;
   timestamp: number;
   downloading: boolean;
@@ -90,6 +91,7 @@ const getSiteProposals = async () => {
           S2: item.S2,
           WV: item.WV,
           L8: item.L8,
+          PL: item.PL,
           status: item.status,
           timestamp: item.timestamp,
           downloading: item.downloading,
@@ -211,6 +213,9 @@ const startDownload = async (data: DownloadSettings) => {
               <v-chip size="x-small">
                 L8: {{ item.L8 }}
               </v-chip>
+              <v-chip size="x-small">
+                PL: {{ item.PL }}
+              </v-chip>
             </div>
             <div v-else>
               <v-chip
@@ -252,7 +257,7 @@ const startDownload = async (data: DownloadSettings) => {
             <v-spacer />
             <v-tooltip>
               <template #activator="{ props:subProps }">
-                <v-btn 
+                <v-btn
                   v-if="!item.downloading"
                   size="x-small"
                   v-bind="subProps"
@@ -261,7 +266,7 @@ const startDownload = async (data: DownloadSettings) => {
                 >
                   Get <v-icon>mdi-image</v-icon>
                 </v-btn>
-                <v-btn 
+                <v-btn
                   v-else-if="item.downloading"
                   size="x-small"
                   v-bind="subProps"

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -57,11 +57,11 @@ const siteEvaluationUpdated = ref(false)
 const siteStatus: Ref<string | null> = ref(null);
 const imageRef: Ref<HTMLImageElement | null> = ref(null);
 const canvasRef: Ref<HTMLCanvasElement | null> = ref(null);
-const baseImageSources = ref(['S2', 'WV', 'L8'])
+const baseImageSources = ref(['S2', 'WV', 'L8', 'PL'])
 const baseObs = ref(['observations', 'non-observations'])
 const filterSettings = ref(false);
 const combinedImages: Ref<{image: EvaluationImage; poly: PixelPoly, groundTruthPoly?: PixelPoly}[]> = ref([]);
-const imageSourcesFilter: Ref<EvaluationImage['source'][]> = ref(['S2', 'WV', 'L8']);
+const imageSourcesFilter: Ref<EvaluationImage['source'][]> = ref(['S2', 'WV', 'L8', 'PL']);
 const percentBlackFilter: Ref<number> = ref(100);
 const cloudFilter: Ref<number> = ref(100);
 const siteObsFilter: Ref<('observations' | 'non-observations')[]> = ref(['observations', 'non-observations'])
@@ -542,7 +542,7 @@ const deleteSelectedPoints = () => {
 
       <v-col v-if="obsDetails">
         <b
-          v-if="groundTruth && hasGroundTruth" 
+          v-if="groundTruth && hasGroundTruth"
           class="mr-1"
         >Model Date Range:</b>
         <span>{{ startDate }}</span> to <span> {{ endDate }}</span>

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -70,7 +70,7 @@ const drawData = (
           const canvasHeight = canvas.height;
           if (rescale) {
             canvas.width = canvas.width * canvasScale;
-            canvas.height = canvas.height * canvasScale;  
+            canvas.height = canvas.height * canvasScale;
           }
           // draw the offscreen canvas
             let destWidth = canvasWidth;
@@ -84,7 +84,7 @@ const drawData = (
             let imageWidth = rescale && poly.scaled ? poly.scaled.crop.width: imageDim[0];
             let imageHeight = rescale && poly.scaled ? poly.scaled.crop.height: imageDim[1];
             //Now if we have more image data than the scaled width and height are available we can take additional pixel information
-            if (rescale && poly.scaled) { //Implies S3/L8 data where more pixel data can be taken
+            if (rescale && poly.scaled) { //Implies S3/L8/PL data where more pixel data can be taken
               computedX = poly.scaled.crop.x - (((poly.scaled.crop.width  * canvasScale) - poly.scaled.crop.width ) / 2.0);
               computedY = poly.scaled.crop.y - (((poly.scaled.crop.height * canvasScale) - poly.scaled.crop.height) / 2.0);
               imageWidth = poly.scaled.crop.width * canvasScale;

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -84,7 +84,7 @@ const drawData = (
             let imageWidth = rescale && poly.scaled ? poly.scaled.crop.width: imageDim[0];
             let imageHeight = rescale && poly.scaled ? poly.scaled.crop.height: imageDim[1];
             //Now if we have more image data than the scaled width and height are available we can take additional pixel information
-            if (rescale && poly.scaled) { //Implies S3/L8/PL data where more pixel data can be taken
+            if (rescale && poly.scaled) { //Implies S2/L8/PL data where more pixel data can be taken
               computedX = poly.scaled.crop.x - (((poly.scaled.crop.width  * canvasScale) - poly.scaled.crop.width ) / 2.0);
               computedY = poly.scaled.crop.y - (((poly.scaled.crop.height * canvasScale) - poly.scaled.crop.height) / 2.0);
               imageWidth = poly.scaled.crop.width * canvasScale;

--- a/vue/src/components/siteObservations/EvaluationDisplay.vue
+++ b/vue/src/components/siteObservations/EvaluationDisplay.vue
@@ -24,7 +24,7 @@ const close = () => {
   }
 }
 const imagesActive = computed(() => state.enabledSiteObservations.findIndex((item) => item.id === props.siteObservation.id) !== -1);
-const hasImages = computed(() => props.siteObservation.imageCounts.WV.loaded > 0 || props.siteObservation.imageCounts.S2.loaded > 0);
+const hasImages = computed(() => props.siteObservation.imageCounts.WV.loaded > 0 || props.siteObservation.imageCounts.S2.loaded > 0 || props.siteObservation.imageCounts.PL.loaded > 0);
 
 const currentClosestTimestamp = computed(() => {
   const observation = state.enabledSiteObservations.find((item) => item.id === props.siteObservation.id);

--- a/vue/src/components/siteObservations/EvaluationImages.vue
+++ b/vue/src/components/siteObservations/EvaluationImages.vue
@@ -185,6 +185,24 @@ const imageDownloadDialog = ref(false);
       </v-col>
     </v-row>
     <v-row
+      dense
+      justify="center"
+      align="center"
+    >
+      <v-col cols="3">
+        <b>PL</b>
+      </v-col>
+      <v-col cols="3">
+        <b>{{ siteObservation.imageCounts.PL.loaded }}</b>
+      </v-col>
+      <v-col cols="3">
+        <b>{{ siteObservation.imageCounts.PL.total }}</b>
+      </v-col>
+      <v-col cols="3">
+        <b>{{ siteObservation.imageCounts.PL.loaded !== 0 ?Math.max(siteObservation.imageCounts.PL.loaded - siteObservation.imageCounts.PL.total, 0) : '-' }}</b>
+      </v-col>
+    </v-row>
+    <v-row
       v-if="isRunning || (progressInfo && progressInfo.error)"
       dense
       justify="center"

--- a/vue/src/components/siteObservations/EvaluationImages.vue
+++ b/vue/src/components/siteObservations/EvaluationImages.vue
@@ -199,7 +199,7 @@ const imageDownloadDialog = ref(false);
         <b>{{ siteObservation.imageCounts.PL.total }}</b>
       </v-col>
       <v-col cols="3">
-        <b>{{ siteObservation.imageCounts.PL.loaded !== 0 ?Math.max(siteObservation.imageCounts.PL.loaded - siteObservation.imageCounts.PL.total, 0) : '-' }}</b>
+        <b>{{ siteObservation.imageCounts.PL.loaded !== 0 ? Math.max(siteObservation.imageCounts.PL.loaded - siteObservation.imageCounts.PL.total, 0) : '-' }}</b>
       </v-col>
     </v-row>
     <v-row

--- a/vue/src/components/siteObservations/EvaluationsSideBar.vue
+++ b/vue/src/components/siteObservations/EvaluationsSideBar.vue
@@ -31,9 +31,9 @@ const updateSources = () => {
   state.enabledSiteObservations = newObservations;
 }
 
-const baseSources: Ref<('S2' |'WV' | 'L8')[]> = ref(['S2', 'WV', 'L8'])
+const baseSources: Ref<('S2' |'WV' | 'L8' | 'PL')[]> = ref(['S2', 'WV', 'L8', 'PL'])
 
-const sources: Ref<('S2' |'WV' | 'L8')[]> = ref(['S2', 'WV', 'L8']);
+const sources: Ref<('S2' |'WV' | 'L8' | 'PL')[]> = ref(['S2', 'WV', 'L8', 'PL']);
 const updateSatSources = () => {
   state.siteObsSatSettings = {...state.siteObsSatSettings, observationSources: sources.value };
   updateSources();


### PR DESCRIPTION
This PR adds support for PlanetLab (PL) imagery. I just used the equivalent Accenture collection (`ta1-pd-acc-3`) to the ones we use for L8 and S2. The UI has been updated to display info/accept PL as an input for downloading images, and all the necessary backend code has been updated to support PL images.

This PR probably seems more complicated than it actually is at first glance; essentially all the changes are just adding an additional `PL` option to every place in the codebase where sensor types are enumerated. The existing L8/S2 code seems to work perfectly for PL as well.