### PR TITLE
L8 satellite images

### DIFF
--- a/rdwatch/core/tasks/__init__.py
+++ b/rdwatch/core/tasks/__init__.py
@@ -55,7 +55,7 @@ from rdwatch.core.utils.images import (
     ignore_pillow_filesize_limits,
     scale_bbox,
 )
-from rdwatch.core.utils.raster_tile import get_raster_bbox
+from rdwatch.core.utils.raster_tile import get_raster_bbox_from_reader
 from rdwatch.core.utils.worldview_nitf.raster_tile import get_worldview_nitf_bbox
 from rdwatch.core.utils.worldview_processed.raster_tile import (
     get_worldview_processed_visual_bbox,
@@ -394,7 +394,8 @@ def get_siteobservations_images(
             elif baseConstellation == 'WV' and worldview_source == 'nitf':
                 bytes = get_worldview_nitf_bbox(capture, max_bbox, 'PNG', scale)
             else:
-                bytes = get_raster_bbox(capture.uri, max_bbox, 'PNG', scale)
+                with capture.open_reader() as reader:
+                    bytes = get_raster_bbox_from_reader(reader, max_bbox, 'PNG', scale)
             if bytes is None:
                 count += 1
                 logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
@@ -424,7 +425,7 @@ def get_siteobservations_images(
                 existing.image.delete()
                 existing.cloudcover = cloudcover
                 existing.image = image
-                existing.aws_location = capture.uri
+                existing.aws_location = getattr(capture, 'uri', '')
                 existing.image_bbox = Polygon.from_bbox(max_bbox)
                 existing.image_dimensions = [imageObj.width, imageObj.height]
                 existing.save()
@@ -432,7 +433,7 @@ def get_siteobservations_images(
                 SiteImage.objects.create(
                     site=baseSiteEval,
                     timestamp=capture_timestamp,
-                    aws_location=capture.uri,
+                    aws_location=getattr(capture, 'uri', ''),
                     image=image,
                     cloudcover=cloudcover,
                     percent_black=percent_black,

--- a/rdwatch/core/utils/capture.py
+++ b/rdwatch/core/utils/capture.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Generator
-from contextlib import contextmanager, ExitStack
-from dataclasses import dataclass
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass, field
 
-from pystac.item import Item
 import rasterio
+from pystac.item import Item
 from rio_tiler.io.base import BaseReader, MultiBaseReader
 from rio_tiler.io.rasterio import Reader
 from rio_tiler.io.stac import STACReader
@@ -24,7 +24,9 @@ class URICapture(AbstractCapture):
     def open_reader(self) -> Generator[Reader, None, None]:
         uri = self.uri
         with ExitStack() as cxt_stack:
-            cxt_stack.enter_context(rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'))
+            cxt_stack.enter_context(
+                rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR')
+            )
 
             if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
                 cxt_stack.enter_context(rasterio.Env(AWS_NO_SIGN_REQUEST='YES'))
@@ -38,15 +40,19 @@ class URICapture(AbstractCapture):
 class STACCapture(AbstractCapture):
     stac_item: Item
     stac_assets: set[str]
+    s3_requester_pays: bool = field(kw_only=True, default=False)
 
     @contextmanager
     def open_reader(self) -> Generator[STACReader, None, None]:
-        with STACReader(None, item=self.stac_item, include_assets=self.stac_assets) as reader:
+        with ExitStack() as cxt_stack:
+            reader = cxt_stack.enter_context(
+                STACReader(None, item=self.stac_item, include_assets=self.stac_assets)
+            )
+            if self.s3_requester_pays:
+                cxt_stack.enter_context(rasterio.Env(AWS_REQUEST_PAYER='requester'))
             yield reader
 
     @property
     def uris(self):
         """Get URIs for each asset in included in the STACReader."""
-        return [
-            self.stac_item.assets[name].href for name in self.stac_assets
-        ]
+        return [self.stac_item.assets[name].href for name in self.stac_assets]

--- a/rdwatch/core/utils/capture.py
+++ b/rdwatch/core/utils/capture.py
@@ -1,0 +1,52 @@
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from contextlib import contextmanager, ExitStack
+from dataclasses import dataclass
+
+from pystac.item import Item
+import rasterio
+from rio_tiler.io.base import BaseReader, MultiBaseReader
+from rio_tiler.io.rasterio import Reader
+from rio_tiler.io.stac import STACReader
+
+
+class AbstractCapture(ABC):
+    @abstractmethod
+    def open_reader(self) -> Generator[BaseReader | MultiBaseReader, None, None]:
+        ...
+
+
+@dataclass
+class URICapture(AbstractCapture):
+    uri: str
+
+    @contextmanager
+    def open_reader(self) -> Generator[Reader, None, None]:
+        uri = self.uri
+        with ExitStack() as cxt_stack:
+            cxt_stack.enter_context(rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'))
+
+            if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
+                cxt_stack.enter_context(rasterio.Env(AWS_NO_SIGN_REQUEST='YES'))
+                uri = 's3://sentinel-cogs/' + uri[49:]
+
+            cog = cxt_stack.enter_context(Reader(input=uri))
+            yield cog
+
+
+@dataclass
+class STACCapture(AbstractCapture):
+    stac_item: Item
+    stac_assets: set[str]
+
+    @contextmanager
+    def open_reader(self) -> Generator[STACReader, None, None]:
+        with STACReader(None, item=self.stac_item, include_assets=self.stac_assets) as reader:
+            yield reader
+
+    @property
+    def uris(self):
+        """Get URIs for each asset in included in the STACReader."""
+        return [
+            self.stac_item.assets[name].href for name in self.stac_assets
+        ]

--- a/rdwatch/core/utils/images.py
+++ b/rdwatch/core/utils/images.py
@@ -8,7 +8,8 @@ from urllib.error import URLError
 
 from PIL import Image
 
-from rdwatch.core.utils.raster_tile import get_raster_bbox
+from rdwatch.core.utils.capture import AbstractCapture
+from rdwatch.core.utils.raster_tile import get_raster_bbox_from_reader
 from rdwatch.core.utils.satellite_bands import get_bands
 from rdwatch.core.utils.worldview_nitf.raster_tile import get_worldview_nitf_bbox
 from rdwatch.core.utils.worldview_nitf.satellite_captures import (
@@ -91,7 +92,7 @@ def get_range_captures(
     constellation: str,
     timebuffer: timedelta,
     worldView: Literal['cog', 'nitf'] | None,
-):
+) -> list[AbstractCapture]:
     if constellation == 'WV' and worldView == 'cog':
         captures = get_worldview_captures(timestamp, bbox, timebuffer)
     elif constellation == 'WV' and worldView == 'nitf':
@@ -138,7 +139,8 @@ def fetch_boundbox_image(
     elif worldView == 'nitf' and constellation == 'wv':
         bytes = get_worldview_nitf_bbox(closest_capture, bbox, 'PNG', scale)
     else:
-        bytes = get_raster_bbox(closest_capture.uri, bbox, 'PNG', scale)
+        with closest_capture.open_reader() as reader:
+            bytes = get_raster_bbox_from_reader(reader, bbox, 'PNG', scale)
     return {
         'bytes': bytes,
         'cloudcover': closest_capture.cloudcover,

--- a/rdwatch/core/utils/raster_tile.py
+++ b/rdwatch/core/utils/raster_tile.py
@@ -1,77 +1,120 @@
 import logging
+from contextlib import ExitStack
 from typing import Literal
 
 import rasterio  # type: ignore
+from pystac import Asset
 from rio_tiler.io.rasterio import Reader
+from rio_tiler.io.stac import STACReader
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_RESCALE_RANGE = (1, 10000)
+
+
+def get_asset_num_bands(asset: Asset) -> int:
+    return len(asset.extra_fields.get('eo:bands', []))
+
+
+def get_read_kwargs_for_reader(reader: Reader | STACReader):
+    """Generates the corresponding part()/tile() kwargs depending on the given reader.
+
+    For STACReader:
+    - will read out all assets specified in STACReader.include_assets
+
+    For all types of readers:
+    - will read all bands for all assets
+    """
+    if isinstance(reader, STACReader):
+        assets = reader.include_assets
+        asset_indexes = {
+            asset_name: list(
+                range(1, get_asset_num_bands(reader.item.assets[asset_name]) + 1)
+            )
+            for asset_name in assets
+        }
+        return {
+            'assets': assets,
+            'asset_indexes': asset_indexes,
+        }
+    return {'indexes': list(range(1, reader.dataset.count + 1))}
+
+
+def get_rescale_range_from_reader(reader: Reader | STACReader) -> tuple[float, float]:
+    """Get the rescale range from the reader statistics."""
+    if isinstance(reader, STACReader):
+        all_stats = reader.merged_statistics()
+    else:
+        all_stats = reader.statistics()
+
+    if len(all_stats) == 0:
+        return DEFAULT_RESCALE_RANGE
+    # TODO This only gets the "first" band of the "first" asset. Acceptable?
+    band_stats = next(iter(all_stats.values()))
+    return band_stats['percentile_2'], band_stats['percentile_98']
+
+
+def get_raster_tile_from_reader(
+    reader: Reader | STACReader,
+    z: int,
+    x: int,
+    y: int,
+    scale: Literal['default', 'bits'] | list[int] = 'default',
+) -> bytes:
+    img = reader.tile(x, y, z, tilesize=512)
+    if scale == 'default':
+        img.rescale(in_range=((0, 10000),))
+    elif scale == 'bits':
+        low, high = get_rescale_range_from_reader(reader)
+        img.rescale(in_range=((low, high),))
+    return img.render(img_format='WEBP')
 
 
 def get_raster_tile(uri: str, z: int, x: int, y: int) -> bytes:
     # logger.warning(f'SITE URI: {uri}')
-    with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):
-        if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
-            with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):
-                s3_uri = 's3://sentinel-cogs/' + uri[49:]
-                with Reader(input=s3_uri) as cog:
-                    img = cog.tile(x, y, z, tilesize=512)
-                    # TODO Rescaling is off for element84 img.rescale(in_range=((0, 10000),))
-                    # Using bit scaling instead
-                    stats = cog.statistics()
-                    low = 0
-                    high = 10000
-                    if 'b1' in stats.keys():
-                        stats_json = stats['b1']
-                        low = stats_json['percentile_2']
-                        high = stats_json['percentile_98']
-                    img.rescale(in_range=((low, high),))
+    with ExitStack() as cxt_stack:
+        cxt_stack.enter_context(rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'))
 
-                    return img.render(img_format='WEBP')
-        with Reader(input=uri) as cog:
-            img = cog.tile(x, y, z, tilesize=512)
-            img.rescale(in_range=((0, 10000),))
-            return img.render(img_format='WEBP')
+        scale_by = 'default'
+        if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
+            cxt_stack.enter_context(rasterio.Env(AWS_NO_SIGN_REQUEST='YES'))
+            uri = 's3://sentinel-cogs/' + uri[49:]
+            # rescale S2 data wit hbits
+            scale_by = 'bits'
+
+        cog = cxt_stack.enter_context(Reader(input=uri))
+        return get_raster_tile_from_reader(cog, z, x, y, scale=scale_by)
+
+
+def get_raster_bbox_from_reader(
+    reader: Reader | STACReader,
+    bbox: tuple[float, float, float, float],
+    format_='PNG',
+    scale: Literal['default', 'bits'] | list[int] = 'bits',
+) -> bytes:
+    img = reader.part(bbox, **get_read_kwargs_for_reader(reader))
+    if scale == 'default':
+        img.rescale(in_range=((0, 10000),))
+    elif scale == 'bits':
+        low, high = get_rescale_range_from_reader(reader)
+        img.rescale(in_range=((low, high),))
+    elif isinstance(scale, list) and len(scale) == 2:
+        img.rescale(in_range=((scale[0], scale[1]),))
+    return img.render(img_format=format_)
 
 
 def get_raster_bbox(
     uri: str,
     bbox: tuple[float, float, float, float],
-    format='PNG',
+    format_='PNG',
     scale: Literal['default', 'bits'] | list[int] = 'bits',
 ) -> bytes:
-    with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):
+    with ExitStack() as cxt_stack:
+        cxt_stack.enter_context(rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'))
+
         if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
-            with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):
-                s3_uri = 's3://sentinel-cogs/' + uri[49:]
-                with Reader(input=s3_uri) as cog:
-                    img = cog.part(bbox)
-                    if scale == 'default':
-                        img.rescale(in_range=((0, 10000),))
-                    elif scale == 'bits':
-                        stats = cog.statistics()
-                        low = 0
-                        high = 10000
-                        if 'b1' in stats.keys():
-                            stats_json = stats['b1']
-                            low = stats_json['percentile_2']
-                            high = stats_json['percentile_98']
-                        img.rescale(in_range=((low, high),))
-                    elif isinstance(scale, list) and len(scale) == 2:
-                        img.rescale(in_range=((scale[0], scale[1]),))
-                    return img.render(img_format=format)
-        with Reader(input=uri) as cog:
-            img = cog.part(bbox)
-            if scale == 'default':
-                img.rescale(in_range=((0, 10000),))
-            elif scale == 'bits':
-                stats = cog.statistics()
-                low = 0
-                high = 10000
-                if 'b1' in stats.keys():
-                    stats_json = stats['b1']
-                    low = stats_json['percentile_2']
-                    high = stats_json['percentile_98']
-                img.rescale(in_range=((low, high),))
-            elif isinstance(scale, list) and len(scale) == 2:
-                img.rescale(in_range=((scale[0], scale[1]),))
-            return img.render(img_format=format)
+            cxt_stack.enter_context(rasterio.Env(AWS_NO_SIGN_REQUEST='YES'))
+            uri = 's3://sentinel-cogs/' + uri[49:]
+
+        cog = cxt_stack.enter_context(Reader(input=uri))
+        return get_raster_bbox_from_reader(cog, bbox, format_=format_, scale=scale)

--- a/rdwatch/core/utils/satellite_bands.py
+++ b/rdwatch/core/utils/satellite_bands.py
@@ -7,7 +7,12 @@ from pystac import Item
 
 from rdwatch.core.models.lookups import CommonBand, ProcessingLevel
 from rdwatch.core.utils.capture import STACCapture
-from rdwatch.core.utils.stac_search import COLLECTIONS, SOURCES, stac_search
+from rdwatch.core.utils.stac_search import (
+    COLLECTIONS,
+    S3_REQUESTER_PAYS_COLLECTIONS,
+    SOURCES,
+    stac_search,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +46,8 @@ def get_bands(
 ) -> Iterator[Band]:
     if constellation not in SOURCES:
         raise ValueError(f'Unsupported constellation {constellation}')
+
+    s3_requester_pays = constellation in S3_REQUESTER_PAYS_COLLECTIONS
 
     results = stac_search(
         constellation,
@@ -97,6 +104,7 @@ def get_bands(
                 collection=item.collection_id,
                 stac_item=item,
                 stac_assets={name},
+                s3_requester_pays=s3_requester_pays,
             )
 
         # Combine red/green/blue together to make our own visual band
@@ -117,4 +125,5 @@ def get_bands(
                 collection=item.collection_id,
                 stac_item=item,
                 stac_assets=set(RED_GREEN_BLUE),
+                s3_requester_pays=s3_requester_pays,
             )

--- a/rdwatch/core/utils/satellite_bands.py
+++ b/rdwatch/core/utils/satellite_bands.py
@@ -103,7 +103,7 @@ def get_bands(
                 cloudcover=cloudcover,
                 collection=item.collection_id,
                 stac_item=item,
-                stac_assets={name},
+                stac_assets=[name],
                 s3_requester_pays=s3_requester_pays,
             )
 
@@ -124,6 +124,6 @@ def get_bands(
                 cloudcover=cloudcover,
                 collection=item.collection_id,
                 stac_item=item,
-                stac_assets=set(RED_GREEN_BLUE),
+                stac_assets=RED_GREEN_BLUE,
                 s3_requester_pays=s3_requester_pays,
             )

--- a/rdwatch/core/utils/stac_search.py
+++ b/rdwatch/core/utils/stac_search.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypedDict
 
 from pystac_client import Client
 
@@ -62,8 +62,8 @@ def stac_search(
     timestamp: datetime,
     bbox: tuple[float, float, float, float],
     timebuffer: timedelta | None = None,
-) -> Results:
     stac_catalog = Client.open(STAC_URL)
+) -> ItemSearch:
 
     if timebuffer is not None:
         min_time = timestamp - timebuffer
@@ -80,7 +80,4 @@ def stac_search(
         limit=100,
     )
 
-    # TODO: return `results` directly instead of converting to a dict.
-    # Before that can happen, the callers need to be updated to handle
-    # an `ItemSearch` object.
-    return cast(Results, results.item_collection_as_dict())
+    return results

--- a/rdwatch/core/utils/stac_search.py
+++ b/rdwatch/core/utils/stac_search.py
@@ -55,9 +55,8 @@ COLLECTIONS_BY_SOURCE: dict[str, list[str]] = {
     'PL': [],
 }
 
-SOURCES: list[str] = COLLECTIONS_BY_SOURCE.keys()
-
-COLLECTIONS: list[str] = list(chain(COLLECTIONS_BY_SOURCE.values()))
+SOURCES: list[str] = list(COLLECTIONS_BY_SOURCE.keys())
+COLLECTIONS: list[str] = list(chain(*COLLECTIONS_BY_SOURCE.values()))
 
 STAC_URLS: dict[str, str] = {
     'L8': 'https://landsatlook.usgs.gov/stac-server/',

--- a/rdwatch/core/utils/stac_search.py
+++ b/rdwatch/core/utils/stac_search.py
@@ -57,6 +57,7 @@ COLLECTIONS_BY_SOURCE: dict[str, list[str]] = {
 
 SOURCES: list[str] = list(COLLECTIONS_BY_SOURCE.keys())
 COLLECTIONS: list[str] = list(chain(*COLLECTIONS_BY_SOURCE.values()))
+S3_REQUESTER_PAYS_COLLECTIONS = ('L8',)
 
 STAC_URLS: dict[str, str] = {
     'L8': 'https://landsatlook.usgs.gov/stac-server/',

--- a/rdwatch/core/utils/worldview_nitf/satellite_captures.py
+++ b/rdwatch/core/utils/worldview_nitf/satellite_captures.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
+from rdwatch.core.utils.capture import URICapture
 from rdwatch.core.utils.worldview_nitf.stac_search import worldview_search
 
 
 @dataclass()
-class WorldViewNITFCapture:
+class WorldViewNITFCapture(URICapture):
     timestamp: datetime
     bbox: tuple[float, float, float, float]
-    uri: str
     cloudcover: int | None
     collection: str
     bits_per_pixel: int

--- a/rdwatch/core/utils/worldview_processed/satellite_captures.py
+++ b/rdwatch/core/utils/worldview_processed/satellite_captures.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
+from rdwatch.core.utils.capture import URICapture
 from rdwatch.core.utils.worldview_processed.stac_search import worldview_search
 
 
 @dataclass()
-class WorldViewProcessedCapture:
+class WorldViewProcessedCapture(URICapture):
     timestamp: datetime
     bbox: tuple[float, float, float, float]
-    uri: str
     panuri: str | None
     cloudcover: int | None
     collection: str

--- a/rdwatch/core/views/satellite_image.py
+++ b/rdwatch/core/views/satellite_image.py
@@ -102,9 +102,11 @@ def get_satelliteimage_raster(
 
     if precise_timestamp == timestamp:
         if request_type == 'bbox':
-            tile = get_raster_bbox_from_reader(bands[0].stac_reader, bbox, format)
+            with bands[0].open_reader() as reader:
+                tile = get_raster_bbox_from_reader(reader, bbox, format)
         else:
-            tile = get_raster_tile_from_reader(bands[0].stac_reader, z, x, y)
+            with bands[0].open_reader() as reader:
+                tile = get_raster_tile_from_reader(reader, z, x, y)
         return HttpResponse(
             tile,
             content_type=f'image/{format}',

--- a/rdwatch/scoring/tasks/__init__.py
+++ b/rdwatch/scoring/tasks/__init__.py
@@ -29,7 +29,7 @@ from rdwatch.core.utils.images import (
     get_range_captures,
     scale_bbox,
 )
-from rdwatch.core.utils.raster_tile import get_raster_bbox
+from rdwatch.core.utils.raster_tile import get_raster_bbox_from_reader
 from rdwatch.scoring.models import (
     AnnotationProposalObservation,
     AnnotationProposalSet,
@@ -338,7 +338,8 @@ def get_siteobservations_images(
                     capture, max_bbox, 'PNG', scale
                 )
             else:
-                bytes = get_raster_bbox(capture.uri, max_bbox, 'PNG', scale)
+                with capture.open_reader() as reader:
+                    bytes = get_raster_bbox_from_reader(reader, max_bbox, 'PNG', scale)
             if bytes is None:
                 count += 1
                 logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
@@ -367,7 +368,7 @@ def get_siteobservations_images(
                 existing.image.delete()
                 existing.cloudcover = cloudcover
                 existing.image = image
-                existing.aws_location = capture.uri
+                existing.aws_location = getattr(capture, 'uri', '')
                 existing.image_bbox = Polygon.from_bbox(max_bbox)
                 existing.image_dimensions = [imageObj.width, imageObj.height]
                 existing.save()
@@ -375,7 +376,7 @@ def get_siteobservations_images(
                 SiteImage.objects.create(
                     site=base_site_eval.pk,
                     timestamp=capture_timestamp,
-                    aws_location=capture.uri,
+                    aws_location=getattr(capture, 'uri', ''),
                     image=image,
                     cloudcover=cloudcover,
                     percent_black=percent_black,

--- a/vue/src/components/ImagesDownloadDialog.vue
+++ b/vue/src/components/ImagesDownloadDialog.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     (e: "cancel"): void;
 }>();
 
-const constellationChoices = ref(['S2', 'WV',]) // TODO: Image Download HotFix ref(['S2', 'WV', 'L8', 'PL'])
+const constellationChoices = ref(['S2', 'WV', "L8"]) // TODO: Image Download HotFix ref(['S2', 'WV', 'L8', 'PL'])
 const selectedConstellation: Ref<Constellation[]> = ref(['S2']);
 const worldviewSourceChoices = computed<string[] | null>(() => selectedConstellation.value.includes('WV') ? ['nitf'] : null); // TODO Image Download Hotfix: add back in cog
 const selectedWorldviewSource = ref<'nitf'>('nitf'); // // TODO: Image Download HotFix ref<'cog' | 'nitf'>('cog');


### PR DESCRIPTION
- `stac_search.py` and `satellite_bands.py`: Switch to using the pystac_client.ItemSearch interface directly
- `satellite_bands.py`: Modified `get_bands()` and the `Bands` type to be a STACCapture
- `raster_tile.py`: refactored get_raster_tile/bbox to accept a reader
- `raster_tile.py`: Removed "b1" key in favor of picking the first band
  - This is a point of discussion for multichannel images!
- `capture.py`: abstracted captures to have an `open_reader()` method for generic rio_tiler reader usage