### PR TITLE
Docker Cache for Development using Docker Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN mkdir /app/django/src \
  && touch /app/django/src/rdwatch_scoring/__init__.py \
  && touch /app/django/README.md \
  && poetry install --with dev
- # Copy git metadata to enable display of version information
+# Copy git metadata to enable display of version information
 RUN git config --global --add safe.directory /app/django
 COPY .git/ /app/.git/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ FROM builder AS dev
 WORKDIR /app/django
 COPY django/pyproject.toml django/poetry.lock /app/django/
 # Copy git metadata to enable display of version information
-COPY .git/ /app/.git/
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \
  && touch /app/django/src/rdwatch/__init__.py \
@@ -93,6 +92,7 @@ RUN mkdir /app/django/src \
  && touch /app/django/README.md \
  && poetry install --with dev
 RUN git config --global --add safe.directory /app/django
+COPY .git/ /app/.git/
 
 
 # Built static assets for vue-rdwatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,6 @@ RUN mkdir /app/django/src \
 FROM builder AS dev
 WORKDIR /app/django
 COPY django/pyproject.toml django/poetry.lock /app/django/
-# Copy git metadata to enable display of version information
 RUN mkdir /app/django/src \
  && mkdir /app/django/src/rdwatch \
  && touch /app/django/src/rdwatch/__init__.py \
@@ -91,6 +90,7 @@ RUN mkdir /app/django/src \
  && touch /app/django/src/rdwatch_scoring/__init__.py \
  && touch /app/django/README.md \
  && poetry install --with dev
+ # Copy git metadata to enable display of version information
 RUN git config --global --add safe.directory /app/django
 COPY .git/ /app/.git/
 


### PR DESCRIPTION
Simple moving the copying of the git directory to lower in the build order for the `dev` tag.
Before it meant that each time you changed branches it would have to run the whole poetry install process.  This keeps the git status in the endpoint working while allowing poetry to remain cached so it only reinstalls dependencies if they change (lock or toml changes).  