### PR TITLE
additional modifications to support region constraint relaxation

### DIFF
--- a/dev/airflow_sample_dag.py
+++ b/dev/airflow_sample_dag.py
@@ -9,7 +9,7 @@ with DAG(
     description="Test DAG",
     params={
         "region_id": Param(
-            default="BR_R002", type="string", pattern=r"^[A-Z]{2}_[RCST]\d{3}$"
+            default="BR_R002", type="string", pattern=r"^.{1,255}$"
         ),
         "model_run_title": Param(default="test_run", type="string"),
     },

--- a/rdwatch/core/schemas/region_model.py
+++ b/rdwatch/core/schemas/region_model.py
@@ -34,7 +34,7 @@ class RegionFeature(Schema):
 class SiteSummaryFeature(Schema):
     type: Literal['site_summary']
     # match the site_id of format KR_R001_0001 or KR_R001_9990
-    site_id: constr(regex=r'^[A-Z]{2}_[RCST]\d{3}_\d{4,8}$')
+    site_id: constr(regex=r'^.{1,255}_\d{4,8}$')
     version: str | None
     mgrs: str
     status: Literal[
@@ -93,7 +93,8 @@ class SiteSummaryFeature(Schema):
 
     @property
     def site_number(self) -> int:
-        return int(self.site_id[8:])
+        splits = self.site_id.split('_')
+        return int(splits[-1])
 
 
 class Feature(Schema):

--- a/rdwatch/core/schemas/site_model.py
+++ b/rdwatch/core/schemas/site_model.py
@@ -29,8 +29,8 @@ class SiteFeatureCache(Schema):
 
 class SiteFeature(Schema):
     type: Literal['site']
-    region_id: constr(regex=r'^[A-Z]{2}_[RCST][\dx]{3}$')
-    site_id: constr(regex=r'^[A-Z]{2}_([RST]\d{3}|C[0-7]\d{2}|[RC][Xx]{3})_\d{4,8}$')
+    region_id: constr(min_length=1, max_length=255)
+    site_id: constr(regex=r'^.{1,255}_\d{4,8}$')
     version: constr(regex=r'^\d+\.\d+\.\d+$')
     mgrs: constr(regex=r'^\d{2}[A-Z]{3}$')
     status: Literal[
@@ -91,7 +91,8 @@ class SiteFeature(Schema):
 
     @property
     def site_number(self) -> int:
-        return int(self.site_id[8:])
+        splits = self.site_id.split('_')
+        return int(splits[-1])
 
 
 class ObservationFeature(Schema):


### PR DESCRIPTION
Updating the region_id constraint in the single schema would only allow for custom region names when creating a model run.  Other portions of the code utilize the region_id constraint.

- The DAG support is relatively new and may not be used in the future, but I figured I should update it.
- The SiteSummaryFeature is used during the creation of a region from a geoJSON and checks inside of it the region_id.  This constraint also needs to be relaxed.
- The SiteFeature was a base tool for importing sites and observations in the system.  Allowing it to have a custom name means that all geoJSON files can now have unconstrained names as well.  (They are limited to the siteID being a name followed by an underscore and 4 or 8 digits.
- We returned back the site_id number before using a slice of the text based on knowing how long it is.  The updated constraint means that the last split of the `_` should be a number that has the site number.

I did this quickly so there may be some more things we would want to enforce.

Below I've attached a quick Command Line python script that can take a folder (like a proposal or ground truth set) and convert them all to utilizing a custom region name.  Just `python RegionNameConverter.py {parent folder of geoJSONS} {new region name}`.  It renames the files and updates the geoJSON properties for `region_id` and `site_id`.  I did this so I could test importing updated data.

I took a KR_R002 folder ran the converter to switch it to "SampleRegionName" and then imported it into RD-WATCH using: `python loadModelRun.py 'SampleRegionName' "./SampleRegionName/**/SampleRegionName*.geojson" --title SampleRegionName --performer_shortcode 'KIT'`.  Hopefully this helps with finding any additional corner cases.


![image](https://github.com/user-attachments/assets/3debff20-dc19-4508-be98-6d58ba887232)

[RegionNameConverter.txt](https://github.com/user-attachments/files/16660261/RegionNameConverter.txt)




