### PR TITLE
Fix query explosion for `SiteImage` admin page

### DIFF
--- a/rdwatch/core/admin.py
+++ b/rdwatch/core/admin.py
@@ -106,6 +106,7 @@ class SiteImageAdmin(admin.ModelAdmin):
         'source',
     )
     list_filter = ('timestamp',)
+    raw_id_fields = ('site', 'observation')
 
 
 @admin.register(SiteObservation)


### PR DESCRIPTION
Similar to #478, each site image is issuing an additional query for its associated evaluation, and also N queries for each of the N observations associated with that evaluation. This leads to a N+1 query explosion that makes the `SiteImage` admin unusable.