### PR TITLE
Include current version in server status endpoint, swagger page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN mkdir /app/django/src \
  && touch /app/django/src/rdwatch_scoring/__init__.py \
  && touch /app/django/README.md \
  && poetry install --with dev
+RUN git config --global --add safe.directory /app/django
 
 
 # Built static assets for vue-rdwatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,8 @@ RUN mkdir /app/django/src \
 FROM builder AS dev
 WORKDIR /app/django
 COPY django/pyproject.toml django/poetry.lock /app/django/
+# Copy git metadata to enable display of version information
+COPY .git/ /app/.git/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \
  && touch /app/django/src/rdwatch/__init__.py \
@@ -114,15 +116,22 @@ RUN chmod -R u=rX,g=rX,o= .
 
 # Final image
 FROM base
+# Copy python virtual environment
 COPY --from=django-builder \
      --chown=rdwatch:rdwatch \
      /poetry/venvs \
      /poetry/venvs
+# Copy django source code
 COPY --from=django-dist \
      --chown=rdwatch:rdwatch \
      /app/django \
      /app/django
+# Copy vue static assets
 COPY --from=vue-dist \
      --chown=unit:unit \
      /app/vue/dist \
      /app/vue/dist
+# Copy git metadata to enable display of version information
+COPY --chown=rdwatch:rdwatch \
+     .git/ \
+     /app/.git/

--- a/django/src/rdwatch/api.py
+++ b/django/src/rdwatch/api.py
@@ -1,6 +1,8 @@
 from ninja import NinjaAPI
 from ninja.errors import ValidationError
 
+from django.conf import settings
+
 from .views import site
 from .views.model_run import router as model_run_router
 from .views.performer import router as performer_router
@@ -10,7 +12,7 @@ from .views.site_evaluation import router as site_evaluation_router
 from .views.site_image import router as images_router
 from .views.site_observation import router as site_observation_router
 
-api = NinjaAPI(title='RD-WATCH', version='0.0.0')
+api = NinjaAPI(title='RD-WATCH', version=settings.GIT_VERSION)
 
 api.add_router('/evaluations/', site_evaluation_router)
 api.add_router('/observations/', site_observation_router)

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -1,5 +1,7 @@
 import os
+import subprocess
 from datetime import timedelta
+from pathlib import Path
 
 from configurations import Configuration, values
 
@@ -11,6 +13,12 @@ _ENVIRON_PREFIX = 'RDWATCH'
 # classes (e.g. `AWS_DEFAULT_REGION) get immediately evaluated and
 # expect env vars to be set.
 values.Value.late_binding = True
+
+GIT_VERSION = subprocess.check_output(
+    ['git', 'describe', '--tags'],
+    encoding='utf-8',
+    cwd=str(Path(__file__).parents[4].resolve()),
+).strip()
 
 
 class BaseConfiguration(Configuration):
@@ -24,6 +32,8 @@ class BaseConfiguration(Configuration):
     # Django's docs suggest that STATIC_URL should be a relative path,
     # for convenience serving a site on a subpath.
     STATIC_URL = 'static/'
+
+    GIT_VERSION = GIT_VERSION
 
     @property
     def INSTALLED_APPS(self):

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -14,11 +14,14 @@ _ENVIRON_PREFIX = 'RDWATCH'
 # expect env vars to be set.
 values.Value.late_binding = True
 
-GIT_VERSION = subprocess.check_output(
-    ['git', 'describe', '--tags'],
-    encoding='utf-8',
-    cwd=str(Path(__file__).parents[4].resolve()),
-).strip()
+try:
+    GIT_VERSION = subprocess.check_output(
+        ['git', 'describe', '--tags'],
+        encoding='utf-8',
+        cwd=str(Path(__file__).parents[4].resolve()),
+    ).strip()
+except subprocess.CalledProcessError:
+    GIT_VERSION = 'unknown'
 
 
 class BaseConfiguration(Configuration):

--- a/django/src/rdwatch/views/server_status.py
+++ b/django/src/rdwatch/views/server_status.py
@@ -25,11 +25,16 @@ class ServerStatusSchema(Schema):
     uptime: UptimeSchema
     hostname: str
     ip: str
+    rdwatch_version: str
 
 
 @router.get('/', response=ServerStatusSchema)
 def get_status(request: HttpRequest):
+    from rdwatch.api import api
+
     uptime = datetime.datetime.now() - SERVER_INSTANCE_EPOCH
     hostname = socket.gethostname()
     ip = socket.gethostbyname(hostname)
-    return ServerStatusSchema(uptime=uptime, hostname=hostname, ip=ip)
+    return ServerStatusSchema(
+        uptime=uptime, hostname=hostname, ip=ip, rdwatch_version=api.version
+    )

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -24,6 +24,7 @@ services:
 
     volumes:
       - ./django:/app/django
+      - ./.git:/app/django/.git
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
It was starting to become difficult to keep track of what's deployed on the different deployments we have. Now that we're referring to each release by it's version number, I think it's much better to use that for versioning instead of the full commit hash.

I didn't put this in the UI yet, but maybe we should rework that at some point to hit the `/api/status` endpoint instead of statically bundling that info in the JS code. Maybe something to think about in the future when we have more time.