### PR TITLE
Get ModelRuns using RDWATCH Api Key

### DIFF
--- a/rdwatch/core/views/model_run.py
+++ b/rdwatch/core/views/model_run.py
@@ -393,6 +393,20 @@ def get_model_run(request: HttpRequest, id: UUID4):
     return get_object_or_404(get_queryset(), id=id)
 
 
+@router.get(
+    '/api-key-version',
+    response={200: list[ModelRunListSchema]},
+    auth=[ModelRunAuth()],
+)
+@paginate(ModelRunPagination)
+@csrf_exempt
+def list_model_runs_api_key(
+    request: HttpRequest,
+    filters: ModelRunFilterSchema = Query(...),  # noqa: B008
+):
+    return filters.filter(get_queryset())
+
+
 @router.post(
     '/{model_run_id}/site-model/',
     response={201: UUID4},

--- a/scripts/loadModelRun.py
+++ b/scripts/loadModelRun.py
@@ -76,7 +76,7 @@ def upload_to_rgd(
     expiration_time: int | None = None,
 ):
     # Check that our run doesn't already exist
-    model_run_results_url = f'{rgd_endpoint}/api/model-runs/'
+    model_run_results_url = f'{rgd_endpoint}/api/model-runs/api-key-version'
     model_runs_result = requests.get(
         model_run_results_url,
         params={'limit': '0'},


### PR DESCRIPTION
simple change to describe what is going on where clients that aren't logged in cannot upload new models.
Our upload models script will check to see if a ModelRun already exists.  It does this by requiring access to the GET /model-runs endpoint.
Our CRSFExempt utilizing the RDWATCH-API-KEY doesn't account for this so it will fail.
This PR is just meant as a draft to show a quick solution to the issue and not intended to be merged in.