### PR TITLE
remove duplicate siteObs detail call

### DIFF
--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -98,7 +98,6 @@ const foundIndex = state.selectedSites.findIndex((item) => item.id === props.sit
 const selectingSite = async (e: boolean) => {
   if (e) {
     emit('selected', props.site)
-    await getSiteObservationDetails(props.site.id);
   } else {
     close();
   }


### PR DESCRIPTION
This was a mistake on my part.  The `emit('selected') has the parent component call `getSiteObservationDetails` with some side-effects to reorder.  There is no need for it to be called here.