### PR TITLE
Fix docker configuration for ARM CPUs

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -68,6 +68,7 @@ services:
       django:
         condition: service_healthy
   celery_beat:
+    platform: linux/amd64
     build:
       dockerfile: Dockerfile
       target: dev


### PR DESCRIPTION
In particular, this makes the full docker-compose dev env build correctly on M1 Macs.