### PR TITLE
download model-run endpoint fix

### DIFF
--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -487,14 +487,13 @@ def start_download(
     return task_id.id
 
 
-@router.get('/download_status/')
-def check_download(request: HttpRequest, task_id: str):
+@router.get('/download_status/{task_id}')
+def check_download(request: HttpRequest, task_id: UUID4):
     task = AsyncResult(task_id)
-    print(task)
     return task.status
 
 
-@router.get('/{id}/download/')
+@router.get('/{id}/download/{task_id}/')
 def get_downloaded_annotations(request: HttpRequest, id: UUID4, task_id: str):
     annotation_export = AnnotationExport.objects.filter(
         configuration=id, celery_id=task_id

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -554,8 +554,7 @@ export class ApiService {
   public static getModelRunDownloadStatus(task_id: string): CancelablePromise<CeleryStates> {
     return __request(OpenAPI, {
       method: 'GET',
-      url: `${this.getApiPrefix()}/model-runs/download_status/`,
-      query: {task_id},
+      url: `${this.getApiPrefix()}/model-runs/download_status/${task_id}`,
     })
   }
 }

--- a/vue/src/components/ModelRunDetail.vue
+++ b/vue/src/components/ModelRunDetail.vue
@@ -87,7 +87,7 @@ const checkDownloadStatus = async () => {
   if (taskId.value) {
     const status = await ApiService.getModelRunDownloadStatus(taskId.value);
     if (status === 'SUCCESS') {
-      const url = `${ApiService.getApiPrefix()}/model-runs/${props.modelRun.id}/download?task_id=${taskId.value}`
+      const url = `${ApiService.getApiPrefix()}/model-runs/${props.modelRun.id}/download/${taskId.value}/`
       window.location.assign(url);
       downloadingModelRun.value = false;
     } else if (['REVOKED', 'FAILURE'].includes(status)) {


### PR DESCRIPTION
Fixes the issue where model-run downloading for proposals wasn't working because using a single parameter query at the end of a trailing slash in ninja wasn't being interpreted properly.