### PR TITLE
Bump node package version

### DIFF
--- a/tileserver/package-lock.json
+++ b/tileserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@resonantgeodata/rdwatch-vector-tileserver",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@resonantgeodata/rdwatch-vector-tileserver",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "postgres": "^3.4.4",
         "redis": "^4.6.12"

--- a/tileserver/package.json
+++ b/tileserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resonantgeodata/rdwatch-vector-tileserver",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/resonantgeodata/RD-WATCH.git"


### PR DESCRIPTION
I forgot to do this in https://github.com/ResonantGeoData/RD-WATCH/pull/407