### PR TITLE
fixing case sensitivity for vector-tiles

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -122,7 +122,7 @@ services:
         RDWATCH_POSTGRESQL_URI: "${RDWATCH_POSTGRESQL_URI-postgresql://rdwatch:secretkey@postgresql:5432/rdwatch}"
         PORT: "8001"
         RDWATCH_REDIS_URI: "${RDWATHC_REDIS_URI-redis://redis:6379}"
-        RDWATCH_POSTGRESQL_SCORING_URI: "${RDWATCH_POSTGRESQL_SCORING_URI-postgresql://scoring:secretkey@localhost:5433/scoring}"
+        RDWATCH_POSTGRESQL_SCORING_URI: "${RDWATCH_POSTGRESQL_SCORING_URI-postgresql://scoring:secretkey@scoredb:5432/scoring}"
         RDWATCH_SUPPRESS_VECTOR_TILE_LOGGING: "true" # prevent console logging of information for dev server
     volumes:
       - ./tileserver:/usr/tileserver

--- a/tileserver/scoring.mjs
+++ b/tileserver/scoring.mjs
@@ -95,7 +95,7 @@ const QUERY = `
       SUBSTRING("site"."site_id", 9) AS "site_number",
       CASE
         WHEN (
-          "site"."originator" = 'TE'
+          "site"."originator" = 'te'
           OR "site"."originator" = 'iMERIT'
         ) THEN (
           SELECT


### PR DESCRIPTION
- Case sensitvie TE vs 'te' was causing issues where the color_code wasn't being populated correctly for scoring implementations
- Fixed issues with local docker dev for tile server connection not working properly.


@mvandenburgh - probably want to push into this to ignore case for the originator fields or at least discuss it?