### PR TITLE
Proposal Saving

### DIFF
--- a/vue/src/components/annotationViewer/ProposalList.vue
+++ b/vue/src/components/annotationViewer/ProposalList.vue
@@ -61,6 +61,7 @@ const getSiteProposals = async () => {
       const regionName: string = proposalList.value.region;
       const accepted: string[] = [];
       const rejected: string[] = [];
+      let selected: ProposalDisplay | null = null;
       proposalList.value.proposed_sites.forEach((item) => {
         const newNum = item.number.toString().padStart(4, "0");
         if (newNum === "9999") {
@@ -96,6 +97,9 @@ const getSiteProposals = async () => {
           timestamp: item.timestamp,
           downloading: item.downloading,
         });
+        if (item.id === props.selectedEval) {
+          selected = modList[modList.length - 1];
+        }
       });
       state.filters.proposals = {
         accepted,
@@ -110,7 +114,9 @@ const getSiteProposals = async () => {
           clearInterval(downloadCheckInterval);
         }
       }
-
+      if (selected) {
+        emit('selected', selected);
+      }
     }
   }
 };

--- a/vue/src/components/imageViewer/ImageEditorDetails.vue
+++ b/vue/src/components/imageViewer/ImageEditorDetails.vue
@@ -130,7 +130,7 @@ const saveSiteEvaluationChanges = async () => {
     label: siteEvaluationLabel.value,
     start_date: startDate.value,
     end_date: endDate.value,
-    notes: siteEvaluationNotes.value ? siteEvaluationNotes.value : '',
+    notes: siteEvaluationNotes.value || '',
   });
   siteEvaluationUpdated.value = false;
   emit('clear-storage');

--- a/vue/src/components/imageViewer/ImageEditorDetails.vue
+++ b/vue/src/components/imageViewer/ImageEditorDetails.vue
@@ -130,7 +130,7 @@ const saveSiteEvaluationChanges = async () => {
     label: siteEvaluationLabel.value,
     start_date: startDate.value,
     end_date: endDate.value,
-    notes: siteEvaluationNotes.value ? siteEvaluationNotes.value : undefined,
+    notes: siteEvaluationNotes.value ? siteEvaluationNotes.value : '',
   });
   siteEvaluationUpdated.value = false;
   emit('clear-storage');


### PR DESCRIPTION
- Fixes issue annotators were noticing with setting notes to a blank or '' empty string.
- Also fixes issue with Date not properly displaying after hitting 'save'.  It was loading the previous DateRange instead of calculating a new one for the currently selected proposal.