### PR TITLE
GroundTruth Refactor

### DIFF
--- a/django/src/rdwatch/admin.py
+++ b/django/src/rdwatch/admin.py
@@ -54,6 +54,7 @@ class ModelRunAdmin(admin.ModelAdmin):
         'evaluation',
         'evaluation_run',
         'expiration_time',
+        'ground_truth',
     )
     list_filter = ('created', 'performer', 'region')
 

--- a/django/src/rdwatch/views/model_run.py
+++ b/django/src/rdwatch/views/model_run.py
@@ -497,6 +497,7 @@ def get_sites_query(model_run_id: UUID4):
                     status='status',
                     filename='cache_originator_file',
                     downloading='downloading',
+                    groundtruth=F('configuration__ground_truth'),
                 ),
                 ordering='number',
                 default=[],

--- a/vue/src/client/models/ModelRun.ts
+++ b/vue/src/client/models/ModelRun.ts
@@ -20,6 +20,7 @@ export type ModelRun = {
   created: string;
   expiration_time: string;
   proposal?: null | 'PROPOSAL' | 'APPROVED';
+  groundTruthLink?: string;
   adjudicated?: {
     proposed: number,
     other: number,

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -66,6 +66,8 @@ export interface SiteInfo {
     timestamp: number;
     filename?: string | null;
     downloading: boolean;
+    groundtruth?: boolean;
+    originator?: string;
 }
 export interface SiteList {
   region: Region;

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -39,10 +39,10 @@ const groundTruthState = computed<GroundTruthState>(() => {
     }
   });
   if (hasGroundTruth) {
-    result = 'HasGroundTruth';
+    result = GroundTruthState.HasGroundTruth;
   }
   // Check to see if it is ground Truth
-  if (result === 'HasGroundTruth') {
+  if (result === GroundTruthState.HasGroundTruth) {
     const keys = Object.keys(state.groundTruthLinks);
     const keysLength = keys.length;
     let selfReferencedKeys = 0;
@@ -52,17 +52,17 @@ const groundTruthState = computed<GroundTruthState>(() => {
       }
     });
     if (selfReferencedKeys === keysLength) { // All groundTruth
-      result = 'AllGroundTruth';
+      result = GroundTruthState.AllGroundTruth;
     }
   }
   return result;
 });
 
 watch(groundTruthState, () => {
-  if (groundTruthState.value === 'AllGroundTruth' && state.filters.drawSiteOutline?.includes('model')) {
+  if (groundTruthState.value === GroundTruthState.AllGroundTruth && state.filters.drawSiteOutline?.includes('model')) {
     state.filters.drawSiteOutline = ['groundtruth'];
   }
-  if (groundTruthState.value === 'AllGroundTruth' && state.filters.drawObservations?.includes('model')) {
+  if (groundTruthState.value === GroundTruthState.AllGroundTruth && state.filters.drawObservations?.includes('model')) {
     state.filters.drawObservations = ['groundtruth'];
   }
 });
@@ -96,7 +96,7 @@ onMounted(() => {
 })
 
 const checkGroundTruth = async () => {
-  if (scoringApp.value || groundTruthState.value === 'AllGroundTruth') {
+  if (scoringApp.value || groundTruthState.value === GroundTruthState.AllGroundTruth) {
     return;
   } else if (proposals.value) {
     // We need to get the groundTruth value and toggle that instead.
@@ -117,10 +117,10 @@ const toggleObs = (type?: undefined | 'model' | 'groundtruth') => {
   let copy = state.filters.drawObservations;
   if (type === undefined) {
     const onVal:string[] = [];
-    if (groundTruthState.value !== 'AllGroundTruth') {
+    if (groundTruthState.value !== GroundTruthState.AllGroundTruth) {
       onVal.push('model');
     } 
-    if (groundTruthState.value === 'HasGroundTruth' || groundTruthState.value === 'AllGroundTruth') {
+    if (groundTruthState.value === GroundTruthState.HasGroundTruth || groundTruthState.value === GroundTruthState.AllGroundTruth) {
       onVal.push('groundtruth');
     }
     val = !state.filters.drawObservations ? onVal : undefined;
@@ -149,10 +149,10 @@ const toggleSite = (type?: undefined | 'model' | 'groundtruth') => {
   let copy = state.filters.drawSiteOutline;
   if (type === undefined) {
     const onVal:string[] = [];
-    if (groundTruthState.value !== 'AllGroundTruth') {
+    if (groundTruthState.value !== GroundTruthState.AllGroundTruth) {
       onVal.push('model');
     } 
-    if (groundTruthState.value === 'HasGroundTruth' || groundTruthState.value === 'AllGroundTruth') {
+    if (groundTruthState.value === GroundTruthState.HasGroundTruth || groundTruthState.value === GroundTruthState.AllGroundTruth) {
       onVal.push('groundtruth');
     }
     val = !state.filters.drawSiteOutline ? onVal : undefined;
@@ -260,9 +260,9 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           </v-list-item>
           <v-list-item
             value="Model"
-            :class="{'disabled-item': groundTruthState === 'AllGroundTruth'}"
-            :disabled="groundTruthState === 'AllGroundTruth'"
-            @click="groundTruthState !== 'AllGroundTruth' && toggleObs('model')"
+            :class="{'disabled-item': groundTruthState === GroundTruthState.AllGroundTruth}"
+            :disabled="groundTruthState === GroundTruthState.AllGroundTruth"
+            @click="groundTruthState !== GroundTruthState.AllGroundTruth && toggleObs('model')"
           >
             <div
               class="layer-icon pl-1"
@@ -278,7 +278,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
               :model-value="state.filters.drawObservations?.includes('model')"
               
               density="compact"
-              :disabled="groundTruthState === 'AllGroundTruth'"
+              :disabled="groundTruthState === GroundTruthState.AllGroundTruth"
               hide-details
               readonly
               class="item-checkbox"
@@ -286,8 +286,8 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           </v-list-item>
           <v-list-item
             value="GroundTruth"
-            :class="{'disabled-item': groundTruthState === 'NoGroundTruth'}"
-            :disabled="groundTruthState === 'NoGroundTruth'"
+            :class="{'disabled-item': groundTruthState === GroundTruthState.NoGroundTruth}"
+            :disabled="groundTruthState === GroundTruthState.NoGroundTruth"
             @click="toggleObs('groundtruth')"
           >
             <div
@@ -303,7 +303,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
             <v-checkbox-btn
               :model-value="state.filters.drawObservations?.includes('groundtruth')"
               density="compact"
-              :disabled="groundTruthState === 'NoGroundTruth'"
+              :disabled="groundTruthState === GroundTruthState.NoGroundTruth"
               hide-details
               readonly
               class="item-checkbox"
@@ -371,8 +371,8 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           </v-list-item>
           <v-list-item
             value="Model"
-            :class="{'disabled-item': groundTruthState === 'AllGroundTruth'}"
-            :disabled="groundTruthState === 'AllGroundTruth'"
+            :class="{'disabled-item': groundTruthState === GroundTruthState.AllGroundTruth}"
+            :disabled="groundTruthState === GroundTruthState.AllGroundTruth"
             @click="toggleSite('model')"
           >
             <div
@@ -389,15 +389,15 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
               :model-value="state.filters.drawSiteOutline?.includes('model')"
               density="compact"
               hide-details
-              :disabled="groundTruthState === 'AllGroundTruth'"
+              :disabled="groundTruthState === GroundTruthState.AllGroundTruth"
               readonly
               class="item-checkbox"
             />
           </v-list-item>
           <v-list-item
             value="GroundTruth"
-            :class="{'disabled-item': groundTruthState === 'NoGroundTruth'}"
-            :disabled="groundTruthState === 'NoGroundTruth'"
+            :class="{'disabled-item': groundTruthState === GroundTruthState.NoGroundTruth}"
+            :disabled="groundTruthState === GroundTruthState.NoGroundTruth"
             @click="toggleSite('groundtruth')"
           >
             <div
@@ -414,7 +414,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
               :model-value="state.filters.drawSiteOutline?.includes('groundtruth')"
               density="compact"
               hide-details
-              :disabled="groundTruthState === 'NoGroundTruth'"
+              :disabled="groundTruthState === GroundTruthState.NoGroundTruth"
               readonly
               class="item-checkbox"
             />

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -13,17 +13,23 @@ const proposals = computed(() => route.path.includes('proposals'));
 
 const modelRunEnabled = computed(() => state.openedModelRuns.size > 0);
 
+enum GroundTruthState {
+  NoGroundTruth = 0,
+  HasGroundTruth = 1,
+  AllGroundTruth = 2,
+}
+
 // Either has ground truth, is ground truth, or no ground truth
-const groundTruthState = computed<'NoGroundTruth'|'HasGroundTruth'|'AllGroundTruth'>(() => {
-  let result: 'NoGroundTruth'|'HasGroundTruth'|'AllGroundTruth'  = 'NoGroundTruth';
+const groundTruthState = computed<GroundTruthState>(() => {
+  let result: GroundTruthState  = GroundTruthState.NoGroundTruth;
   if (scoringApp.value) {
-    return 'HasGroundTruth';
+    return GroundTruthState.HasGroundTruth;
   }
   if (proposals.value) {
     if (state.proposals.ground_truths) {
-      return 'HasGroundTruth';
+      return GroundTruthState.HasGroundTruth;
     } else {
-      return 'NoGroundTruth';
+      return GroundTruthState.NoGroundTruth;
     }
   }
   let hasGroundTruth = false;

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from "vue";
+import { computed, onMounted, watch } from "vue";
 import { ApiService } from "../client";
 import { state } from "../store";
 import { useRoute } from 'vue-router';
@@ -47,6 +47,15 @@ const groundTruthState = computed<'NoGroundTruth'|'HasGroundTruth'|'AllGroundTru
     }
   }
   return result;
+});
+
+watch(groundTruthState, () => {
+  if (groundTruthState.value === 'AllGroundTruth' && state.filters.drawSiteOutline?.includes('model')) {
+    state.filters.drawSiteOutline = ['groundtruth'];
+  }
+  if (groundTruthState.value === 'AllGroundTruth' && state.filters.drawObservations?.includes('model')) {
+    state.filters.drawObservations = ['groundtruth'];
+  }
 });
 
 const toggleGroundTruth = (id: string) => {
@@ -243,6 +252,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           <v-list-item
             value="Model"
             :class="{'disabled-item': groundTruthState === 'AllGroundTruth'}"
+            :disabled="groundTruthState === 'AllGroundTruth'"
             @click="groundTruthState !== 'AllGroundTruth' && toggleObs('model')"
           >
             <div
@@ -267,6 +277,8 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           </v-list-item>
           <v-list-item
             value="GroundTruth"
+            :class="{'disabled-item': groundTruthState === 'NoGroundTruth'}"
+            :disabled="groundTruthState === 'NoGroundTruth'"
             @click="toggleObs('groundtruth')"
           >
             <div
@@ -282,6 +294,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
             <v-checkbox-btn
               :model-value="state.filters.drawObservations?.includes('groundtruth')"
               density="compact"
+              :disabled="groundTruthState === 'NoGroundTruth'"
               hide-details
               readonly
               class="item-checkbox"
@@ -349,6 +362,8 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
           </v-list-item>
           <v-list-item
             value="Model"
+            :class="{'disabled-item': groundTruthState === 'AllGroundTruth'}"
+            :disabled="groundTruthState === 'AllGroundTruth'"
             @click="toggleSite('model')"
           >
             <div
@@ -365,12 +380,15 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
               :model-value="state.filters.drawSiteOutline?.includes('model')"
               density="compact"
               hide-details
+              :disabled="groundTruthState === 'AllGroundTruth'"
               readonly
               class="item-checkbox"
             />
           </v-list-item>
           <v-list-item
             value="GroundTruth"
+            :class="{'disabled-item': groundTruthState === 'NoGroundTruth'}"
+            :disabled="groundTruthState === 'NoGroundTruth'"
             @click="toggleSite('groundtruth')"
           >
             <div
@@ -387,6 +405,7 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
               :model-value="state.filters.drawSiteOutline?.includes('groundtruth')"
               density="compact"
               hide-details
+              :disabled="groundTruthState === 'NoGroundTruth'"
               readonly
               class="item-checkbox"
             />
@@ -553,5 +572,11 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
 .item-checkbox {
   display:inline;
   float:right;
+}
+
+.disabled-item {
+  background-color: gray;
+  color: lightgray;
+  cursor:not-allowed;
 }
 </style>

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -16,6 +16,9 @@ const modelRunEnabled = computed(() => state.openedModelRuns.size > 0);
 // Either has ground truth, is ground truth, or no ground truth
 const groundTruthState = computed<'NoGroundTruth'|'HasGroundTruth'|'AllGroundTruth'>(() => {
   let result: 'NoGroundTruth'|'HasGroundTruth'|'AllGroundTruth'  = 'NoGroundTruth';
+  if (scoringApp.value) {
+    return 'HasGroundTruth';
+  }
   if (proposals.value) {
     if (state.proposals.ground_truths) {
       return 'HasGroundTruth';

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -121,11 +121,18 @@ function handleToggle(modelRun: KeyedModelRun) {
   }
   if (state.openedModelRuns.has(modelRun.key)) {
     state.openedModelRuns.delete(modelRun.key);
+    if (modelRun.groundTruthLink && state.groundTruthLinks[modelRun.id]) {
+      delete state.groundTruthLinks[modelRun.id];
+    }
   } else {
     if (props.compact) {
       state.openedModelRuns.clear();
     }
     state.openedModelRuns.add(modelRun.key);
+    if (modelRun.groundTruthLink) {
+      state.groundTruthLinks[modelRun.id] = modelRun.groundTruthLink;
+    }
+
   }
 
   if (state.openedModelRuns.size > 0) {

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -41,9 +41,11 @@ const queryFilters = computed<QueryArguments>(() => ({
   region: selectedRegion.value,
   mode: selectedModes.value,
   eval: selectedEval.value,
+  groundtruth: groundtruth.value,
 }));
 
 const selectedModes: Ref<string[]> = ref([]);
+const groundtruth: Ref<boolean> = ref(false);
 const selectedPerformer: Ref<Performer[]> = ref([]);
 const selectedRegion: Ref<Region | undefined> = ref(undefined);
 const selectedEval: Ref<Eval[]> = ref([]);
@@ -283,6 +285,21 @@ const satelliteLoadingColor = computed(() => {
         >
           <v-icon>mdi-map-legend</v-icon>
         </v-btn>
+        <v-tooltip>
+          <template #activator="{ props: props }">
+            <v-btn
+              variant="tonal"
+              v-bind="props"
+              density="compact"
+              class="pa-0 ma-1 sidebar-icon"
+              :color="groundtruth ? 'primary' : 'gray'"
+              @click="groundtruth = !groundtruth"
+            >
+              <v-icon>mdi-check-decagram</v-icon>
+            </v-btn>
+          </template>
+          <span> Toggle Ground Truth in the list</span>
+        </v-tooltip>
         <v-btn
           :color="expandSettings ? 'primary' : 'gray'"
           variant="tonal"

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -188,7 +188,6 @@ watch(() => props.selectedEval, () => {
 watch(() => hoveredInfo.value.siteId, () => {
   if (hoveredInfo.value.siteId.length && controlKeyPressed.value) {
     const id = hoveredInfo.value.siteId[0];
-    console.log('scroll to id');
     scrollVirtualList(id)
   }
 });
@@ -214,10 +213,8 @@ onUnmounted(() => {
 const scrollVirtualList = (id: string, itemHeight = 105) => {
   if (virtualList.value) {
     const index = modifiedList.value.findIndex((item) => item.id === id)
-    console.log(`Found: index: ${index}`);
     if (index !== -1) {
       const height = (itemHeight * index) - (itemHeight * 1.25)
-      console.log(height);
       virtualList.value.$el.scrollTo({top: height, left: 0, behavior: 'smooth' });
     }
   }

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -131,7 +131,13 @@ const getAllSiteProposals = async (initRun = false) => {
         mainList = mainList.concat(results);
     }
     baseModifiedList.value = mainList;
-    modifiedList.value = mainList;
+    const includeGroundTruth = (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth'))
+    if (!includeGroundTruth) {
+      modifiedList.value = baseModifiedList.value.filter((item) => !item.groundTruth);
+    } else {
+      modifiedList.value = mainList;
+    }
+    modifiedList.value.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 }
 onMounted(() => getAllSiteProposals(true));
 onUnmounted(() => {
@@ -257,12 +263,18 @@ const startDownload = async (data: DownloadSettings) => {
 const cancelDownload = () => {
   setTimeout(() => getAllSiteProposals(), 1000);
 }
-watch(filter, () => {
+watch([filter, () => state.filters.drawObservations, () => state.filters.drawSiteOutline], () => {
+  const includeGroundTruth = (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth'))
+  let tempList: SiteDisplay[];
   if (filter.value) {
-    modifiedList.value = baseModifiedList.value.filter((item) => item.name.includes(filter.value))
+    tempList = baseModifiedList.value.filter((item) => item.name.includes(filter.value))
   } else {
-    modifiedList.value = baseModifiedList.value;
+    tempList = baseModifiedList.value;
   }
+  if (!includeGroundTruth) {
+    tempList = tempList.filter((item) => !item.groundTruth);
+  }
+  modifiedList.value = tempList;
 });
 
 </script>

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -103,6 +103,8 @@ const getSites = async (modelRun: string, initRun = false) => {
           PL: item.PL,
           status: item.status,
           timestamp: item.timestamp,
+          groundTruth: item.groundtruth,
+          originator: item.originator,
           downloading: item.downloading,
           details,
           proposal: !!details?.proposal,

--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -28,6 +28,8 @@ export interface SiteDisplay {
   status?: SiteModelStatus;
   timestamp: number;
   downloading: boolean;
+  groundTruth?: boolean;
+  originator?: string;
   proposal?: boolean;
   details?: {
     performer: string;
@@ -167,8 +169,10 @@ const selectingSite = async (e: boolean) => {
         v-if="!localSite.proposal && localSite.details"
         dense
       >
+      <span v-if="localSite.groundTruth" class="pr-2"><v-icon color="primary">mdi-check-decagram</v-icon></span>
         <span class="site-model-info"> {{ localSite.details.performer }} {{ localSite.details.title }}: {{ localSite.details.version }} </span>
       </v-row>
+
       <v-row
         v-if="!localSite.proposal"
         dense

--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -169,7 +169,10 @@ const selectingSite = async (e: boolean) => {
         v-if="!localSite.proposal && localSite.details"
         dense
       >
-      <span v-if="localSite.groundTruth" class="pr-2"><v-icon color="primary">mdi-check-decagram</v-icon></span>
+        <span
+          v-if="localSite.groundTruth"
+          class="pr-2"
+        ><v-icon color="primary">mdi-check-decagram</v-icon></span>
         <span class="site-model-info"> {{ localSite.details.performer }} {{ localSite.details.title }}: {{ localSite.details.version }} </span>
       </v-row>
 

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -191,6 +191,9 @@ export const state = reactive<{
   selectedImageSite?: SelectedImageSite | null;
   // Tooltip Display
   toolTipDisplay: Record<string, boolean>;
+  // GroundTruthLinks - regular model runs list of ground truths that can be opened
+  // KeyValue store of the sourceModelRun UID and the groundTruth UID
+  groundTruthLinks: Record<string, string>,
 }>({
   errorText: '',
   timestamp: Math.floor(Date.now() / 1000),
@@ -259,7 +262,8 @@ export const state = reactive<{
     Time: true,
     Score: false,
     Area: false,
-  }
+  },
+  groundTruthLinks: {},
 });
 
 export const filteredSatelliteTimeList = computed(() => {


### PR DESCRIPTION
resolves #418 

- May be a slight performance penalty but I think it's better to have non-groundtruth provide a direct link to the ground truth so it can be used to toggle on/off.
- The linked groundtruth will be the matching region with `ground_truth=True` with the newest date.
- The ground truth is not shown by default and instead in RDWatch it will link to ground truth when you turn it on using the Layer buttons.
- The groundtruth and model for the layer selections will enable/disable automatically based on the selected model.  So groundtruth is inherently connected to the model-run instead of having to be toggled automatically.
- Updated the scoring response to label ground-truth vs the regular items respectively in the list.
- Updated the regular RDWatch response to label groundtruth vs the regular items as well.



https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/ac762d5a-fce1-49d7-b502-b7ee5e1c0c4c



