### PR TITLE
Validate RegionFeature originator

### DIFF
--- a/rdwatch/core/schemas/region_model.py
+++ b/rdwatch/core/schemas/region_model.py
@@ -22,6 +22,12 @@ class RegionFeature(Schema):
     end_date: datetime | None
     originator: str
 
+    @validator('originator')
+    def validate_originator(cls, v: str) -> str:
+        if Performer.objects.filter(short_code=v.upper()).exists():
+            return v
+        raise ValueError(f'Invalid originator "{v}"')
+
     # Optional fields
     comments: str | None
     performer_cache: dict[Any, Any] | None


### PR DESCRIPTION
@mvandenburgh I discovered that there are two `originator` fields per region model: one in the RegionFeature and another one in the SiteSummaryFeature. This adds originator validation for the RegionFeature (the previous PR added it for the SiteSummaryFeature).