### PR TITLE
Fix version display in AWS deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,3 +135,4 @@ COPY --from=vue-dist \
 COPY --chown=rdwatch:rdwatch \
      .git/ \
      /app/.git/
+RUN git config --global --add safe.directory /app


### PR DESCRIPTION
The `/api/status` endpoint in the AWS deployment currently returns `"rdwatch_version": "unknown"` for the version. Looking at the logs, it looks like [this subprocess](https://github.com/ResonantGeoData/RD-WATCH/blob/main/django/src/rdwatch/server/settings.py#L19) call to `git` is failing with 

```
fatal: detected dubious ownership in repository at '/app'
To add an exception for this directory, call:

        git config --global --add safe.directory /app
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'describe', '--tags']' returned non-zero exit status 128.
```