### PR TITLE
Refactor loadModelRuns to the store as a global action

### DIFF
--- a/vue/src/client/models/ModelRunList.ts
+++ b/vue/src/client/models/ModelRunList.ts
@@ -11,3 +11,12 @@ export type ModelRunList = {
   bbox: GeoJSON.Polygon | null;
   items: ModelRun[];
 };
+
+export const emptyModelRunList = (): ModelRunList => ({
+  count: 0,
+  next: null,
+  previous: null,
+  timerange: null,
+  bbox: null,
+  items: [],
+});

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -3,7 +3,7 @@ import ModelRunCard from "./ModelRunCard.vue";
 import type { ModelRunList } from "../client/models/ModelRunList";
 import type { QueryArguments } from "../client";
 import { computed, onMounted, ref, watch, withDefaults } from "vue";
-import { filteredSatelliteTimeList, queryModelRuns, refreshModelRunDownloadingStatuses, state, updateCameraBoundsBasedOnModelRunList } from "../store";
+import { filteredSatelliteTimeList, queryModelRuns, state, updateCameraBoundsBasedOnModelRunList } from "../store";
 import type { KeyedModelRun } from '../store'
 import { hoveredInfo } from "../interactions/mouseEvents";
 
@@ -27,8 +27,6 @@ async function loadModelRuns(type: 'firstPage' | 'nextPage') {
   const modelRunList = await queryModelRuns(type, props.filters, props.compact);
   emit('modelrunlist', modelRunList);
 }
-
-watch(() => state.downloadingCheck, () => refreshModelRunDownloadingStatuses());
 
 const loadingSatelliteTimestamps = ref(false);
 

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -16,7 +16,6 @@ import { changeTime } from "../interactions/timeStepper";
 import { useRoute } from "vue-router";
 import ModeSelector from './ModeSelector.vue';
 
-const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
 const route = useRoute();
 watch(() => route.path, (oldPath, newPath) => {
@@ -186,7 +185,7 @@ const satelliteLoadingColor = computed(() => {
       <mode-selector />
       <v-row>
         <TimeSlider
-          :min="timemin"
+          :min="state.timeMin"
           :max="Math.floor(Date.now() / 1000)"
         />
       </v-row>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -335,14 +335,6 @@ const satelliteLoadingColor = computed(() => {
         v-if="!expandSettings"
         :filters="queryFilters"
         class="flex-grow-1"
-        @update:timerange="
-          (timerange) => {
-            if (timerange !== null) {
-              timemin = timerange.min;
-              state.timeMin = timemin;
-            }
-          }
-        "
         @modelrunlist="currentModelRunList = $event"
       />
     </v-row>

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -5,7 +5,7 @@ import {
   DownloadSettings,
   SiteList,
 } from "../../client/services/ApiService";
-import { state, updateCameraBoundsBasedOnModelRunList } from "../../store";
+import { refreshModelRunDownloadingStatuses, state, updateCameraBoundsBasedOnModelRunList } from "../../store";
 import { clickedInfo, hoveredInfo } from "../../interactions/mouseEvents";
 import ImagesDownloadDialog from "../ImagesDownloadDialog.vue";
 import SiteListCard from "../siteList/SiteListCard.vue";
@@ -128,7 +128,6 @@ const getSiteProposals = async () => {
       if (selected) {
         selectSite(selected);
       }
-      
     }
   }
 };
@@ -238,8 +237,8 @@ const startDownload = async (data: DownloadSettings) => {
   const id = imageDownloadingId.value;
   imageDownloadDialog.value = false;
   if (id) {
-  await ApiService.getObservationImages(id, data);
-  state.downloadingCheck += 1;
+    await ApiService.getObservationImages(id, data);
+    refreshModelRunDownloadingStatuses();
     // Now we get the results to see if the service is running
     setTimeout(() => getSiteProposals(), 1000);
   }

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -11,7 +11,6 @@ import type { Ref } from "vue";
 import { changeTime } from "../../interactions/timeStepper";
 import ErrorPopup from "../ErrorPopup.vue";
 import ModeSelector from "../ModeSelector.vue";
-const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
 const queryFilters = computed<QueryArguments>(() => ({
   performer: selectedPerformer.value.map((item) => item.short_code),
@@ -150,7 +149,7 @@ const satelliteLoadingColor = computed(() => {
       <mode-selector />
       <v-row>
         <TimeSlider
-          :min="timemin || 0"
+          :min="state.timeMin"
           :max="Math.floor(Date.now() / 1000)"
         />
       </v-row>

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -263,14 +263,6 @@ const satelliteLoadingColor = computed(() => {
         class="flex-grow-1"
         compact
         @modelrunlist="currentModelRunList = $event"
-        @update:timerange="
-          (timerange) => {
-            if (timerange !== null) {
-              timemin = timerange.min;
-              state.timeMin = timemin;
-            }
-          }
-        "
       />
     </v-row>
     <v-dialog

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -10,7 +10,7 @@ import SiteListCard from "./SiteListCard.vue";
 import { SiteDisplay } from "./SiteListCard.vue";
 import SiteListHeader from "./SiteListHeader.vue";
 import SiteListFilter from "./SiteListFilter.vue";
-import { getSiteObservationDetails, state } from "../../store";
+import { getSiteObservationDetails, refreshModelRunDownloadingStatuses, state } from "../../store";
 import { scoringColors, scoringColorsKeys } from "../../mapstyle/annotationStyles";
 
 const props = defineProps<{
@@ -283,12 +283,12 @@ const startDownload = async (data: DownloadSettings) => {
   const id = imageDownloadingId.value;
   imageDownloadDialog.value = false;
   if (id) {
-  await ApiService.getObservationImages(id, data);
-  // Notify the ModelRunList that downloading is happening
-  if (imageDownloadingModelRunId.value) {
-    emit('image-download', imageDownloadingModelRunId.value);
-  }
-  state.downloadingCheck += 1;
+    await ApiService.getObservationImages(id, data);
+    // Notify the ModelRunList that downloading is happening
+    if (imageDownloadingModelRunId.value) {
+      emit('image-download', imageDownloadingModelRunId.value);
+    }
+    refreshModelRunDownloadingStatuses();
     // Now we get the results to see if the service is running
     setTimeout(() => getAllSiteProposals(), 1000);
   }

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -205,8 +205,6 @@ export const state = reactive<{
   // Region map is used to index names and owners with ids
   regionMap: RegionMapType;
   regionList: RegionDetail[];
-  // Downloading Check - used to indicate to the modelRunList to check for downloading images
-  downloadingCheck: number;
   // Query states - stores states for network queries
   queryStates: {
     loadModelRuns: {
@@ -292,7 +290,6 @@ export const state = reactive<{
   groundTruthLinks: {},
   regionMap: {},
   regionList: [],
-  downloadingCheck: 0,
   queryStates: {
     loadModelRuns: {
       inflightQueries: 0,

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -1,10 +1,11 @@
 import { computed, reactive } from "vue";
 
-import { ApiService, ModelRun, Performer, Region } from "./client";
+import { ApiService, CancelError, CancelablePromise, ModelRun, ModelRunList, Performer, QueryArguments, Region } from "./client";
 import { EditGeoJSONType } from "./interactions/editGeoJSON";
 import { BaseBBox, EvaluationImage } from "./types";
 import { LngLatBounds } from "maplibre-gl";
 import { RegionDetail } from "./client/models/Region";
+import { emptyModelRunList } from "./client/models/ModelRunList";
 
 export interface MapFilters {
   configuration_id?: string[];
@@ -178,7 +179,8 @@ export const state = reactive<{
   loopingInterval: NodeJS.Timeout | null,
   loopingId: string | null,
   modelRuns: KeyedModelRun[],
-  openedModelRuns: Set<KeyedModelRun["key"]>
+  totalNumModelRuns: number;
+  openedModelRuns: Set<KeyedModelRun["key"]>;
   gifSettings: { fps: number, quality: number, pointSize: number},
   performerMapping: Record<number, Performer>,
   proposals: {
@@ -205,11 +207,20 @@ export const state = reactive<{
   regionList: RegionDetail[];
   // Downloading Check - used to indicate to the modelRunList to check for downloading images
   downloadingCheck: number;
+  // Query states - stores states for network queries
+  queryStates: {
+    loadModelRuns: {
+      request: CancelablePromise<ModelRunList> | undefined;
+      inflightQueries: number;
+      nextPage: number;
+      activeFilters: QueryArguments;
+    };
+  };
 }>({
   appVersion: '',
   errorText: '',
   timestamp: Math.floor(Date.now() / 1000),
-  timeMin: new Date(0).valueOf(),
+  timeMin: Math.floor(new Date(0).valueOf() / 1000),
   settings: {
     autoZoom: false,
   },
@@ -254,6 +265,7 @@ export const state = reactive<{
   loopingInterval: null,
   loopingId: null,
   modelRuns: [],
+  totalNumModelRuns: 0,
   openedModelRuns: new Set<KeyedModelRun["key"]>(),
   gifSettings: { fps: 1, quality: 1, pointSize: 1},
   performerMapping: {},
@@ -281,6 +293,14 @@ export const state = reactive<{
   regionMap: {},
   regionList: [],
   downloadingCheck: 0,
+  queryStates: {
+    loadModelRuns: {
+      inflightQueries: 0,
+      request: undefined,
+      nextPage: 1,
+      activeFilters: {},
+    },
+  },
 });
 
 export const filteredSatelliteTimeList = computed(() => {
@@ -442,7 +462,7 @@ function updateCameraBoundsBasedOnModelRunList(filtered = true, force = false) {
     );
   }
   if (
-    !force && 
+    !force &&
     !state.settings.autoZoom &&
     state.filters.regions &&
     state.filters.regions?.length > 0
@@ -490,7 +510,7 @@ const updateRegionList = async () => {
     }
     // If both have owners or both do not, sort by name
     return a.name.localeCompare(b.name);
-  });  
+  });
   state.regionList = regionResults;
 }
 
@@ -502,11 +522,180 @@ const updateRegionMap = async () => {
   state.regionMap = tempRegionMap;
 }
 
+/**
+ * Loads a page of model runs.
+ *
+ * Next page information is only saved when the request completes.
+ * Therefore, request nextPage while firstPage is inflight will cancel
+ * the firstPage request.
+ *
+ * @param type "firstPage" or "nextPage"
+ * @param filters query filters
+ * @param compact
+ * @returns
+ */
+async function queryModelRuns(type: 'firstPage' | 'nextPage', filters: QueryArguments, compact  = false): Promise<ModelRunList> {
+  const queryState = state.queryStates.loadModelRuns;
+
+  queryState.request?.cancel();
+  queryState.request = undefined;
+
+  if (type !== 'firstPage' && state.modelRuns.length === state.totalNumModelRuns) {
+    return emptyModelRunList();
+  }
+
+  let page = 0;
+  if (type === 'firstPage') {
+    page = 1;
+  } else if (type === 'nextPage') {
+    page = queryState.nextPage;
+  } else {
+    throw new Error('Invalid call to loadModelRuns');
+  }
+
+  const { mode, performer } = filters; // unwrap performer and mode arrays
+  queryState.activeFilters = {
+    ...filters,
+    mode,
+    performer,
+    proposal: compact ? 'PROPOSAL' : undefined, // if compact we are doing proposal adjudication
+  };
+  queryState.request = ApiService.getModelRuns({
+    ...queryState.activeFilters,
+    page,
+  });
+  try {
+    queryState.inflightQueries++;
+    const modelRunList = await queryState.request;
+    queryState.request = undefined;
+    state.totalNumModelRuns = modelRunList.count;
+    queryState.nextPage = page + 1;
+
+    // sort list to show ground truth near the top
+    const modelRunResults = modelRunList.items;
+    const keyedModelRunResults = modelRunResults.map((val) => {
+      return {
+        ...val,
+        key: `${val.id}`,
+      };
+    });
+
+    // If a bounding box was provided for this model run list, zoom the camera to it.
+    if (modelRunList.bbox) {
+      const bounds = new LngLatBounds();
+      modelRunList.bbox.coordinates
+        .flat()
+        .forEach((c) => bounds.extend(c as [number, number]));
+      const bbox = {
+        xmin: bounds.getWest(),
+        ymin: bounds.getSouth(),
+        xmax: bounds.getEast(),
+        ymax: bounds.getNorth(),
+      };
+      state.bbox = bbox;
+    } else if (!state.filters.regions?.length) {
+      const bbox = {
+        xmin: -180,
+        ymin: -90,
+        xmax: 180,
+        ymax: 90,
+      };
+      state.bbox = bbox;
+    }
+
+    // If we're on page 1, we *might* have switched to a different filter/grouping in the UI,
+    // meaning we would need to clear out any existing results.
+    // To account for this, just set the array to the results directly instead of concatenating.
+    if (page === 1) {
+      state.modelRuns = keyedModelRunResults;
+    } else {
+      state.modelRuns = state.modelRuns.concat(keyedModelRunResults);
+    }
+
+    if (modelRunList['timerange'] !== null) {
+      state.timeMin = modelRunList['timerange'].min;
+    }
+
+    return modelRunList;
+  } catch (e) {
+    if (e instanceof CancelError) {
+      console.log('Request has been cancelled');
+    } else {
+      throw e;
+    }
+  } finally {
+    queryState.inflightQueries--;
+  }
+
+  return emptyModelRunList();
+}
+
+/**
+ * Refreshes the downloading state for the queried model runs.
+ *
+ * This will paginate the model run listing endpoint until all loaded
+ * pages are satisfied.
+ *
+ * - Only operates on the loaded pages at the time of invocation.
+ * - If an existing request is inflight, this will chain onto the
+ *   existing request (a CancelablePromise).
+ * - If cancelled, the entire chain is cancelled.
+ */
+const refreshModelRunDownloadingStatuses = async () => {
+  const queryState = state.queryStates.loadModelRuns;
+  const loadedPages = queryState.nextPage - 1;
+  const activeFilters = queryState.activeFilters;
+
+  let existingRequest = queryState.request as CancelablePromise<void> | undefined;
+
+  // chain cancelable requests
+  for (let page = 0; page < loadedPages; page++) {
+    const prevReq = existingRequest;
+    existingRequest = new CancelablePromise(async (resolve, reject, onCancel) => {
+      let apiCallRequest: CancelablePromise<ModelRunList> | undefined;
+
+      onCancel(() => {
+        prevReq?.cancel();
+        apiCallRequest?.cancel();
+      });
+
+      try {
+        await prevReq;
+
+        apiCallRequest = ApiService.getModelRuns({
+          ...activeFilters,
+          page,
+        });
+        const modelRunList = await apiCallRequest;
+
+        const modelRuns = modelRunList.items;
+        // NOTE this is inefficient if modelRuns.length is large and/or
+        // if the page size is large. Practically, this shouldn't be an issue.
+        // A better solution here is to use a lookup table (id -> modelRun).
+        for (let i = 0; i < state.modelRuns.length; i += 1) {
+          const currentModelRun = state.modelRuns[i];
+          const found = modelRuns.find((item) => item.id === currentModelRun.id);
+          if (found) {
+            if (found.downloading) {
+              state.modelRuns[i].downloading = found.downloading;
+            }
+          }
+        }
+      } catch (err) {
+        if (!(err instanceof CancelError)) reject(err);
+      }
+
+      resolve();
+    });
+  }
+};
 
 export {
   loadAndToggleSatelliteImages,
   updateCameraBoundsBasedOnModelRunList,
   updateRegionList,
   updateRegionMap,
+  queryModelRuns,
+  refreshModelRunDownloadingStatuses,
 }
 


### PR DESCRIPTION
- `loadModelRuns` is now part of the store as `queryModelRuns` and updates store state.
- `queryModelRuns` manages pagination state through "firstPage" and "nextPage" requests (see ModelRunList.vue for usage).
- `checkDownloading` is now part of the store as `refreshModelRunDownloadingStatuses`. Additionally, it has been fixed to properly update the downloading statuses of all loaded pagination pages.
  - A side note: I have yet to test this function!
- All usages of `state.downloadCheck` have been replaced with calls to `refreshModelRunDownloadingStatuses`.