### PR TITLE
Free up space on GH actions runner before build

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,6 +17,10 @@ jobs:
     name: Build [rdwatch]
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space to make room for docker image
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
After merging #381, the github actions runner was still running out of space. This PR is a stopgap to allow us to at least publish images until we can sort out what is taking up so much space on the runner.

cc @BryonLewis ^ just so you're aware. I'll merge this now so we can get the tagged release image to build tomorrow after #384 is merged, but we should maybe discuss what to do about this going forward.