### PR TITLE
Misc fixes/improvements to ingest endpoint

### DIFF
--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -9,6 +9,8 @@ from pydantic import confloat, constr, root_validator, validator
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry
 
+from rdwatch.models import Performer
+
 CurrentPhase: TypeAlias = Literal[
     'No Activity',
     'Site Preparation',
@@ -48,19 +50,13 @@ class SiteFeature(Schema):
     start_date: datetime | None
     end_date: datetime | None
     model_content: Literal['annotation', 'proposed', 'update']
-    originator: Literal[
-        'te',
-        'pmo',
-        'acc',
-        'ara',
-        'ast',
-        'bla',
-        'iai',
-        'kit',
-        'str',
-        'iMERIT',
-        'imerit',
-    ]
+    originator: str
+
+    @validator('originator')
+    def validate_originator(cls, v: str) -> str:
+        if Performer.objects.filter(short_code=v.upper()).exists():
+            return v
+        raise ValueError(f'Invalid originator "{v}"')
 
     # Optional fields
     score: confloat(ge=0.0, le=1.0) | None

--- a/django/src/rdwatch/schemas/site_model.py
+++ b/django/src/rdwatch/schemas/site_model.py
@@ -8,6 +8,7 @@ from pydantic import confloat, constr, root_validator, validator
 
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos.error import GEOSException
 
 from rdwatch.models import Performer
 
@@ -182,6 +183,8 @@ class Feature(Schema):
             GEOSGeometry(json.dumps(v))
         except GDALException:
             raise ValueError('Failed to parse geometry.')
+        except GEOSException as e:
+            raise ValueError(f'Failed to parse geometry: {e}')
         return v
 
     @root_validator


### PR DESCRIPTION
This PR fixes some issues I noticed while debugging the bug David reported about 500 errors on model run upload.

- After #407, new performers can be created. But, the pydantic validation for site/region models still restricts the list of accepted performers. 
- If an invalid geojson polygon is provided, GeoDjango throws a `GEOSException`. We don't explicitly catch it currently, resulting in a 500 error.