### PR TITLE
Add year filter to vector tiles endpoint

### DIFF
--- a/tileserver/devServer.mjs
+++ b/tileserver/devServer.mjs
@@ -7,9 +7,9 @@ const fastify = Fastify({ logger: true });
 await fastify.register(cors);
 
 fastify.get('/api/vector-tiles/tile.pbf', async (request, reply) => {
-  const { modelRunId, z, x, y, randomKey } = request.query;
+  const { modelRunId, z, x, y, randomKey, year } = request.query;
 
-  const vectorTileData = await getRGDVectorTiles(modelRunId, z, x, y, randomKey);
+  const vectorTileData = await getRGDVectorTiles(modelRunId, z, x, y, year, randomKey);
 
   reply.header('Content-Type', 'application/octet-stream');
   reply.code(vectorTileData.length === 0 ? 204 : 200);
@@ -18,9 +18,9 @@ fastify.get('/api/vector-tiles/tile.pbf', async (request, reply) => {
 });
 
 fastify.get('/api/scoring/vector-tiles/tile.pbf', async (request, reply) => {
-  const { modelRunId, z, x, y } = request.query;
+  const { modelRunId, z, x, y, year } = request.query;
 
-  const vectorTileData = await getScoringVectorTiles(modelRunId, z, x, y);
+  const vectorTileData = await getScoringVectorTiles(modelRunId, z, x, y, year);
 
   reply.header('Content-Type', 'application/octet-stream');
   reply.code(vectorTileData.length === 0 ? 204 : 200);

--- a/tileserver/package-lock.json
+++ b/tileserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@resonantgeodata/rdwatch-vector-tileserver",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@resonantgeodata/rdwatch-vector-tileserver",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "pg": "^8.11.3",
         "redis": "^4.6.12"

--- a/tileserver/package.json
+++ b/tileserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resonantgeodata/rdwatch-vector-tileserver",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/resonantgeodata/RD-WATCH.git"

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -34,7 +34,7 @@ export const style = (
     ...naturalearthSources,
     ...buildSatelliteSourceFilter(timestamp, satellite),
     ...buildImageSourceFilter(timestamp, enabledSiteObservations, settings),
-    ...buildRdwatchtilesSources(modelRunIds, randomKey),
+    ...buildRdwatchtilesSources(timestamp, modelRunIds, randomKey),
     ...openmaptilesSources(filters),
   },
   sprite: `${tileServerURL}/sprites/osm-liberty`,

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -263,13 +263,14 @@ const buildObservationFill = (
 };
 
 // Nudge is used to refresh vector tiles when modified by proposal view
-export const buildSourceFilter = (modelRunIds: string[], randomKey='') => {
+export const buildSourceFilter = (timestamp: number, modelRunIds: string[], randomKey='') => {
   const results: Record<string, SourceSpecification> = {};
+  const year = new Date(timestamp * 1000).getFullYear();
   modelRunIds.forEach((id) => {
     const source = `vectorTileSource_${id}`;
     results[source] = {
       type: "vector",
-      tiles: [`${urlRoot}${ApiService.getApiPrefix()}/vector-tiles/tile.pbf?modelRunId=${id}&z={z}&x={x}&y={y}${randomKey}`],
+      tiles: [`${urlRoot}${ApiService.getApiPrefix()}/vector-tiles/tile.pbf?modelRunId=${id}&z={z}&x={x}&y={y}${randomKey}&year=${year}`],
       minzoom: 0,
       maxzoom: 14,
     };


### PR DESCRIPTION
Adds a year filter to the vector tiles endpoint. This makes it so that the client must supply a year representing the range of site observations they wish to view. The client makes additional requests if the user slides the time slider to a new year.

This resolves the performance issues for large sites that contain a significant amount of observation polygons.