### PR TITLE
gitignore `celerybeat-schedule.*` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,5 @@ __pycache__
 dmypy.json
 
 # Django Files
-django/celerybeat-schedule.db
+celerybeat-schedule.*
 django/nohup.out
-


### PR DESCRIPTION
Sometimes this file appears in the root for me.