### PR TITLE
Properly serve static files in production with `whitenoise`

### DIFF
--- a/docker/nginx.json
+++ b/docker/nginx.json
@@ -46,6 +46,11 @@
       }
     },
     {
+      "match": {
+        "uri": "/staticfiles/*"
+      }
+    },
+    {
       "action": {
         "share": "/app/vue/dist/$uri"
       }

--- a/poetry.lock
+++ b/poetry.lock
@@ -3102,7 +3102,21 @@ MarkupSafe = ">=2.1.1"
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
 
+[[package]]
+name = "whitenoise"
+version = "6.7.0"
+description = "Radically simplified static file serving for WSGI applications"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "whitenoise-6.7.0-py3-none-any.whl", hash = "sha256:a1ae85e01fdc9815d12fa33f17765bc132ed2c54fa76daf9e39e879dd93566f6"},
+    {file = "whitenoise-6.7.0.tar.gz", hash = "sha256:58c7a6cd811e275a6c91af22e96e87da0b1109e9a53bb7464116ef4c963bf636"},
+]
+
+[package.extras]
+brotli = ["brotli"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11.9,<4"
-content-hash = "d1fa960169950a7babfc915b2d33ff785ca071586534f8864fce271b5b4d3c0a"
+content-hash = "f5b5bd1198d611cf02b3c3cb49ddb4834eebd5b3da396a7420978b0b18de5e0d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ django-login-required-middleware = "^0.9.0"
 django-s3-file-field = {version = "^1.0.1", extras = ["s3"]}
 parver = "^0.5"
 sentry-sdk = {extras = ["celery", "django"], version = "^2.14.0"}
+whitenoise = "^6.7.0"
 
 [tool.poetry.group.dev.dependencies]
 django-stubs = "^4.2.7"

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -71,6 +71,10 @@ export default ({ mode}) => {
             target: `http://${devHost}:8000`,
             xfwd: true,
           },
+          "/static/admin": {
+            target: `http://${devHost}:8000`,
+            xfwd: true,
+          },
         },
         strictPort: true,
       },


### PR DESCRIPTION
This will fix the CSS issues on https://rgd.kitware.watch/admin/.

This PR is largely based on https://github.com/kitware-resonant/django-composed-configuration/blob/master/composed_configuration/_static.py