### PR TITLE
Enable Ground Truth List for Simple/Detailed views

### DIFF
--- a/rdwatch/core/utils/raster_tile.py
+++ b/rdwatch/core/utils/raster_tile.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 def get_raster_tile(uri: str, z: int, x: int, y: int) -> bytes:
     # logger.warning(f'SITE URI: {uri}')
+    logger.warning(f'Image URI: {uri}')
     with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):
         if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
             with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):

--- a/rdwatch/core/utils/raster_tile.py
+++ b/rdwatch/core/utils/raster_tile.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 def get_raster_tile(uri: str, z: int, x: int, y: int) -> bytes:
     # logger.warning(f'SITE URI: {uri}')
-    logger.warning(f'Image URI: {uri}')
     with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):
         if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
             with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -64,6 +64,7 @@ export interface SiteInfo {
     bbox: { xmin: number; ymin: number; xmax: number; ymax: number }
     status: SiteModelStatus
     timestamp: number;
+    color_code?: number;
     filename?: string | null;
     downloading: boolean;
     groundtruth?: boolean;

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -134,7 +134,7 @@ const getAllSiteProposals = async (initRun = false) => {
         mainList = mainList.concat(results);
     }
     baseModifiedList.value = mainList;
-    const includeGroundTruth = (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth'))
+    const includeGroundTruth = (state.filters.drawObservations?.includes('groundtruth') || state.filters.drawSiteOutline?.includes('groundtruth') || state.filters.scoringColoring)
     if (!includeGroundTruth) {
       modifiedList.value = baseModifiedList.value.filter((item) => !item.groundTruth);
     } else {

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -142,7 +142,6 @@ const getAllSiteProposals = async (initRun = false) => {
     } else {
       if (state.filters.scoringColoring) { // Remove items based on color codes
         modifiedList.value = baseModifiedList.value.filter((item) => {
-          console.log(item.color_code);
           if (item.color_code !== undefined) {
             const colorKey = scoringColors[item.color_code as scoringColorsKeys];
             if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
@@ -311,22 +310,19 @@ watch([filter, () => state.filters.drawObservations, () => state.filters.drawSit
   } else {
       if (state.filters.scoringColoring) { // Remove items based on color codes
         tempList = tempList.filter((item) => {
-          console.log(item.color_code);
           if (item.color_code !== undefined) {
             const colorKey = scoringColors[item.color_code as scoringColorsKeys];
-            console.log(colorKey);
             if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
               return true;
             }
             return false;
           }
           return false;
-        })
-      } else {
+        });
       }
-    }
+  }
   modifiedList.value = tempList;
-});
+},{deep: true});
 
 const deselectAll = () => {
   const updatedList: SiteDisplay[] = [];

--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -30,6 +30,7 @@ export interface SiteDisplay {
   timestamp: number;
   downloading: boolean;
   groundTruth?: boolean;
+  color_code?: number;
   originator?: string;
   proposal?: boolean;
   details?: {


### PR DESCRIPTION
Previously the Site List while in scoring mode and looking at the simple or detailed views wouldn't display the ground truth in the list.

Updates:

- Makes sure the simple/detailed scoring views don't filter out the ground truth
- Adds to the backend the color_code data for each site.  This may be an expensive operation in comparison to not having it
- Handles filtering the sites in the list based on the simple/detailed display properties in the annotation colors
- Adds an X/Y (x out of y) to the site list to indicate how many sites are displayed out of the total number of sites.



https://github.com/user-attachments/assets/aab4a00c-b454-4e5d-9bf6-7dab45bae282

