### PR TITLE
Combine raster image bands if multiple are available

### DIFF
--- a/rdwatch/core/utils/raster_tile.py
+++ b/rdwatch/core/utils/raster_tile.py
@@ -44,7 +44,9 @@ def get_raster_bbox(
             with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):
                 s3_uri = 's3://sentinel-cogs/' + uri[49:]
                 with Reader(input=s3_uri) as cog:
-                    img = cog.part(bbox)
+                    # if there are multiple bands, use all of them
+                    indexes = list(range(1, cog.dataset.count + 1))
+                    img = cog.part(bbox, indexes=indexes)
                     if scale == 'default':
                         img.rescale(in_range=((0, 10000),))
                     elif scale == 'bits':
@@ -60,7 +62,9 @@ def get_raster_bbox(
                         img.rescale(in_range=((scale[0], scale[1]),))
                     return img.render(img_format=format)
         with Reader(input=uri) as cog:
-            img = cog.part(bbox)
+            # if there are multiple bands, use all of them
+            indexes = list(range(1, cog.dataset.count + 1))
+            img = cog.part(bbox, indexes=indexes)
             if scale == 'default':
                 img.rescale(in_range=((0, 10000),))
             elif scale == 'bits':


### PR DESCRIPTION
This updates the logic for pulling S2 raster imagery so that if the image contains multiple bands, all of them are combined prior to rendering.

See https://cogeotiff.github.io/rio-tiler/readers/#rio_tileriorasterioreader for example.