### PR TITLE
Do a full checkout in docker image build

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -24,6 +24,8 @@ jobs:
           # actions/checkout fails if this is true and the action
           # triggers on a tag event.
           fetch-tags: github.ref_type != 'tag'
+          # poetry-dynamic-versioning requires a full checkout
+          fetch-depth: 0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR


### PR DESCRIPTION
`poetry-dynamic-versioning` requires a full checkout of the repo to determine the version string.