### PR TITLE
Remove originator validators

### DIFF
--- a/rdwatch/core/schemas/region_model.py
+++ b/rdwatch/core/schemas/region_model.py
@@ -9,8 +9,6 @@ from pydantic import confloat, constr, validator
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 
-from rdwatch.core.models import Performer
-
 
 class RegionFeature(Schema):
     type: Literal['region']
@@ -58,12 +56,6 @@ class SiteSummaryFeature(Schema):
     end_date: datetime | None
     model_content: Literal['annotation', 'proposed'] | None
     originator: str
-
-    @validator('originator')
-    def validate_originator(cls, v: str) -> str:
-        if Performer.objects.filter(short_code=v.upper()).exists():
-            return v
-        raise ValueError(f'Invalid originator "{v}"')
 
     # Optional fields
     comments: str | None

--- a/rdwatch/core/schemas/site_model.py
+++ b/rdwatch/core/schemas/site_model.py
@@ -10,8 +10,6 @@ from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
 
-from rdwatch.core.models import Performer
-
 CurrentPhase: TypeAlias = Literal[
     'No Activity',
     'Site Preparation',
@@ -52,12 +50,6 @@ class SiteFeature(Schema):
     end_date: datetime | None
     model_content: Literal['annotation', 'proposed', 'update']
     originator: str
-
-    @validator('originator')
-    def validate_originator(cls, v: str) -> str:
-        if Performer.objects.filter(short_code=v.upper()).exists():
-            return v
-        raise ValueError(f'Invalid originator "{v}"')
 
     # Optional fields
     score: confloat(ge=0.0, le=1.0) | None


### PR DESCRIPTION
Remove the originator validators. These validators only validated that the originator exists in the database, and did so for every Feature that has an `originator` field, which could lead to many DB queries.

See #498 for an alternative to these validators.