### PR TITLE
Switch to Redis for task queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ env:
   DJANGO_SETTINGS_MODULE: rdwatch.server.settings
   RDWATCH_SECRET_KEY: ff07f533a59fed1349a4fc49941d02ff22514f6dbf6086a44ea0c0a8952e8644
   RDWATCH_POSTGRESQL_URI: postgresql://rdwatch:ff07f533a59fed1349a4fc49941d02ff22514f6dbf6086a44ea0c0a8952e8644@localhost:5432/rdwatch
-  RDWATCH_CELERY_BROKER_URL: amqp://localhost:5672/
+  RDWATCH_CELERY_BROKER_URL: redis://localhost:6379/
   RDWATCH_REDIS_URI: redis://localhost:6379/rdwatch
   RDWATCH_DJANGO_DEBUG: 0
   RDWATCH_MINIO_STORAGE_ACCESS_KEY: rdwatch
@@ -88,10 +88,6 @@ jobs:
           POSTGRES_PASSWORD: ${{ env.RDWATCH_SECRET_KEY }}
         ports:
           - 5433:5432
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
       redis:
         image: redis:latest
         ports:

--- a/dev/.env.docker-compose-native
+++ b/dev/.env.docker-compose-native
@@ -9,5 +9,5 @@ RDWATCH_STORAGE_BUCKET_NAME=rdwatch
 AWS_REQUEST_PAYER=requester
 RDWATCH_POSTGRESQL_URI="postgresql://rdwatch:secretkey@localhost:5432/rdwatch"
 RDWATCH_REDIS_URI="redis://localhost:6379"
-RDWATCH_CELERY_BROKER_URL="amqp://rdwatch:secretkey@localhost:5672/"
+RDWATCH_CELERY_BROKER_URL="redis://localhost:6379"
 RDWATCH_POSTGRESQL_SCORING_URI="postgresql://scoring:secretkey@localhost:5433/scoring"

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -15,7 +15,7 @@ services:
     environment:
       RDWATCH_POSTGRESQL_URI: "postgresql://rdwatch:secretkey@postgresql:5432/rdwatch"
       RDWATCH_REDIS_URI: "redis://redis:6379"
-      RDWATCH_CELERY_BROKER_URL: amqp://rdwatch:secretkey@rabbitmq:5672/
+      RDWATCH_CELERY_BROKER_URL: "redis://redis:6379"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/status"]
       interval: 30s
@@ -29,7 +29,6 @@ services:
       - 8000:8000
     depends_on:
       - postgresql
-      - rabbitmq
       - redis
       - minio
 
@@ -52,7 +51,7 @@ services:
     environment:
       RDWATCH_POSTGRESQL_URI: "postgresql://rdwatch:secretkey@postgresql:5432/rdwatch"
       RDWATCH_REDIS_URI: "redis://redis:6379"
-      RDWATCH_CELERY_BROKER_URL: amqp://rdwatch:secretkey@rabbitmq:5672/
+      RDWATCH_CELERY_BROKER_URL: "redis://redis:6379"
     volumes:
       - ./django:/app/django
       - celery-SAM-model:/data/SAM
@@ -63,8 +62,6 @@ services:
       minio:
         condition: service_started
       redis:
-        condition: service_started
-      rabbitmq:
         condition: service_started
       django:
         condition: service_healthy
@@ -86,7 +83,7 @@ services:
     environment:
       RDWATCH_POSTGRESQL_URI: "postgresql://rdwatch:secretkey@postgresql:5432/rdwatch"
       RDWATCH_REDIS_URI: "redis://redis:6379"
-      RDWATCH_CELERY_BROKER_URL: amqp://rdwatch:secretkey@rabbitmq:5672/
+      RDWATCH_CELERY_BROKER_URL: "redis://redis:6379"
     volumes:
       - ./django:/app/django
   rdwatch-client:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,15 +33,6 @@ services:
       - ${DOCKER_MINIO_PORT-9000}:9000
       - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001
 
-  # RabbitMQ
-  rabbitmq:
-    image: rabbitmq:management
-    environment:
-      RABBITMQ_DEFAULT_USER: rdwatch
-      RABBITMQ_DEFAULT_PASS: secretkey
-    ports:
-      - 5672:5672
-
   # Scoring database
   scoredb:
     image: postgis/postgis:latest


### PR DESCRIPTION
This PR configures celery to use the existing redis instance (the one used for caching) for queueing instead of provisioning a separate RabbitMQ instance.

@BryonLewis I applied this change to the rgd-dev instance as well, if you'd like to verify that as well.