### PR TITLE
DAG Typescript Warning

### DIFF
--- a/vue/src/views/SmartFlow.vue
+++ b/vue/src/views/SmartFlow.vue
@@ -46,7 +46,7 @@ const fetchDags = debounce(async (searchTerm: string) => {
   loading.value = true;
   const query = searchTerm ? { dag_id_pattern: searchTerm } : {};
   const res = await SmartflowService.rdwatchSmartflowViewsListDags(query);
-  // TODO:  Currently Dags are experimental, Type definiations once more solidified implementation
+  // TODO:  Currently Dags are experimental, Type definitions once more solidified implementation
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dagResults.value = res.dags.map((dag: any) => dag.dag_id);
   loading.value = false;

--- a/vue/src/views/SmartFlow.vue
+++ b/vue/src/views/SmartFlow.vue
@@ -46,6 +46,8 @@ const fetchDags = debounce(async (searchTerm: string) => {
   loading.value = true;
   const query = searchTerm ? { dag_id_pattern: searchTerm } : {};
   const res = await SmartflowService.rdwatchSmartflowViewsListDags(query);
+  // TODO:  Currently Dags are experimental, Type definiations once more solidified implementation
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dagResults.value = res.dags.map((dag: any) => dag.dag_id);
   loading.value = false;
 }, 500);


### PR DESCRIPTION
An additional error I noticed when reviewing code.
The Smartflow integration is experimental and in early stages right now.  In the future if we continue down this path (Not guaranteed) I would suggest updating the types for the responses, but for right now, I believe disabling the typescript warning is fine.