### PR TITLE
update scoring and proposals to handle new model-run region relationship

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -472,8 +472,7 @@ def get_proposals(request: HttpRequest, model_run_id: UUID4):
     region = get_object_or_404(ModelRun, pk=model_run_id).region
 
     query = get_proposals_query(model_run_id)
-    model_run = region[0]
-    query['region'] = model_run['region']
+    query['region'] = region.name
     return 200, query
 
 

--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -101,7 +101,7 @@ def get_queryset():
                 'evaluation_run_number',
                 output_field=CharField(),
             ),
-            region=F('region'),
+            region_name=F('region'),
             performer_slug=F('performer'),
             performer=JSONObject(
                 id=0, team_name=F('performer'), short_code=F('performer')
@@ -173,6 +173,7 @@ def list_model_runs(
         .values()
         .annotate(
             id=F('uuid'),
+            region_name=F('region'),
             title=Concat(
                 Value('Eval '),
                 'evaluation_number',


### PR DESCRIPTION
Small updates to enable selecting scoring properly with the new region relationship.
The scoring app relied on the RDWatch  ModelRunDetailSchema which included the alias.  Adding that alias to the queries in the Scoring app fixed the issue.
https://github.com/ResonantGeoData/RD-WATCH/blob/model-run-region/django/src/rdwatch/views/model_run.py#L112


Additionally, the proposal when selecting one had a need to know the region and it referenced the ModelRun region relationship differently.  I've updated it so it will reference the proper name field.

