### PR TITLE
adds iMerit to lookups

### DIFF
--- a/rdwatch/core/fixtures/lookups.json
+++ b/rdwatch/core/fixtures/lookups.json
@@ -424,7 +424,7 @@
     "pk": 9,
     "fields": {
       "short_code": "IMERIT",
-      "team_name": "IMERIT"
+      "team_name": "iMERIT"
     }
   },
   {

--- a/rdwatch/core/fixtures/lookups.json
+++ b/rdwatch/core/fixtures/lookups.json
@@ -420,6 +420,14 @@
     }
   },
   {
+    "model": "core.performer",
+    "pk": 9,
+    "fields": {
+      "short_code": "IMERIT",
+      "team_name": "IMERIT"
+    }
+  },
+  {
     "model": "core.processinglevel",
     "pk": 1,
     "fields": {


### PR DESCRIPTION
Adds the iMerit performer to the lookups to support ground truth annotations.  The validator looks like the following:
```
    @validator('originator')
    def validate_originator(cls, v: str) -> str:
        if Performer.objects.filter(short_code=v.upper()).exists():
            return v
        raise ValueError(f'Invalid originator "{v}"')
```
The `v.upper` is why I'm using IMERIT as the short code.