### PR TITLE
Creating Site Proposals

### DIFF
--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -515,7 +515,7 @@ export class ApiService {
     const bboxstr = `${minY},${minX},${maxY},${maxX}`;
     return __request(OpenAPI, {
       method: "GET",
-      url: "/api/satellite-image/all-timestamps/",
+      url: "/api/satellite-image/all-timestamps",
       query: { constellation, level, spectrum, start_timestamp: startTime, end_timestamp: endTime, bbox: bboxstr,
       }
     });

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -128,6 +128,41 @@ export interface SiteDetails {
   timemax: number;
 }
 
+export interface SMARTSiteFeatureCache {
+  originator_file?: string;
+  timestamp?: string;
+  commit_hash?: string;
+}
+export interface SMARTSiteFeature {
+  type: 'Feature';
+  properties: {
+  type: 'site';
+  region_id: string;
+  site_id: string;
+  version: string;
+  mgrs: string;
+  status: string;
+  start_date: string | null;
+  end_date: string | null;
+  model_content: 'annotation' | 'proposed' | 'update';
+  originator: string;
+  comments: string;
+  // Optional fields
+  score?: number;
+  validated?: boolean;
+  cache?: SMARTSiteFeatureCache;
+  predicted_phase_transition?: 'Active Construction' | 'Post Construction';
+  predicted_phase_transition_date?: string;
+  misc_info?: Record<string, any>;
+  performer_cache?: Record<string, any>;
+  }
+  geometry: GeoJSON.Geometry;
+}
+export interface SiteModelUpload {
+  type: 'FeatureCollection',
+  features: SMARTSiteFeature[];
+}
+
 type ApiPrefix = '/api' | '/api/scoring';
 
 export class ApiService {
@@ -608,4 +643,19 @@ export class ApiService {
     })
   }
 
+  public static addSiteModel(
+    modelRunId: string,
+    siteModel: SiteModelUpload
+  ): CancelablePromise<boolean> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: `${this.getApiPrefix()}/model-runs/{id}/site-model/`,
+      path: {
+        id: modelRunId,
+      },
+      body: {
+        ...siteModel
+      }
+    });
+  }
 }

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -467,7 +467,7 @@ const addProposal = () => {
       class="px-2 mx-2"
       size="large"
       :disabled="state.filters.addingSitePolygon"
-      :color="state.filters.drawRegionPoly ? 'primary' : ''"
+      :color="state.filters.addingSitePolygon ? 'primary' : ''"
       @click="addProposal()"
     >
       <v-icon>mdi-plus</v-icon>Add Proposal

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -382,17 +382,6 @@ const addProposal = () => {
     >
       Region
     </v-btn>
-    <v-btn
-      v-if="modelRunEnabled && proposals"
-      class="px-2 mx-2"
-      size="large"
-      :disabled="state.filters.addingSitePolygon"
-      :color="state.filters.drawRegionPoly ? 'primary' : ''"
-      @click="addProposal()"
-    >
-      <v-icon>mdi-plus</v-icon>Add Proposal
-    </v-btn>
-
     <v-menu
       open-on-hover
     >
@@ -473,6 +462,16 @@ const addProposal = () => {
         </v-list>
       </v-card>
     </v-menu>
+    <v-btn
+      v-if="modelRunEnabled && proposals && !scoringApp"
+      class="px-2 mx-2"
+      size="large"
+      :disabled="state.filters.addingSitePolygon"
+      :color="state.filters.drawRegionPoly ? 'primary' : ''"
+      @click="addProposal()"
+    >
+      <v-icon>mdi-plus</v-icon>Add Proposal
+    </v-btn>
   </v-row>
 </template>
 

--- a/vue/src/components/LayerSelection.vue
+++ b/vue/src/components/LayerSelection.vue
@@ -11,6 +11,8 @@ const route = useRoute();
 const proposals = computed(() => route.path.includes('proposals'));
 
 
+const modelRunEnabled = computed(() => state.openedModelRuns.size > 0);
+
 const toggleGroundTruth = (id: string) => {
   if (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth')) {
         if (state.openedModelRuns) {
@@ -136,6 +138,10 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
 
   }
   state.filters = { ...state.filters, scoringColoring: val as 'simple' | 'detailed' | undefined };
+}
+
+const addProposal = () => {
+  state.filters.addingSitePolygon = true;
 }
 
 </script>
@@ -376,6 +382,17 @@ const toggleScoring = (data? : undefined | 'simple' | 'detailed') => {
     >
       Region
     </v-btn>
+    <v-btn
+      v-if="modelRunEnabled && proposals"
+      class="px-2 mx-2"
+      size="large"
+      :disabled="state.filters.addingSitePolygon"
+      :color="state.filters.drawRegionPoly ? 'primary' : ''"
+      @click="addProposal()"
+    >
+      <v-icon>mdi-plus</v-icon>Add Proposal
+    </v-btn>
+
     <v-menu
       open-on-hover
     >

--- a/vue/src/components/annotationViewer/AddProposal.vue
+++ b/vue/src/components/annotationViewer/AddProposal.vue
@@ -170,6 +170,7 @@ const addProposal = async () => {
     }
   }
 };
+const isSiteIdValid = computed(() => /^[0-9]{4}$/.test(siteId.value));
 </script>
 
 <template>
@@ -235,6 +236,8 @@ const addProposal = async () => {
         <v-text-field
           v-model="siteId"
           label="SiteId"
+          :error-messages="isSiteIdValid ? '' : 'Site ID must be a 4-digit number'"
+          :rules="[v => isSiteIdValid || 'Site ID must be a 4-digit number']"
         />
       </v-row>
       <v-row>

--- a/vue/src/components/annotationViewer/AddProposal.vue
+++ b/vue/src/components/annotationViewer/AddProposal.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import { Ref, computed, onMounted, ref } from "vue";
+import { state } from "../../store";
+import { getColorFromLabel, styles } from '../../mapstyle/annotationStyles';
+import { useDate } from "vuetify/lib/framework.mjs";
+
+
+
+onMounted(() => {
+    if (state.editPolygon) {
+        state.editPolygon.setPolygonNew();
+    }
+});
+
+const dateAdpter = useDate();
+
+type EditModes = 'SiteEvaluationLabel' | 'StartDate' | 'EndDate' | 'SiteObservationLabel' | 'SiteEvaluationNotes' | 'SiteObservationNotes'
+
+const currentTimestamp = computed(() => (new Date(state.timestamp * 1000).toISOString().split('T')[0]));
+const startDate: Ref<string|null> = ref(null);
+const endDate: Ref<string|null> = ref(null);
+const startDateTemp: Ref<string | null> = ref(new Date(state.timestamp * 1000).toISOString().split('T')[0]);
+const endDateTemp: Ref<string | null> = ref(new Date(state.timestamp * 1000).toISOString().split('T')[0]);
+const editDialog = ref(false);
+const currentEditMode: Ref<null | EditModes> = ref(null);
+const siteEvaluationList = computed(() => Object.entries(styles).filter(([, { type }]) => type === 'sites').map(([label]) => label));
+const siteEvaluationLabel = ref('Positive Annotated');
+
+const deleteSelectedPoints = () => {
+  if (state.editPolygon && selectedPoints.value) {
+    state.editPolygon.deleteSelectedPoints();
+  }
+}
+const selectedPoints = computed(() => state.editPolygon && (state.editPolygon.selectedPoints).length);
+
+const setEditingMode = (mode: EditModes) => {
+  if (['StartDate', 'EndDate'].includes(mode)){
+    if (startDate.value !== null) {
+      startDateTemp.value = startDate.value;
+    } else {
+        startDateTemp.value = new Date(state.timestamp * 1000).toISOString().split('T')[0];
+    }
+    if (endDate.value !== null) {
+      endDateTemp.value = endDate.value;
+    } else {
+        endDateTemp.value = new Date(state.timestamp * 1000).toISOString().split('T')[0];
+    }
+  }
+  editDialog.value = true;
+  currentEditMode.value = mode;
+}
+
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const updateTime = (time: any, date: 'StartDate' | 'EndDate'| 'StartDateTemp' | 'EndDateTemp') => {
+  if (time === null) {
+    if (date === 'StartDate') {
+      startDate.value = null;
+    } else if (date === 'EndDate') {
+      endDate.value = null
+    } else if (date === 'StartDateTemp') {
+      startDateTemp.value = null;
+    }  else if (date === 'EndDateTemp') {
+      endDateTemp.value = null;
+    }
+    editDialog.value = false;
+  } else {
+    if (date === 'StartDate') {
+      startDate.value = new Date(time as string).toISOString().split('T')[0];
+    } else if (date === 'EndDate') {
+      endDate.value = new Date(time as string).toISOString().split('T')[0];
+    } else if (date === 'StartDateTemp') {
+      startDateTemp.value = new Date(time as string).toISOString().split('T')[0];
+    } else if (date === 'EndDateTemp') {
+      endDateTemp.value = new Date(time as string).toISOString().split('T')[0];
+    }
+    editDialog.value = false;
+  }
+};
+
+</script>
+
+<template>
+  <v-card>
+    <v-card-title>
+      <v-row>
+        <h5>Add Proposal</h5>
+        <v-spacer />
+      </v-row>
+    </v-card-title>
+    <v-card-text>
+      <ul>
+        <li>Begin by clicking on the screen to add a point.</li>
+        <li>Complete the polygon by double clicking.</li>
+        <li>Right click to Edit the polygon after complettion</li>
+      </ul>
+      <div class="label">
+        <b>Label:</b>
+        <v-chip
+          size="small"
+          :color="getColorFromLabel(siteEvaluationLabel)"
+          class="ml-2"
+        >
+          {{ siteEvaluationLabel }}
+        </v-chip>
+        <v-icon
+          @click="setEditingMode('SiteEvaluationLabel')"
+        >
+          mdi-pencil
+        </v-icon>
+      </div>
+
+      <div class="label">
+        <b class="mr-1">Start Date:</b>
+        <span> {{ startDate ? startDate : 'null' }}
+          <v-icon
+            class="ma-0"
+            @click="setEditingMode('StartDate')"
+          >
+            mdi-pencil
+          </v-icon>
+
+        </span>
+      </div>
+      <div class="label">
+        <b class="mr-1">End Date:</b>
+        <span> {{ endDate ? endDate : 'null' }}
+          <v-icon
+            class="ma-0"
+            @click="setEditingMode('EndDate')"
+          >
+            mdi-pencil
+          </v-icon>
+
+        </span>
+      </div>
+      <v-btn
+        v-if="selectedPoints"
+        size="small"
+        color="error"
+        class="mx-2"
+        @click="deleteSelectedPoints()"
+      >
+        <v-icon>mdi-delete</v-icon>
+        points
+      </v-btn>
+    </v-card-text>
+    <v-dialog
+      v-model="editDialog"
+      width="400"
+    >
+      <v-card v-if="currentEditMode === 'SiteEvaluationLabel'">
+        <v-card-title>Edit Site Model Label</v-card-title>
+        <v-card-text>
+          <v-select
+            v-model="siteEvaluationLabel"
+            :items="siteEvaluationList"
+            label="Label"
+            class="mx-2"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-row dense>
+            <v-btn
+              color="error"
+              class="mx-3"
+              @click="editDialog = false"
+            >
+              Cancel
+            </v-btn>
+            <v-btn
+              color="success"
+              class="mx-3"
+              @click="editDialog = false; siteEvaluationUpdated = true"
+            >
+              Save
+            </v-btn>
+          </v-row>
+        </v-card-actions>
+      </v-card>
+      <v-card v-if="currentEditMode === 'StartDate'">
+        <v-card>
+          <v-card-title>Site Start Time</v-card-title>
+          <v-card-text>
+            <v-row
+              dense
+              justify="center"
+            >
+              <v-btn
+                color="error"
+                class="mb-2 mx-1"
+                size="small"
+                @click="updateTime(null, 'StartDate'); editDialog=false"
+              >
+                Set Time to Null
+              </v-btn>
+            </v-row>
+            <v-date-picker
+              v-if="startDateTemp !== null"
+              :model-value="dateAdpter.parseISO(startDateTemp ? startDateTemp : currentTimestamp)"
+              @update:model-value="updateTime($event, 'StartDate')"
+              @click:cancel="editDialog = false"
+              @click:save="editDialog = false"
+            />
+          </v-card-text>
+        </v-card>
+      </v-card>
+      <v-card v-if="currentEditMode === 'EndDate'">
+        <v-card>
+          <v-card-title>Site End Time</v-card-title>
+          <v-card-text>
+            <v-row
+              dense
+              justify="center"
+            >
+              <v-btn
+                color="error"
+                class="mb-2 mx-1"
+                size="small"
+                @click="updateTime(null, 'EndDate'); editDialog=false"
+              >
+                Set Time to Null
+              </v-btn>
+            </v-row>
+            <v-date-picker
+              v-if="endDateTemp !== null"
+              :model-value="dateAdpter.parseISO(endDateTemp ? endDateTemp : currentTimestamp)"
+              @update:model-value="updateTime($event, 'EndDate')"
+              @click:cancel="editDialog = false"
+              @click:save="editDialog = false"
+            />
+          </v-card-text>
+        </v-card>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+

--- a/vue/src/components/annotationViewer/AddProposal.vue
+++ b/vue/src/components/annotationViewer/AddProposal.vue
@@ -49,7 +49,7 @@ const currentEditMode: Ref<null | EditModes> = ref(null);
 const siteEvaluationList = computed(() =>
   Object.entries(styles)
     .filter(([, { type }]) => type === "sites")
-    .map(([label]) => label)
+    .map(([,item]) => item.label)
 );
 const siteEvaluationLabel = ref("Positive Annotated");
 const siteId = ref("");
@@ -130,8 +130,8 @@ const addProposal = async () => {
   if (state.editPolygon) {
     const polyGeoJSON = state.editPolygon.getEditingPolygon();
     if (polyGeoJSON) {
-      const found = Object.entries(styles).find(([, item]) => (item.label === siteEvaluationLabel.value));
-
+      const found = Object.entries(styles).find(([key , item]) => (item.label === siteEvaluationLabel.value || item.label === key));
+      console.log(found);
       if (found) {
         const label = found[0];
         const siteModel: SiteModelUpload = {

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -140,7 +140,6 @@ watch(
     getSiteProposals();
   }
 );
-getSiteProposals();
 watch(clickedInfo, () => {
   if (clickedInfo.value.siteId.length) {
     const found = modifiedList.value.find(
@@ -204,6 +203,7 @@ const toggleControlKey = (event: KeyboardEvent) => {
 onMounted(() => {
   window.addEventListener('keydown', toggleControlKey);
   window.addEventListener('keyup', toggleControlKey);
+  getSiteProposals();
 });
 
 // Remove event listener when the component is unmounted

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -187,7 +187,6 @@ watch(() => props.selectedEval, () => {
 watch(() => hoveredInfo.value.siteId, () => {
   if (hoveredInfo.value.siteId.length && controlKeyPressed.value) {
     const id = hoveredInfo.value.siteId[0];
-    console.log('scroll to id');
     scrollVirtualList(id)
   }
 });
@@ -210,14 +209,13 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('keydown', toggleControlKey);
   window.removeEventListener('keyup', toggleControlKey);
+  state.selectedImageSite = undefined;
 });
 const scrollVirtualList = (id: string, itemHeight = 105) => {
   if (virtualList.value) {
     const index = modifiedList.value.findIndex((item) => item.id === id)
-    console.log(`Found: index: ${index}`);
     if (index !== -1) {
       const height = (itemHeight * index) - (itemHeight * 1.25)
-      console.log(height);
       virtualList.value.$el.scrollTo({top: height, left: 0, behavior: 'smooth' });
     }
   }

--- a/vue/src/interactions/editPolygon.ts
+++ b/vue/src/interactions/editPolygon.ts
@@ -19,7 +19,6 @@ export default function useEditPolygon(mapObj: Map): EditPolygonType {
   const selectedPoints: Ref<DrawSelectionChangeEvent['points']> = ref([] as DrawSelectionChangeEvent['points']);
 
   const updated = (e: MapboxDraw.DrawUpdateEvent) => {
-    console.log(e);
     if (e.features.length) {
       editingPolygon.value = e.features[0].geometry as GeoJSON.Polygon;
     }

--- a/vue/src/interactions/editPolygon.ts
+++ b/vue/src/interactions/editPolygon.ts
@@ -5,6 +5,7 @@ import { Ref, ShallowRef, ref, shallowRef } from "vue";
 export interface EditPolygonType {
   initialize: () => void;
   setPolygonEdit: (polygon: GeoJSON.Polygon) => void;
+  setPolygonNew: () => void;
   getEditingPolygon: () => GeoJSON.Polygon | null;
   cancelPolygonEdit: () => void;
   deleteSelectedPoints: () => void;
@@ -193,6 +194,15 @@ export default function useEditPolygon(mapObj: Map): EditPolygonType {
     }
   };
 
+  const setPolygonNew = () => {
+    if (draw.value) {
+      draw.value.deleteAll();
+      editingPolygon.value = null;
+      selectedPoints.value = [];
+      draw.value.changeMode('draw_polygon');
+    }
+  }
+
   const deleteSelectedPoints = () => {
     if (draw.value) {
       selectedPoints.value = [];
@@ -212,6 +222,7 @@ export default function useEditPolygon(mapObj: Map): EditPolygonType {
   return {
     initialize,
     setPolygonEdit,
+    setPolygonNew,
     getEditingPolygon,
     cancelPolygonEdit,
     deleteSelectedPoints,

--- a/vue/src/interactions/editPolygon.ts
+++ b/vue/src/interactions/editPolygon.ts
@@ -19,6 +19,7 @@ export default function useEditPolygon(mapObj: Map): EditPolygonType {
   const selectedPoints: Ref<DrawSelectionChangeEvent['points']> = ref([] as DrawSelectionChangeEvent['points']);
 
   const updated = (e: MapboxDraw.DrawUpdateEvent) => {
+    console.log(e);
     if (e.features.length) {
       editingPolygon.value = e.features[0].geometry as GeoJSON.Polygon;
     }
@@ -181,6 +182,7 @@ export default function useEditPolygon(mapObj: Map): EditPolygonType {
       }
     }
     map.value.on("draw.update", updated);
+    map.value.on("draw.create", updated);
     map.value.on("draw.selectionchange", selectionChange);
   };
 

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -26,6 +26,7 @@ export interface MapFilters {
   }
   randomKey?: string;
   editingPolygonSiteId?: string | null; //currently editing a polygon
+  addingSitePolygon?: boolean;
 }
 
 export interface SatelliteTimeStamp {

--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -94,7 +94,10 @@ const updateSiteList = async () => {
             :selected-eval="state.selectedImageSite?.siteId || null"
             style="flex-grow: 1;"
           />
-          <add-proposal v-if="state.filters.addingSitePolygon" />
+          <add-proposal
+            v-if="state.filters.addingSitePolygon"
+            :region="region"
+          />
         </v-col>
       </v-row>
     </v-navigation-drawer>

--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -4,6 +4,7 @@ import ImageViewer from "../components/imageViewer/ImageViewer.vue"
 import MapLibre from "../components/MapLibre.vue";
 import LayerSelection from "../components/LayerSelection.vue";
 import AnnotationList from "../components/annotationViewer/AnnotationList.vue"
+import AddProposal from "../components/annotationViewer/AddProposal.vue"
 import MapLegend from "../components/MapLegend.vue";
 import { Ref, computed, onMounted, ref, watch } from "vue";
 import { state } from "../store";
@@ -87,12 +88,13 @@ const updateSiteList = async () => {
           class="navcolumn"
         >
           <annotation-list
-            v-if="selectedModelRun !== null"
+            v-if="selectedModelRun !== null && !state.filters.addingSitePolygon"
             ref="siteList"
             :model-run="selectedModelRun"
             :selected-eval="state.selectedImageSite?.siteId || null"
             style="flex-grow: 1;"
-          />          
+          />
+          <add-proposal v-if="state.filters.addingSitePolygon" />
         </v-col>
       </v-row>
     </v-navigation-drawer>


### PR DESCRIPTION
resolves #427 
- Adds button in proposal mode to create Site Proposals
- When clicked it opens a side panel that has instructions about drawing a polygon
- User can draw the polygon and then edit the metadata such as time, label, comments and siteId number.
- Added in the ability to turn on regional satellite images for proposal view for drawing new annotations.
- Updated the proposal view to add in the satellite timestamps so that a satelliteview can be used when drawing new proposals.

https://github.com/ResonantGeoData/RD-WATCH/assets/61746913/473f6d4d-a27d-4cbe-9ff2-0f0704e718c6

