### PR TITLE
Add versioning info

### DIFF
--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router';
 import { state } from './store';
+import type { ServerStatus } from './client';
 
 import { onBeforeMount, onErrorCaptured, ref } from "vue";
 
@@ -23,6 +24,7 @@ onBeforeMount(async () => {
       return;
     }
     isLoggedIn.value = true;
+    state.appVersion = (json as ServerStatus).rdwatch_version;
   } catch (e) {
     if (import.meta.env.PROD) {
       window.location.href = `/accounts/gitlab/login/?next=${window.location.pathname}`;

--- a/vue/src/client/models/ServerStatus.ts
+++ b/vue/src/client/models/ServerStatus.ts
@@ -11,4 +11,5 @@ export type ServerStatus = {
   };
   hostname: string;
   ip: string;
+  rdwatch_version: string;
 };

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -173,13 +173,15 @@ const satelliteLoadingColor = computed(() => {
         dense
       >
         <ErrorPopup />
-        <img
-          height="50"
-          class="mx-auto pb-4"
-          src="../assets/logo.svg"
-          alt="Resonant GeoData"
-          draggable="false"
-        >
+        <div class="d-flex flex-column align-center mx-auto pb-4">
+          <img
+            height="38"
+            src="../assets/logo.svg"
+            alt="Resonant GeoData"
+            draggable="false"
+          >
+          <span class="text-caption">{{ state.appVersion }}</span>
+        </div>
       </v-row>
       <mode-selector />
       <v-row>

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -157,6 +157,7 @@ export interface KeyedModelRun extends ModelRun {
 }
 
 export const state = reactive<{
+  appVersion: string;
   errorText: string;
   timestamp: number;
   timeMin: number;
@@ -203,6 +204,7 @@ export const state = reactive<{
   regionMap: RegionMapType;
   regionList: RegionDetail[];
 }>({
+  appVersion: '',
   errorText: '',
   timestamp: Math.floor(Date.now() / 1000),
   timeMin: new Date(0).valueOf(),


### PR DESCRIPTION
- Populate versioning info in the docker build for prod and dev
- Show the version in the UI
  <img width="384" alt="image" src="https://github.com/user-attachments/assets/b2969a39-f737-4ac7-a1f8-4de99efd7ffd">

The dev build will still show `0.0.0dev0` because `/app/rdwatch/__init__.py` doesn't exist in the docker container at build time (and it gets mounted over anyways). I verified that the prod docker image has a populated `__init__.py`, but haven't tried running it yet. Installing `poetry-dynamic-versioning` and running `poetry dynamic-versioning` will update the version info.