### PR TITLE
Fix site observation admin 500 error

### DIFF
--- a/rdwatch/core/models/site_observation.py
+++ b/rdwatch/core/models/site_observation.py
@@ -63,7 +63,7 @@ class SiteObservation(models.Model):
     def __str__(self):
         sit = str(self.siteeval)
         lbl = str(self.label).upper()
-        tim = self.timestamp.isoformat()
+        tim = self.timestamp.isoformat() if self.timestamp else 'unknown'
         return f'{sit}[{lbl}@{tim}]'
 
     @classmethod


### PR DESCRIPTION
The presence of any null-valued timestamps broke the rendering of the site observation admin page. More generally it would break any place we call the `__str__` method on such a site observation.