### PR TITLE
Auto delete old satellite fetches

### DIFF
--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -159,8 +159,8 @@ class BaseConfiguration(Configuration):
             return []
 
     CELERY_BEAT_SCHEDULE = {
-        'delete-temp-model-runs-beat': {
-            'task': 'rdwatch.tasks.delete_temp_model_runs_task',
+        'collect-garbage-beat': {
+            'task': 'rdwatch.tasks.collect_garbage_task',
             'schedule': timedelta(hours=1),
         },
         'delete-export-files-runs-beat': {

--- a/django/src/rdwatch/server/settings.py
+++ b/django/src/rdwatch/server/settings.py
@@ -163,10 +163,6 @@ class BaseConfiguration(Configuration):
             'task': 'rdwatch.tasks.collect_garbage_task',
             'schedule': timedelta(hours=1),
         },
-        'delete-export-files-runs-beat': {
-            'task': 'rdwatch.tasks.delete_export_files',
-            'schedule': timedelta(hours=1),
-        },
     }
 
 

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -393,7 +393,7 @@ def get_siteobservations_images(
 
 
 @shared_task
-def delete_temp_model_runs_task() -> None:
+def collect_garbage_task() -> None:
     """Delete all model runs that are due to be deleted."""
     model_runs_to_delete = (
         ModelRun.objects.filter(expiration_time__isnull=False)

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -443,6 +443,11 @@ def collect_garbage_task() -> None:
         created__lte=timezone.now() - timedelta(hours=1)
     ).delete()
 
+    # Delete all SatelliteFetching tasks that are over an day old
+    SatelliteFetching.objects.filter(
+        timestamp__lte=timezone.now() - timedelta(days=1)
+    ).delete()
+
 
 @app.task(bind=True)
 def download_annotations(self, id: UUID4, mode: Literal['all', 'approved', 'rejected']):

--- a/django/src/rdwatch/tasks/__init__.py
+++ b/django/src/rdwatch/tasks/__init__.py
@@ -438,14 +438,10 @@ def collect_garbage_task() -> None:
         ):
             ModelRun.objects.filter(pk__in=model_runs).delete()
 
-
-@shared_task
-def delete_export_files() -> None:
-    """Delete all S3 Export Files that are over an hour old."""
-    exports_to_delete = AnnotationExport.objects.filter(
+    # Delete all S3 Export Files that are over an hour old
+    AnnotationExport.objects.filter(
         created__lte=timezone.now() - timedelta(hours=1)
-    )
-    exports_to_delete.delete()
+    ).delete()
 
 
 @app.task(bind=True)

--- a/django/src/rdwatch/tests/test_model_runs.py
+++ b/django/src/rdwatch/tests/test_model_runs.py
@@ -8,7 +8,7 @@ from ninja.testing import TestClient
 from django.utils import timezone
 
 from rdwatch.models import ModelRun, Region, lookups
-from rdwatch.tasks import delete_temp_model_runs_task
+from rdwatch.tasks import collect_garbage_task
 
 
 @pytest.mark.django_db(databases=['default'])
@@ -37,7 +37,7 @@ def test_model_run_auto_delete(region: Region) -> None:
     )
     assert ModelRun.objects.count() == 3
 
-    delete_temp_model_runs_task()
+    collect_garbage_task()
 
     assert ModelRun.objects.count() == 2
     assert list(ModelRun.objects.all()) == [


### PR DESCRIPTION
This PR consolidates the two existing "garbage collection" tasks (cleaning up old model runs + annotation exports) into one task, and also adds scheduled cleanup of Satellite fetches that are over a day old.