### PR TITLE
Preliminary support for  WorldView NITF imagery

### DIFF
--- a/rdwatch/core/tasks/__init__.py
+++ b/rdwatch/core/tasks/__init__.py
@@ -45,9 +45,11 @@ from rdwatch.core.utils.images import (
     get_max_bbox,
     get_percent_black_pixels,
     get_range_captures,
+    ignore_pillow_filesize_limits,
     scale_bbox,
 )
 from rdwatch.core.utils.raster_tile import get_raster_bbox
+from rdwatch.core.utils.worldview_nitf.raster_tile import get_worldview_nitf_bbox
 from rdwatch.core.utils.worldview_processed.raster_tile import (
     get_worldview_processed_visual_bbox,
 )
@@ -88,6 +90,7 @@ def get_siteobservation_images_task(
     overrideDates: None | list[datetime, datetime] = None,
     scale: Literal['default', 'bits'] | list[int] = 'default',
     bboxScale: float = BboxScaleDefault,
+    worldview_source: Literal['cog', 'nitf'] | None = 'cog',
 ) -> None:
     capture_count = 0
     for constellation in baseConstellations:
@@ -101,6 +104,7 @@ def get_siteobservation_images_task(
             overrideDates=overrideDates,
             scale=scale,
             bboxScale=bboxScale,
+            worldview_source=worldview_source,
         )
     fetching_task = SatelliteFetching.objects.get(site_id=site_eval_id)
     fetching_task.status = SatelliteFetching.Status.COMPLETE
@@ -120,6 +124,7 @@ def get_siteobservations_images(
     overrideDates: None | list[datetime, datetime] = None,
     scale: Literal['default', 'bits'] | list[int] = 'default',
     bboxScale: float = BboxScaleDefault,
+    worldview_source: Literal['cog', 'nitf'] | None = 'cog',
 ) -> None:
     constellationObj = Constellation.objects.filter(slug=baseConstellation).first()
     # Ensure we are using ints for the DayRange and no_data_limit
@@ -215,7 +220,11 @@ def get_siteobservations_images(
                 found_timestamps[observation.timestamp] = True
                 continue
             results = fetch_boundbox_image(
-                bbox, timestamp, constellation.slug, baseConstellation == 'WV', scale
+                bbox,
+                timestamp,
+                constellation.slug,
+                worldview_source,
+                scale,
             )
             if results is None:
                 logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
@@ -234,7 +243,8 @@ def get_siteobservations_images(
             # logger.warning(f'Retrieved Image with timestamp: {timestamp}')
             output = f'tile_image_{observation.id}.png'
             image = File(io.BytesIO(bytes), name=output)
-            imageObj = Image.open(io.BytesIO(bytes))
+            with ignore_pillow_filesize_limits():
+                imageObj = Image.open(io.BytesIO(bytes))
             if image is None:  # No null/None images should be set
                 continue
             downloaded_count += 1
@@ -276,7 +286,6 @@ def get_siteobservations_images(
         timestamp = (min_time - timedelta(days=30)) + timebuffer
 
     # Now we get a list of all the timestamps and captures that fall in this range.
-    worldView = baseConstellation == 'WV'
     if matchConstellation == '':
         matchConstellation = Constellation.objects.filter(
             slug=baseConstellation
@@ -286,7 +295,11 @@ def get_siteobservations_images(
         )
 
     captures = get_range_captures(
-        max_bbox, timestamp, matchConstellation.slug, timebuffer, worldView
+        max_bbox,
+        timestamp,
+        matchConstellation.slug,
+        timebuffer,
+        worldview_source,
     )
     self.update_state(
         state='PROGRESS',
@@ -339,10 +352,12 @@ def get_siteobservations_images(
         if capture_timestamp not in found_timestamps.keys():
             # we need to add a new image into the structure
             bytes = None
-            if worldView:
+            if worldview_source == 'cog':
                 bytes = get_worldview_processed_visual_bbox(
                     capture, max_bbox, 'PNG', scale
                 )
+            elif worldview_source == 'nitf':
+                bytes = get_worldview_nitf_bbox(capture, max_bbox, 'PNG', scale)
             else:
                 bytes = get_raster_bbox(capture.uri, max_bbox, 'PNG', scale)
             if bytes is None:
@@ -354,7 +369,8 @@ def get_siteobservations_images(
             count += 1
             output = f'tile_image_{baseSiteEval.pk}_nonobs_{uuid4()}.png'
             image = File(io.BytesIO(bytes), name=output)
-            imageObj = Image.open(io.BytesIO(bytes))
+            with ignore_pillow_filesize_limits():
+                imageObj = Image.open(io.BytesIO(bytes))
             if image is None:  # No null/None images should be set
                 count += 1
                 continue
@@ -545,6 +561,7 @@ def generate_site_images(
     overrideDates: None | list[datetime, datetime] = None,
     scale: Literal['default', 'bits'] | list[int] = 'default',
     bboxScale: float = BboxScaleDefault,
+    worldview_source: Literal['cog', 'nitf'] | None = 'cog',
 ):
     siteeval = SiteEvaluation.objects.get(pk=site_id)
     with transaction.atomic():
@@ -578,6 +595,7 @@ def generate_site_images(
             overrideDates,
             scale,
             bboxScale,
+            worldview_source,
         )
         fetching_task.celery_id = task_id.id
         fetching_task.save()

--- a/rdwatch/core/utils/worldview_nitf/raster_tile.py
+++ b/rdwatch/core/utils/worldview_nitf/raster_tile.py
@@ -1,0 +1,85 @@
+import logging
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from typing import Literal
+from urllib.parse import urlparse
+
+import boto3
+import rasterio  # type: ignore
+from rio_tiler.io.rasterio import Reader
+
+from rdwatch.core.utils.worldview_nitf.satellite_captures import WorldViewNITFCapture
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _download_nitf_image(uri: str) -> Generator[str, None, None]:
+    s3 = boto3.client('s3')
+
+    parsed_url = urlparse(uri)
+
+    s3_bucket = parsed_url.netloc
+    s3_path = parsed_url.path.lstrip('/')
+
+    with NamedTemporaryFile(suffix='.nitf') as f:
+        startTime = time.time()
+        logger.warning(f'Image URI: {uri}')
+        logger.warning(f'Base Info Time: {time.time() - startTime}')
+        s3.download_fileobj(s3_bucket, s3_path, f)
+        logger.warning(f'RGB Download Time: {time.time() - startTime}')
+        yield f.name
+
+
+def get_worldview_nitf_tile(
+    capture: WorldViewNITFCapture, z: int, x: int, y: int
+) -> bytes:
+    with rasterio.Env(
+        GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR',
+        GDAL_HTTP_MERGE_CONSECUTIVE_RANGES='YES',
+        GDAL_CACHEMAX=200,
+        CPL_VSIL_CURL_CACHE_SIZE=20000000,
+        GDAL_BAND_BLOCK_CACHE='HASHSET',
+        GDAL_HTTP_MULTIPLEX='YES',
+        GDAL_HTTP_VERSION=2,
+        VSI_CACHE='TRUE',
+        VSI_CACHE_SIZE=5000000,
+    ):
+        with Reader(input=capture.uri) as img:
+            rgb = img.tile(x, y, z, tilesize=512)
+        return rgb.render(img_format='WEBP')
+
+
+def get_worldview_nitf_bbox(
+    capture: WorldViewNITFCapture,
+    bbox: tuple[float, float, float, float],
+    format='PNG',
+    scale: Literal['default', 'bits'] = 'default',
+) -> bytes:
+    with rasterio.Env(
+        GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR',
+        GDAL_HTTP_MERGE_CONSECUTIVE_RANGES='YES',
+        GDAL_CACHEMAX=200,
+        CPL_VSIL_CURL_CACHE_SIZE=20000000,
+        GDAL_BAND_BLOCK_CACHE='HASHSET',
+        GDAL_HTTP_MULTIPLEX='YES',
+        GDAL_HTTP_VERSION=2,
+        VSI_CACHE='TRUE',
+        VSI_CACHE_SIZE=5000000,
+    ):
+        with _download_nitf_image(capture.uri) as nitf_filepath:
+            with Reader(input=nitf_filepath) as img:
+                rgb = img.part(bbox)
+
+        if scale == 'default':
+            rgb.rescale(in_range=((0, 10000),))
+        elif scale == 'bits':
+            if capture.bits_per_pixel != 8:
+                max_bits = 2**capture.bits_per_pixel - 1
+                rgb.rescale(in_range=((0, max_bits),))
+        elif isinstance(scale, list) and len(scale) == 2:  # scale is an integeter range
+            rgb.rescale(in_range=((scale[0], scale[1]),))
+
+        return rgb.render(img_format=format)

--- a/rdwatch/core/utils/worldview_nitf/satellite_captures.py
+++ b/rdwatch/core/utils/worldview_nitf/satellite_captures.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import cast
+
+from rdwatch.core.utils.worldview_nitf.stac_search import worldview_search
+
+
+@dataclass()
+class WorldViewNITFCapture:
+    timestamp: datetime
+    bbox: tuple[float, float, float, float]
+    uri: str
+    cloudcover: int | None
+    collection: str
+    bits_per_pixel: int
+    epsg: int
+
+
+def get_features(
+    timestamp: datetime,
+    bbox: tuple[float, float, float, float],
+    timebuffer: timedelta,
+):
+    results = worldview_search(timestamp, bbox, timebuffer=timebuffer)
+    yield from results['features']
+
+
+def get_captures(
+    timestamp: datetime,
+    bbox: tuple[float, float, float, float],
+    timebuffer: timedelta | None = None,
+) -> list[WorldViewNITFCapture]:
+    if timebuffer is None:
+        timebuffer = timedelta(hours=1)
+
+    features = [f for f in get_features(timestamp, bbox, timebuffer=timebuffer)]
+    captures = []
+    for feature in features:
+        if 'data' in feature['assets']:
+            cloudcover = 0
+            if 'properties' in feature:
+                if 'eo:cloud_cover' in feature['properties']:
+                    cloudcover = feature['properties']['eo:cloud_cover']
+            # from pprint import pprint; pprint(feature)
+            capture = WorldViewNITFCapture(
+                timestamp=datetime.fromisoformat(
+                    feature['properties']['datetime'].rstrip('Z')
+                ),
+                bbox=cast(tuple[float, float, float, float], tuple(feature['bbox'])),
+                uri=feature['assets']['data']['href'],
+                bits_per_pixel=feature['properties']['nitf:bits_per_pixel'],
+                cloudcover=cloudcover,
+                collection=feature['collection'],
+                epsg=feature['properties']['proj:epsg'],
+            )
+            captures.append(capture)
+
+    return captures

--- a/rdwatch/core/utils/worldview_nitf/satellite_captures.py
+++ b/rdwatch/core/utils/worldview_nitf/satellite_captures.py
@@ -41,7 +41,6 @@ def get_captures(
             if 'properties' in feature:
                 if 'eo:cloud_cover' in feature['properties']:
                     cloudcover = feature['properties']['eo:cloud_cover']
-            # from pprint import pprint; pprint(feature)
             capture = WorldViewNITFCapture(
                 timestamp=datetime.fromisoformat(
                     feature['properties']['datetime'].rstrip('Z')

--- a/rdwatch/core/utils/worldview_nitf/stac_search.py
+++ b/rdwatch/core/utils/worldview_nitf/stac_search.py
@@ -1,0 +1,83 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Literal, TypedDict, cast
+
+from pystac_client import Client
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class Link(TypedDict):
+    rel: str
+    href: str
+
+
+class Asset(TypedDict):
+    href: str
+
+
+Properties = TypedDict(
+    'Properties',
+    {
+        'datetime': str,
+        'nitf:image_representation': Literal['MULTI', 'MONO'],
+    },
+)
+
+
+class Feature(TypedDict):
+    id: str
+    properties: Properties
+    assets: dict[str, Asset]
+    bbox: list[float]
+
+
+class Context(TypedDict):
+    matched: int
+    limit: int
+
+
+class Results(TypedDict):
+    context: Context
+    features: list[Feature]
+    links: list[Link]
+
+
+COLLECTIONS: list[str] = ['worldview-nitf']
+
+
+def _fmt_time(time: datetime):
+    return f'{time.isoformat()[:19]}Z'
+
+
+def worldview_search(
+    timestamp: datetime,
+    bbox: tuple[float, float, float, float],
+    timebuffer: timedelta | None = None,
+) -> Results:
+    stac_catalog = Client.open(
+        settings.SMART_STAC_URL,
+        headers={'x-api-key': settings.SMART_STAC_KEY},
+    )
+
+    if timebuffer is not None:
+        min_time = timestamp - timebuffer
+        max_time = timestamp + timebuffer
+        time_str = f'{_fmt_time(min_time)}/{_fmt_time(max_time)}'
+    else:
+        time_str = f'{_fmt_time(timestamp)}Z'
+
+    results = stac_catalog.search(
+        method='GET',
+        bbox=bbox,
+        datetime=time_str,
+        collections=COLLECTIONS,
+        limit=100,
+    )
+
+    # TODO: return `results` directly instead of converting to a dict.
+    # Before that can happen, the callers need to be updated to handle
+    # an `ItemSearch` object.
+    return cast(Results, results.item_collection_as_dict())

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -108,6 +108,7 @@ export interface SiteObservationUpdateQuery {
 export type Constellation  = 'S2' | 'WV' | 'L8' | 'PL';
 export interface DownloadSettings {
   constellation: Constellation[];
+  worldviewSource?: 'cog' | 'nitf',
   dayRange?: number;
   noData?: number;
   overrideDates?: [string, string];
@@ -384,7 +385,7 @@ export class ApiService {
          },
        });
      }
- 
+
 
   /**
    * @param id
@@ -438,7 +439,7 @@ export class ApiService {
     });
   }
 
-  
+
   /**
    * @returns RegionList
    * @throws ApiError

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 const constellationChoices = ref(['S2', 'WV', 'L8', 'PL'])
 const selectedConstellation: Ref<Constellation[]> = ref(['WV']);
 const worldviewSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['cog', 'nitf'] : null);
-const selectedWorldviewSource = ref<'cog' | 'nitf' | undefined>(undefined);
+const selectedWorldviewSource = ref<'cog' | 'nitf'>('cog');
 const dayRange = ref(14);
 const noData = ref(50)
 const overrideDates: Ref<[string, string]> = ref([

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -21,8 +21,8 @@ const emit = defineEmits<{
 
 const constellationChoices = ref(['S2', 'WV', 'L8', 'PL'])
 const selectedConstellation: Ref<Constellation[]> = ref(['WV']);
-const imageSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['cog', 'nitf'] : null);
-const selectedImageSource = ref<'cog' | 'nitf' | undefined>(undefined);
+const worldviewSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['cog', 'nitf'] : null);
+const selectedWorldviewSource = ref<'cog' | 'nitf' | undefined>(undefined);
 const dayRange = ref(14);
 const noData = ref(50)
 const overrideDates: Ref<[string, string]> = ref([
@@ -42,7 +42,7 @@ const download = debounce(
   () => {
     emit('download', {
       constellation: selectedConstellation.value,
-      worldviewSource: selectedImageSource.value,
+      worldviewSource: selectedWorldviewSource.value,
       dayRange: dayRange.value,
       noData: noData.value,
       overrideDates: customDateRange.value ? overrideDates.value : undefined,
@@ -92,9 +92,9 @@ const display = ref(true);
               class="mr-2"
             />
             <v-select
-              v-if="imageSourceChoices"
-              v-model="selectedImageSource"
-              :items="imageSourceChoices"
+              v-if="worldviewSourceChoices"
+              v-model="selectedWorldviewSource"
+              :items="worldviewSourceChoices"
               label="Imagery Type"
               class="mr-2"
             />

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -19,8 +19,8 @@ const emit = defineEmits<{
     (e: "cancel"): void;
 }>();
 
-const baseList = ref(['S2', 'WV', 'L8', 'PL'])
-const selectedSource: Ref<Constellation[]> = ref(['WV']);
+const constellationChoices = ref(['S2', 'WV', 'L8', 'PL'])
+const selectedConstellation: Ref<Constellation[]> = ref(['WV']);
 const dayRange = ref(14);
 const noData = ref(50)
 const overrideDates: Ref<[string, string]> = ref([
@@ -39,7 +39,7 @@ const dateAdpter = useDate();
 const download = debounce(
   () => {
     emit('download', {
-      constellation: selectedSource.value,
+      constellation: selectedConstellation.value,
       dayRange: dayRange.value,
       noData: noData.value,
       overrideDates: customDateRange.value ? overrideDates.value : undefined,
@@ -82,9 +82,9 @@ const display = ref(true);
             align="center"
           >
             <v-select
-              v-model="selectedSource"
+              v-model="selectedConstellation"
               multiple
-              :items="baseList"
+              :items="constellationChoices"
               label="Source"
               class="mr-2"
             />

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Ref, defineProps, ref, withDefaults } from "vue";
+import { Ref, computed, defineProps, ref, withDefaults } from "vue";
 import { debounce } from 'lodash';
 import { Constellation, DownloadSettings } from "../client/services/ApiService";
 import { useDate } from "vuetify/lib/framework.mjs";
@@ -21,6 +21,8 @@ const emit = defineEmits<{
 
 const constellationChoices = ref(['S2', 'WV', 'L8', 'PL'])
 const selectedConstellation: Ref<Constellation[]> = ref(['WV']);
+const imageSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['cog', 'nitf'] : null);
+const selectedImageSource = ref<'cog' | 'nitf' | undefined>(undefined);
 const dayRange = ref(14);
 const noData = ref(50)
 const overrideDates: Ref<[string, string]> = ref([
@@ -40,6 +42,7 @@ const download = debounce(
   () => {
     emit('download', {
       constellation: selectedConstellation.value,
+      worldviewSource: selectedImageSource.value,
       dayRange: dayRange.value,
       noData: noData.value,
       overrideDates: customDateRange.value ? overrideDates.value : undefined,
@@ -86,6 +89,13 @@ const display = ref(true);
               multiple
               :items="constellationChoices"
               label="Source"
+              class="mr-2"
+            />
+            <v-select
+              v-if="imageSourceChoices"
+              v-model="selectedImageSource"
+              :items="imageSourceChoices"
+              label="Imagery Type"
               class="mr-2"
             />
             <v-icon


### PR DESCRIPTION
This PR adds support for downloading WorldView NITF imagery. 

On the STAC server, NITFs are stored in the `worldview-nitf` collection. I created a new module, `rdwatch.core.utils.worldview_nitf`, that mirrors the existing `rdwatch.core.utils.worldview_processed` with a few key differences:

1) I removed pan-sharpening logic from `worldview_nitf`.
2) `rio-tiler` gets stuck indefinitely if you give it an S3 URL to a NITF file directly. I assume it's struggling with the size somehow, as obviously unlike COGs it must download the entire image (on the order of gigabytes) every time it wants to chip out a small bounding box. To get around this, I download the NITF image from S3 directly using boto3 to a temporary file and pass `rio-tiler` the path to that, and it works.
3) Following on from 2), because we need to do that explicit image download to the worker's filesystem, it is not really possible to have the region-level on-demand imagery from an endpoint. Thus the only way to use NITF imagery in this PR is in the site/observation-level chips; see the GIF I posted in Slack.

Going forward I'd like to clean up some of the image fetching architecture and logic **(especially if we're going to add dev docs on how this stuff is structured/how to add new image sources)**. Currently there are a lot of complicated functions that are tighly coupled to each other and difficult to reason about. But for the purposes of keeping this PR well-scoped, I haven't made any attempts at that here.