### PR TITLE
Validate the RegionModel performer against the db

### DIFF
--- a/rdwatch/core/schemas/region_model.py
+++ b/rdwatch/core/schemas/region_model.py
@@ -9,6 +9,8 @@ from pydantic import confloat, constr, validator
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 
+from rdwatch.core.models import Performer
+
 
 class RegionFeature(Schema):
     type: Literal['region']
@@ -55,19 +57,13 @@ class SiteSummaryFeature(Schema):
     start_date: datetime | None
     end_date: datetime | None
     model_content: Literal['annotation', 'proposed'] | None
-    originator: Literal[
-        'te',
-        'pmo',
-        'acc',
-        'ara',
-        'ast',
-        'bla',
-        'iai',
-        'kit',
-        'str',
-        'iMERIT',
-        'imerit',
-    ]
+    originator: str
+
+    @validator('originator')
+    def validate_originator(cls, v: str) -> str:
+        if Performer.objects.filter(short_code=v.upper()).exists():
+            return v
+        raise ValueError(f'Invalid originator "{v}"')
 
     # Optional fields
     comments: str | None


### PR DESCRIPTION
Matches the [SiteModel originator validation logic](https://github.com/ResonantGeoData/RD-WATCH/blob/65d54aebee3be6ba418830aaa8bd358889d22466/rdwatch/core/schemas/site_model.py#L56).