### PR TITLE
minor satellite timestamp fix

### DIFF
--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -57,9 +57,13 @@ watch (() => state.filters.regions, () => {
   if (state.filters.regions?.length) {
     selectedRegion.value = state.filters.regions[0];
   }
-  satelliteRegionTooLarge.value = false;
 });
 
+watch(selectedRegion, () => {
+  // Reset satellite time list when on other regions
+  satelliteRegionTooLarge.value = false;
+  state.satellite = { ...state.satellite, satelliteImagesOn: false, satelliteTimeList: []};
+});
 
 const expandSettings = ref(false);
 


### PR DESCRIPTION
This was a minor thing that resets the satellite icon when a user changes the selectedRegion.  I had it but forgot to commit it in my latest version of the guard the other dayt.