### PR TITLE
Relax name restrictions on model run region names

### DIFF
--- a/dev/airflow_sample_dag.py
+++ b/dev/airflow_sample_dag.py
@@ -9,7 +9,7 @@ with DAG(
     description="Test DAG",
     params={
         "region_id": Param(
-            default="BR_R002", type="string", pattern=r"^[A-Z]{2}_[RCST]\d{3}$"
+            default="BR_R002", type="string", pattern=r"^.{1,255}$"
         ),
         "model_run_title": Param(default="test_run", type="string"),
     },

--- a/rdwatch/core/schemas/region_model.py
+++ b/rdwatch/core/schemas/region_model.py
@@ -34,7 +34,7 @@ class RegionFeature(Schema):
 class SiteSummaryFeature(Schema):
     type: Literal['site_summary']
     # match the site_id of format KR_R001_0001 or KR_R001_9990
-    site_id: constr(regex=r'^[A-Z]{2}_[RCST]\d{3}_\d{4,8}$')
+    site_id: constr(regex=r'^.{1,255}_\d{4,8}$')
     version: str | None
     mgrs: str
     status: Literal[
@@ -93,7 +93,8 @@ class SiteSummaryFeature(Schema):
 
     @property
     def site_number(self) -> int:
-        return int(self.site_id[8:])
+        splits = self.site_id.split('_')
+        return int(splits[-1])
 
 
 class Feature(Schema):

--- a/rdwatch/core/schemas/site_model.py
+++ b/rdwatch/core/schemas/site_model.py
@@ -29,8 +29,8 @@ class SiteFeatureCache(Schema):
 
 class SiteFeature(Schema):
     type: Literal['site']
-    region_id: constr(regex=r'^[A-Z]{2}_[RCST][\dx]{3}$')
-    site_id: constr(regex=r'^[A-Z]{2}_([RST]\d{3}|C[0-7]\d{2}|[RC][Xx]{3})_\d{4,8}$')
+    region_id: constr(min_length=1, max_length=255)
+    site_id: constr(regex=r'^.{1,255}_\d{4,8}$')
     version: constr(regex=r'^\d+\.\d+\.\d+$')
     mgrs: constr(regex=r'^\d{2}[A-Z]{3}$')
     status: Literal[
@@ -91,7 +91,8 @@ class SiteFeature(Schema):
 
     @property
     def site_number(self) -> int:
-        return int(self.site_id[8:])
+        splits = self.site_id.split('_')
+        return int(splits[-1])
 
 
 class ObservationFeature(Schema):

--- a/rdwatch/core/views/model_run.py
+++ b/rdwatch/core/views/model_run.py
@@ -92,7 +92,7 @@ class ModelRunFilterSchema(FilterSchema):
 class ModelRunWriteSchema(Schema):
     performer: str
     title: constr(max_length=1000)
-    region: constr(regex=r'^[A-Z]{2}_[RCST][\dx]{3}$')  # noqa: F722
+    region: constr(min_length=1, max_length=255)
     parameters: dict
     expiration_time: int | None
     evaluation: int | None = None


### PR DESCRIPTION
Fixes #484

For now I've just made the region name accept any non-empty string that fits in the database column. Let me know if that's not constrained enough.