### PR TITLE
proposal image fix

### DIFF
--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -483,6 +483,7 @@ const clearStorage = async () => {
           </h3>
         </v-col>
         <image-editor-details
+          v-if="combinedImages.length"
           :site-eval-id="siteEvalId"
           :editable="editable"
           :date-range="dateRange"


### PR DESCRIPTION
Async issue when getting information for another selected site it wasn't waiting to display the information for it.  So it was lagging behind and selection was offset.

https://github.com/ResonantGeoData/RD-WATCH/blob/4d6fa70a83e389a79943002f6f28806729b8fac2/vue/src/components/imageViewer/ImageViewer.vue#L129

This is where it loads in the new images to display so really the image-editor shouldn't be displayed unless there is data in the `combinedImages` indicated by it having a length > 0;