### PR TITLE
Default to S2 imagery download

### DIFF
--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 }>();
 
 const constellationChoices = ref(['S2', 'WV',]) // TODO: Image Download HotFix ref(['S2', 'WV', 'L8', 'PL'])
-const selectedConstellation: Ref<Constellation[]> = ref(['WV']);
+const selectedConstellation: Ref<Constellation[]> = ref(['S2']);
 const worldviewSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['nitf'] : null); // TODO Image Download Hotfix: add back in cog
 const selectedWorldviewSource = ref<'nitf'>('nitf'); // // TODO: Image Download HotFix ref<'cog' | 'nitf'>('cog');
 const dayRange = ref(14);


### PR DESCRIPTION
Now that WV cog is disabled, we should default to S2 instead of WV nitf.