### PR TITLE
set timeMin to modelRun list timeMin

### DIFF
--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -16,7 +16,6 @@ import { changeTime } from "../interactions/timeStepper";
 import { useRoute } from "vue-router";
 import ModeSelector from './ModeSelector.vue';
 
-const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
 const route = useRoute();
 watch(() => route.path, (oldPath, newPath) => {
@@ -186,7 +185,7 @@ const satelliteLoadingColor = computed(() => {
       <mode-selector />
       <v-row>
         <TimeSlider
-          :min="timemin"
+          :min="state.timeMin"
           :max="Math.floor(Date.now() / 1000)"
         />
       </v-row>

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -11,7 +11,6 @@ import type { Ref } from "vue";
 import { changeTime } from "../../interactions/timeStepper";
 import ErrorPopup from "../ErrorPopup.vue";
 import ModeSelector from "../ModeSelector.vue";
-const timemin = ref(Math.floor(new Date(0).valueOf() / 1000));
 
 const queryFilters = computed<QueryArguments>(() => ({
   performer: selectedPerformer.value.map((item) => item.short_code),
@@ -150,7 +149,7 @@ const satelliteLoadingColor = computed(() => {
       <mode-selector />
       <v-row>
         <TimeSlider
-          :min="timemin || 0"
+          :min="state.timeMin"
           :max="Math.floor(Date.now() / 1000)"
         />
       </v-row>


### PR DESCRIPTION
The removal of the `@update:timeRang` from `SideBar.vue` meant that the slider was always going to utilize the UNIX epoch time.  This uses the global `state.timeMin`.  I think this was an oversight of mine when I was converting the very heavily integrated component system signaling (where it was doing some passing up/down of information) into more of a store system when I came on to the project.

I do understand that our Store is really overloaded right now and at some point should probably be refactored but that is an issue for another time.