### PR TITLE
Fix Docs Deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -70,3 +70,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CONFIG_FILE: mkdocs.yml
         EXTRA_PACKAGES: build-base
+        REQUIREMENTS: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5.29
+pymdown-extensions


### PR DESCRIPTION
The mkdocs github action has support for a 'requirements.txt' for any additional dependencies that are needed for mkdocs:
https://github.com/mhausenblas/mkdocs-deploy-gh-pages?tab=readme-ov-file#installing-mkdocs-plugins
We utilize a materials icon plugin so it can render some of the icons I am using currently in the documentation.

The Error from deploying docs github actions log:
![image](https://github.com/user-attachments/assets/c57efea4-dc10-4835-a2af-c8f363076402)


I forked the Repo and applied the test on my own and it seems to to work: https://bryonlewis.github.io/RD-WATCH/
