### PR TITLE
Fix query explosion problem in django-admin

### DIFF
--- a/rdwatch/core/admin.py
+++ b/rdwatch/core/admin.py
@@ -74,7 +74,7 @@ class SatelliteFetchingAdmin(admin.ModelAdmin):
         'celery_id',
         'error',
     )
-    list_filter = ('site', 'timestamp')
+    raw_id_fields = ('site',)
 
 
 @admin.register(SiteEvaluation)


### PR DESCRIPTION
The Satellite Fetching admin page was emitting tens of thousands of SQL queries when loading, even though my system contained zero satellite fetching records.

The reason for this was the `list_filter` on the `site` attribute, which was causing a SQL query for each SiteEvaluation that exists in the database to be issued.

Additionally, there was a similar issue when loading the Add satellite fetching page in django-admin, which was fixed by making `site` use the `raw_id` field behavior.