### PR TITLE
Fetch git tags in docker build action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR


### PR DESCRIPTION
After deploying #419, it now says

`fatal: No names found, cannot describe anything.`

When trying to get the version git tag. The `checkout` action doesn't fetch tags by default, so the `.git` directory getting copied into the docker image won't have them.