### PR TITLE
Scoring Proposal Changes

### DIFF
--- a/django/src/rdwatch_scoring/views/model_run.py
+++ b/django/src/rdwatch_scoring/views/model_run.py
@@ -184,7 +184,7 @@ def get_queryset_proposal():
     return (
         AnnotationProposalSet.objects.values().annotate(
             id=F('uuid'),
-            region=F('region_id'),
+            region_name=F('region_id'),
             title=Concat(
                 Value('Proposal '),
                 'originator',
@@ -344,7 +344,7 @@ def list_annotation_proposal_sets(
 @router.get('/', response={200: ModelRunPagination.Output})
 def list_model_runs(
     request: HttpRequest,
-    proposal: Literal['PROPOSAL', 'APPROVED'] | None,
+    proposal: Literal['PROPOSAL', 'APPROVED', None] = None,
     page: int = 1,
     filters: ModelRunFilterSchema = Query(...),  # noqa: B008
 ):
@@ -479,7 +479,9 @@ def list_model_runs(
 
 @router.get('/{id}/', response={200: ModelRunDetailSchema})
 def get_model_run(
-    request: HttpRequest, id: UUID4, proposal: Literal['PROPOSAL', 'APPROVED'] | None
+    request: HttpRequest,
+    id: UUID4,
+    proposal: Literal['PROPOSAL', 'APPROVED', None] = None,
 ):
     if proposal:
         data = get_object_or_404(get_queryset_proposal(), id=id)

--- a/django/src/rdwatch_scoring/views/vector_tile.py
+++ b/django/src/rdwatch_scoring/views/vector_tile.py
@@ -114,6 +114,7 @@ def vector_tile_proposal(
             .values()
             .annotate(
                 id=F('uuid'),
+                uuid=F('uuid'),  # used for mouse clicking
                 mvtgeom=mvtgeom,
                 configuration_id=F('annotation_proposal_set_uuid'),
                 configuration_name=ExpressionWrapper(

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -6,7 +6,7 @@ import { useRoute } from 'vue-router';
 
 
 
-const scoringApp = computed(()=> ApiService.getApiPrefix().includes('scoring'));
+const scoringApp = computed(()=> ApiService.getApiPrefix().includes('scoring') && !proposals.value);
 const route = useRoute();
 const proposals = computed(() => route.path.includes('proposals'));
 

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -362,7 +362,7 @@ const clearStorage = async () => {
   maplibregl.clearStorage();
   // We need to update the source to get information
   // This reloads the source vector-tile to color it properly after data has been changed.
-  state.filters.randomKey = `&randomKey=randomKey_${Math.random() * 1000}`;
+  state.filters.randomKey = `randomKey=randomKey_${Math.random() * 1000}`;
   await getImageData();
 };
 </script>
@@ -528,7 +528,7 @@ const clearStorage = async () => {
       </v-tooltip>
       <v-tooltip
         v-if="
-          !loading && filteredImages.length &&
+          !loading && !ApiService.getApiPrefix().includes('scoring') && filteredImages.length &&
             filteredImages[currentImage] &&
             filteredImages[currentImage].image &&
             filteredImages[currentImage].image.source === 'WV'

--- a/vue/src/mapstyle/rdwatchtiles.ts
+++ b/vue/src/mapstyle/rdwatchtiles.ts
@@ -268,10 +268,21 @@ export const buildSourceFilter = (timestamp: number, modelRunIds: string[], rand
   const year = new Date(timestamp * 1000).getFullYear();
   modelRunIds.forEach((id) => {
     const source = `vectorTileSource_${id}`;
-    const proposal = ApiService.getProposalsQuery()
+    const proposal = ApiService.getProposalsQuery() ? 'proposal=PROPOSAL' : '';
+    const additionalOptions = [proposal, randomKey, year];
+    let additionalOptionsString = ''
+    additionalOptions.forEach((item, index) => {
+      if (item && index === 0) {
+        additionalOptionsString += '?'
+        additionalOptionsString += item
+      } else if (item) {
+        additionalOptionsString += '&'
+        additionalOptionsString += item
+      }
+    });
     results[source] = {
       type: "vector",
-      tiles: [`${urlRoot}${ApiService.getApiPrefix()}/model-runs/${id}/vector-tile/{z}/{x}/{y}.pbf${randomKey}/${proposal ? "?proposal=PROPOSAL" : ""}`],
+      tiles: [`${urlRoot}${ApiService.getApiPrefix()}/model-runs/${id}/vector-tile/{z}/{x}/{y}.pbf/${additionalOptionsString}`],
       minzoom: 0,
       maxzoom: 14,
     };


### PR DESCRIPTION
List of minor changes to fix small issues:

- Proposal Query need the 'region_name' instead of 'region' returned
- The model-run endpoints for getting the values required a `proposal` parameter.  We wanted it to be an optional parameter with the default value of `None`.  WIthout this the default /scoring view would break.
- Within ImageViewer I made the SAM icon dependent on it not being within scoring because there are no implemented features of SAM in the scoring app yet.
- rdwatchtiles.ts - the built query string was incorrect, it didn't properly handle the 'randomKey' and also didn't include the 'year' for our year filtering.  I've quickly improved how it generates the query so it should be better for any combination of `proposal, randomKey, year`
- In the vector tile creation I needed to add the `uuid` key because that is used by proposals when clicking on a site to select it in the list.  Without this the clicking on the geometry of the site wouldn't work.