### PR TITLE
Make endpoint backslashes consistent

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -481,7 +481,7 @@ def get_proposals_query(model_run_id: UUID4):
     )
 
 
-@router.get('/{model_run_id}/proposals')
+@router.get('/{model_run_id}/proposals/')
 def get_proposals(request: HttpRequest, model_run_id: UUID4):
     region = get_region(model_run_id).values_list('json', flat=True)
     if not region.exists():
@@ -504,14 +504,14 @@ def start_download(
     return task_id.id
 
 
-@router.get('/download_status')
+@router.get('/download_status/')
 def check_download(request: HttpRequest, task_id: str):
     task = AsyncResult(task_id)
     print(task)
     return task.status
 
 
-@router.get('/{id}/download')
+@router.get('/{id}/download/')
 def get_downloaded_annotations(request: HttpRequest, id: UUID4, task_id: str):
     annotation_export = AnnotationExport.objects.filter(
         configuration=id, celery_id=task_id

--- a/django/src/rdwatch/views/site.py
+++ b/django/src/rdwatch/views/site.py
@@ -21,7 +21,7 @@ class SiteImageSiteDetailResponse(Schema):
     timemax: int | None
 
 
-@router.get('/{id}/details', response=SiteImageSiteDetailResponse)
+@router.get('/{id}/details/', response=SiteImageSiteDetailResponse)
 def siteDetails(request: HttpRequest, id: UUID4):
     return (
         SiteEvaluation.objects.filter(pk=id)

--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -279,7 +279,7 @@ def get_site_model_feature_JSON(id: UUID4, obsevations=False):
     return None, None
 
 
-@router.get('/{id}/download')
+@router.get('/{id}/download/')
 def download_annotations(request: HttpRequest, id: UUID4):
     output, site_id, filename = get_site_model_feature_JSON(id)
     if output is not None:

--- a/django/src/rdwatch_scoring/views/site.py
+++ b/django/src/rdwatch_scoring/views/site.py
@@ -12,7 +12,7 @@ from rdwatch_scoring.models import Site
 router = Router()
 
 
-@router.get('/{id}/details', response=SiteImageSiteDetailResponse)
+@router.get('/{id}/details/', response=SiteImageSiteDetailResponse)
 def siteDetails(request: HttpRequest, id: UUID4):
     return (
         Site.objects.filter(pk=id)

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -141,7 +141,7 @@ export class ApiService {
   public static getStatus(): CancelablePromise<ServerStatus> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/status",
+      url: "/api/status/",
     });
   }
 
@@ -154,7 +154,7 @@ export class ApiService {
   ): CancelablePromise<SiteEvaluationList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/evaluations`,
+      url: `${this.getApiPrefix()}/evaluations/`,
       query,
     });
   }
@@ -169,7 +169,7 @@ export class ApiService {
   ): CancelablePromise<SiteObservationList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/observations/{id}`,
+      url: `${this.getApiPrefix()}/observations/{id}/`,
       path: {
         id: id,
       },
@@ -186,7 +186,7 @@ export class ApiService {
     ): CancelablePromise<SiteDetails> {
       return __request(OpenAPI, {
         method: "GET",
-        url: `${this.getApiPrefix()}/sites/{id}/details`,
+        url: `${this.getApiPrefix()}/sites/{id}/details/`,
         path: {
           id: id,
         },
@@ -279,7 +279,7 @@ export class ApiService {
   ): CancelablePromise<ModelRunList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/model-runs`,
+      url: `${this.getApiPrefix()}/model-runs/`,
       query: Object.fromEntries(
         Object.entries(query).filter(([key, value]) => value !== undefined)
       ),
@@ -293,7 +293,7 @@ export class ApiService {
     public static getProposals(id: string): CancelablePromise<Proposals> {
       return __request(OpenAPI, {
         method: "GET",
-        url: `${this.getApiPrefix()}/model-runs/{id}/proposals`,
+        url: `${this.getApiPrefix()}/model-runs/{id}/proposals/`,
         path: {
           id: id,
         },
@@ -324,7 +324,7 @@ export class ApiService {
   public static getPerformers(): CancelablePromise<PerformerList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/performers`,
+      url: `${this.getApiPrefix()}/performers/`,
     });
   }
 
@@ -350,7 +350,7 @@ export class ApiService {
   public static getRegions(): CancelablePromise<RegionList> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/regions`,
+      url: `${this.getApiPrefix()}/regions/`,
     });
   }
 
@@ -390,7 +390,7 @@ export class ApiService {
     const bboxstr = `${minY},${minX},${maxY},${maxX}`;;
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/satellite-image/timestamps",
+      url: "/api/satellite-image/timestamps/",
       query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });
@@ -422,7 +422,7 @@ export class ApiService {
     const bboxstr = `${minY},${minX},${maxY},${maxX}`;
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/satellite-image/visual-timestamps",
+      url: "/api/satellite-image/visual-timestamps/",
       query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });
@@ -452,7 +452,7 @@ export class ApiService {
     const bboxstr = `${minY},${minX},${maxY},${maxX}`;
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/satellite-image/all-timestamps",
+      url: "/api/satellite-image/all-timestamps/",
       query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });
@@ -467,7 +467,7 @@ export class ApiService {
   {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/scores/details",
+      url: "/api/scores/details/",
       query: { configurationId, region, siteNumber, version },
     });
   }
@@ -475,7 +475,7 @@ export class ApiService {
   public static getEvaluationImages(id: string): CancelablePromise<EvaluationImageResults> {
     return __request(OpenAPI, {
       method: "GET",
-      url: `${this.getApiPrefix()}/evaluations/images/{id}`,
+      url: `${this.getApiPrefix()}/evaluations/images/{id}/`,
       path: {
         id: id,
       },
@@ -568,7 +568,7 @@ export class ApiService {
   public static getModelRunDownloadStatus(task_id: string): CancelablePromise<CeleryStates> {
     return __request(OpenAPI, {
       method: 'GET',
-      url: `${this.getApiPrefix()}/model-runs/download_status`,
+      url: `${this.getApiPrefix()}/model-runs/download_status/`,
       query: {task_id},
     })
   }


### PR DESCRIPTION
This changes every endpoint to end with a backslash, as well as the corresponding client code. This will avoid unnecessary redirect requests in the frontend.