### PR TITLE
Remove version numbers in docs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 services:
-  # PostgreSQL 14
+  # PostgreSQL
   postgresql:
     image: postgis/postgis:latest
     environment:

--- a/docs/DevDocs/GettingStarted.md
+++ b/docs/DevDocs/GettingStarted.md
@@ -97,8 +97,9 @@ The Vue-based SPA frontend. Source code is in the ["vue"](https://github.com/Res
 Services the application requires.
 
 - [NGINX Unit](https://unit.nginx.org/): serves both the backend and the bundled static assets ([Dockerfile](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/Dockerfile))
-- [PostgreSQL 14](https://www.postgresql.org/docs/14/index.html) and [PostGIS 3.2](http://www.postgis.net/documentation/): data warehouse ([Dockerfile](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/docker/services/postgresql/Dockerfile))
-- [Redis 7](https://redis.io/docs/): caching (and maybe in the future as a job queue) ([Dockerfile](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/docker/services/redis/Dockerfile))
+- [PostgreSQL](https://www.postgresql.org/docs/14/index.html) and [PostGIS 3.2](http://www.postgis.net/documentation/): data warehouse ([Dockerfile](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/docker/services/postgresql/Dockerfile))
+- [MinIO/S3](https://min.io/): storage for satellite images for faster browsing
+- [Redis](https://redis.io/docs/): caching and job queue ([Dockerfile](https://github.com/ResonantGeoData/RD-WATCH/blob/phase-ii/docker/services/redis/Dockerfile))
 
 ### Ingesting Data
 


### PR DESCRIPTION
Fixes a minor issue I noticed while reviewing the docs.

We're now running Postgres 16, so this is no longer accurate. I went ahead and removed the mention of the Redis version as well, as these things will inevitably change over time and I don't think there's any value in mentioning them in the docs.