### PR TITLE
Fix crash on site model JSON download endpoint

### DIFF
--- a/django/src/rdwatch/views/site_evaluation.py
+++ b/django/src/rdwatch/views/site_evaluation.py
@@ -64,7 +64,7 @@ def get_site_model_feature_JSON(id: UUID4, obsevations=False):
         .annotate(
             json=JSONObject(
                 site=JSONObject(
-                    region='region__name',
+                    region='configuration__region__name',
                     number='number',
                 ),
                 configuration='configuration__parameters',


### PR DESCRIPTION
We have to go through the model run to get the region name now.