### PR TITLE
Change WARN logs to INFO where needed

### DIFF
--- a/rdwatch/allauth.py
+++ b/rdwatch/allauth.py
@@ -32,9 +32,7 @@ class RDWatchSocialAccountAdapter(DefaultSocialAccountAdapter):
         if sociallogin.user.is_active:
             return
 
-        logger.warning(
-            f'User {sociallogin.user} is not active, checking if eligible...'
-        )
+        logger.info(f'User {sociallogin.user} is not active, checking if eligible...')
 
         gitlab_url: str = settings.SOCIALACCOUNT_PROVIDERS['gitlab']['APPS'][0][
             'settings'
@@ -46,7 +44,7 @@ class RDWatchSocialAccountAdapter(DefaultSocialAccountAdapter):
         groups = resp.json().get('groups', [])
 
         if any(group in settings.ALLOWED_GITLAB_GROUPS for group in groups):
-            logger.warning(
+            logger.info(
                 f'User {sociallogin.user} is a member of an allowed GitLab group'
             )
             sociallogin.user.is_active = True
@@ -57,6 +55,6 @@ class RDWatchSocialAccountAdapter(DefaultSocialAccountAdapter):
             if sociallogin.is_existing:
                 sociallogin.user.save()
         else:
-            logger.warning(
+            logger.info(
                 f'User {sociallogin.user} is not a member of any allowed GitLab group'
             )

--- a/rdwatch/core/tasks/__init__.py
+++ b/rdwatch/core/tasks/__init__.py
@@ -81,7 +81,7 @@ def is_inside_range(
     for timestamp in timestamps:
         time_difference = check_timestamp - timestamp
         if abs(time_difference.days) <= days_range:
-            logger.warning(
+            logger.info(
                 f'Skipping Timestamp because difference is: {time_difference.days}'
             )
             return True
@@ -125,7 +125,7 @@ def get_siteobservation_images_task(
         fetching_task.celery_id = ''
         fetching_task.save()
     except Exception as e:
-        logger.warning(f'EXCEPTION: {e}')
+        logger.info(f'EXCEPTION: {e}')
         fetching_task = SatelliteFetching.objects.get(site_id=site_eval_id)
         fetching_task.error = f'Error: {e}'
         fetching_task.status = SatelliteFetching.Status.ERROR
@@ -205,7 +205,7 @@ def get_siteobservations_images(
     bbox = scale_bbox(bbox, bboxScale)
     # get the updated BBOX if it's bigger
     max_bbox = get_max_bbox(bbox, max_bbox)
-    logger.warning(f'UPGRADED BBOX: {bbox}')
+    logger.info(f'UPGRADED BBOX: {bbox}')
 
     # First we gather all images that match observations
     count = 0
@@ -228,7 +228,7 @@ def get_siteobservations_images(
         timestamp = observation.timestamp
         constellation = observation.constellation
         # We need to grab the image for this timerange and type
-        logger.warning(timestamp)
+        logger.info(timestamp)
         if str(constellation) == baseConstellation and timestamp is not None:
             count += 1
             baseSiteEval = observation.siteeval
@@ -246,7 +246,7 @@ def get_siteobservations_images(
                     found_timestamps.keys(), observation.timestamp, dayRange
                 )
             ):
-                logger.warning(f'Skipping Timestamp: {timestamp}')
+                logger.info(f'Skipping Timestamp: {timestamp}')
                 continue
             if found.exists() and not force:
                 found_timestamps[observation.timestamp] = True
@@ -259,20 +259,20 @@ def get_siteobservations_images(
                 scale,
             )
             if results is None:
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             bytes = results['bytes']
             percent_black = get_percent_black_pixels(bytes)
             cloudcover = results['cloudcover']
             found_timestamp = results['timestamp']
             if bytes is None:
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             if dayRange != -1 and percent_black < no_data_limit:
                 found_timestamps[found_timestamp] = True
             elif dayRange == -1:
                 found_timestamps[found_timestamp] = True
-            # logger.warning(f'Retrieved Image with timestamp: {timestamp}')
+            # logger.info(f'Retrieved Image with timestamp: {timestamp}')
             output = f'tile_image_{observation.id}.png'
             image = File(io.BytesIO(bytes), name=output)
             with ignore_pillow_filesize_limits():
@@ -322,7 +322,7 @@ def get_siteobservations_images(
         matchConstellation = Constellation.objects.filter(
             slug=baseConstellation
         ).first()
-        logger.warning(
+        logger.info(
             f'Utilizing Constellation: {matchConstellation} - {matchConstellation.slug}'
         )
 
@@ -349,7 +349,7 @@ def get_siteobservations_images(
         baseSiteEval = SiteEvaluation.objects.filter(pk=site_eval_id).first()
     count = 1
     num_of_captures = len(captures)
-    logger.warning(f'Found {num_of_captures} captures')
+    logger.info(f'Found {num_of_captures} captures')
     if num_of_captures == 0:
         self.update_state(
             state='PROGRESS',
@@ -362,7 +362,7 @@ def get_siteobservations_images(
             },
         )
 
-    logger.warning(f'Found {num_of_captures} captures')
+    logger.info(f'Found {num_of_captures} captures')
     # Now we go through the list and add in a timestamp if it doesn't exist
     for capture in captures:
         self.update_state(
@@ -397,7 +397,7 @@ def get_siteobservations_images(
                 bytes = get_raster_bbox(capture.uri, max_bbox, 'PNG', scale)
             if bytes is None:
                 count += 1
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             percent_black = get_percent_black_pixels(bytes)
             cloudcover = capture.cloudcover
@@ -678,7 +678,7 @@ def generate_site_images_for_evaluation_run(
 def generate_image_embedding(id: int):
     site_image = SiteImage.objects.get(pk=id)
     try:
-        logger.warning('Loading checkpoint Model')
+        logger.info('Loading checkpoint Model')
         checkpoint = settings.SAM_CHECKPOINT_MODEL
         model_type = 'vit_h'
         sam = sam_model_registry[model_type](checkpoint=checkpoint)
@@ -689,14 +689,14 @@ def generate_image_embedding(id: int):
             site_image.image.open(mode='rb')
             temp_image_file.write(site_image.image.read())
 
-            logger.warning('Reading local image file')
+            logger.info('Reading local image file')
 
             image = cv2.imread(temp_image_file.name)
-            logger.warning('Setting the predictor for the file')
+            logger.info('Setting the predictor for the file')
             predictor.set_image(image)
-            logger.warning('Creating the embedding')
+            logger.info('Creating the embedding')
             image_embedding = predictor.get_image_embedding().cpu().numpy()
-            logger.warning('Saving the npy')
+            logger.info('Saving the npy')
 
             # Assuming you want to save the numpy array to the image_embedding
             with tempfile.NamedTemporaryFile(
@@ -727,7 +727,7 @@ def generate_image_embedding(id: int):
 @signals.worker_ready.connect
 def download_sam_model_if_not_exists(**kwargs):
     file_path = settings.SAM_CHECKPOINT_MODEL
-    logger.warning('Trying to download SAM')
+    logger.info('Trying to download SAM')
 
     # Check if the file exists
     if not os.path.exists(file_path):

--- a/rdwatch/core/tasks/animation_export.py
+++ b/rdwatch/core/tasks/animation_export.py
@@ -171,9 +171,9 @@ def paste_image_with_bbox(
     rescale_y_factor = output_pixel_per_unit_x / pixel_per_unit_x
     rescale_x = int(rescale_x_factor * source_width_px)
     rescale_y = int(rescale_y_factor * source_height_px)
-    # logger.warning(f'\tRescaling Source: {source_width_px} {source_height_px}')
-    # logger.warning(f'\tRescale Size: {rescale_x} {rescale_y}')
-    # logger.warning(f'\tRescaling Factor: {rescale_x_factor} {rescale_y_factor}')
+    # logger.info(f'\tRescaling Source: {source_width_px} {source_height_px}')
+    # logger.info(f'\tRescale Size: {rescale_x} {rescale_y}')
+    # logger.info(f'\tRescaling Factor: {rescale_x_factor} {rescale_y_factor}')
     rescaled_source_image = source_image.resize((rescale_x, rescale_y))
 
     # determine what section of the new image to grab based on the output_bbox_size
@@ -184,7 +184,7 @@ def paste_image_with_bbox(
         (output_bbox[2] - bbox[0]) * output_pixel_per_unit_x,
         (output_bbox[3] - bbox[1]) * output_pixel_per_unit_y,
     )
-    # logger.warning(f'\tCrop: {crop}')
+    # logger.info(f'\tCrop: {crop}')
     cropped_img = rescaled_source_image.crop(
         (crop[0], crop[1], crop[2], crop[3])
     )  # left, top, right, bottom
@@ -357,7 +357,7 @@ def create_animation(
     images = SiteImage.objects.filter(query).order_by('timestamp')
 
     if len(images) == 0:
-        logger.warning('No Images found returning')
+        logger.info('No Images found returning')
         return False, False
     total_images = len(images)
     max_image_record = None
@@ -406,8 +406,8 @@ def create_animation(
         y_pixel_per_unit = max_height_px / (
             max_image_record_bbox[3] - max_image_record_bbox[1]
         )
-        logger.warning('PixelPerUnit : {x_pixel_perunit}, {y_pixel_per_unit}')
-        logger.warning(
+        logger.info('PixelPerUnit : {x_pixel_perunit}, {y_pixel_per_unit}')
+        logger.info(
             f'Rescaled: {rescaled_image_bbox_width} {rescaled_image_bbox_height}'
         )
         # Update the rescaled max dimensions
@@ -711,7 +711,7 @@ def create_site_animation_export(
         site_export.save()
         file_path, name = create_animation(self, site_evaluation_id, settings)
         if file_path is False and name is False:
-            logger.warning('No Images were found')
+            logger.info('No Images were found')
             site_export.delete()
             return
         site_export.name = name

--- a/rdwatch/core/utils/raster_tile.py
+++ b/rdwatch/core/utils/raster_tile.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_raster_tile(uri: str, z: int, x: int, y: int) -> bytes:
-    # logger.warning(f'SITE URI: {uri}')
+    # logger.info(f'SITE URI: {uri}')
     with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):
         if uri.startswith('https://sentinel-cogs.s3.us-west-2.amazonaws.com'):
             with rasterio.Env(AWS_NO_SIGN_REQUEST='YES'):

--- a/rdwatch/core/utils/worldview_nitf/raster_tile.py
+++ b/rdwatch/core/utils/worldview_nitf/raster_tile.py
@@ -26,10 +26,10 @@ def _download_nitf_image(uri: str) -> Generator[str, None, None]:
 
     with NamedTemporaryFile(suffix='.nitf') as f:
         startTime = time.time()
-        logger.warning(f'Image URI: {uri}')
-        logger.warning(f'Base Info Time: {time.time() - startTime}')
+        logger.info(f'Image URI: {uri}')
+        logger.info(f'Base Info Time: {time.time() - startTime}')
         s3.download_fileobj(s3_bucket, s3_path, f)
-        logger.warning(f'RGB Download Time: {time.time() - startTime}')
+        logger.info(f'RGB Download Time: {time.time() - startTime}')
         yield f.name
 
 

--- a/rdwatch/core/utils/worldview_processed/raster_tile.py
+++ b/rdwatch/core/utils/worldview_processed/raster_tile.py
@@ -31,7 +31,7 @@ def get_worldview_processed_visual_tile(
             with Reader(input=capture.uri) as img:
                 rgb = img.tile(x, y, z, tilesize=512)
         if capture.panuri:
-            logger.warning(f'PAN URI: {capture.panuri}')
+            logger.info(f'PAN URI: {capture.panuri}')
             with Reader(input=capture.panuri) as img:
                 pan = img.tile(
                     x,
@@ -72,25 +72,25 @@ def get_worldview_processed_visual_bbox(
     ):
         startTime = time.time()
         if not capture.panuri:
-            logger.warning(f'Image URI: {capture.uri}')
+            logger.info(f'Image URI: {capture.uri}')
             with Reader(input=capture.uri) as img:
-                logger.warning(f'Base Info Time: {time.time() - startTime}')
+                logger.info(f'Base Info Time: {time.time() - startTime}')
                 rgb = img.part(bbox)
-                logger.warning(f'RGB Download Time: {time.time() - startTime}')
+                logger.info(f'RGB Download Time: {time.time() - startTime}')
 
         if capture.panuri:
-            logger.warning(f'Pan URI: {capture.panuri}')
+            logger.info(f'Pan URI: {capture.panuri}')
             with Reader(input=capture.panuri) as img:
                 pan = img.part(bbox)
-                logger.warning(f'Pan Download Time: {time.time() - startTime}')
+                logger.info(f'Pan Download Time: {time.time() - startTime}')
                 with Reader(input=capture.uri) as rgbimg:
                     rgb = rgbimg.part(bbox, width=pan.width, height=pan.height)
-                    logger.warning(f'RGB Download Time: {time.time() - startTime}')
-                    logger.warning(f'PanSharpening: {capture.panuri}')
+                    logger.info(f'RGB Download Time: {time.time() - startTime}')
+                    logger.info(f'PanSharpening: {capture.panuri}')
                     rgb = rgb.from_array(
                         pansharpening_brovey(rgb.data, pan.data, 0.2, 'uint16')
                     )
-                    logger.warning(f'Pan Sharpening Time: {time.time() - startTime}')
+                    logger.info(f'Pan Sharpening Time: {time.time() - startTime}')
 
         if scale == 'default':
             rgb.rescale(in_range=((0, 10000),))

--- a/rdwatch/scoring/tasks/__init__.py
+++ b/rdwatch/scoring/tasks/__init__.py
@@ -137,10 +137,10 @@ def get_siteobservations_images(
     # if width | height is too small we pad S2/L8/PL regions for more context
     bbox_width = (bbox[2] - bbox[0]) * ToMeters
     bbox_height = (bbox[3] - bbox[1]) * ToMeters
-    logger.warning('BBOX')
-    logger.warning(bbox)
-    logger.warning(bbox_width)
-    logger.warning(bbox_height)
+    logger.info('BBOX')
+    logger.info(bbox)
+    logger.info(bbox_width)
+    logger.info(bbox_height)
     if baseConstellation != 'WV' and (
         bbox_width < overrideImageSize or bbox_height < overrideImageSize
     ):
@@ -157,7 +157,7 @@ def get_siteobservations_images(
     bbox = scale_bbox(bbox, bboxScale)
     # get the updated BBOX if it's bigger
     max_bbox = get_max_bbox(bbox, max_bbox)
-    logger.warning(max_bbox)
+    logger.info(max_bbox)
 
     # First we gather all images that match observations
     count = 0
@@ -192,7 +192,7 @@ def get_siteobservations_images(
             observation.sensor_name if proposal else observation.sensor_name or 'WV'
         )
         # We need to grab the image for this timerange and type
-        logger.warning(timestamp)
+        logger.info(timestamp)
         if str(constellation) == baseConstellation and timestamp is not None:
             count += 1
             base_site_eval = site_eval_id
@@ -207,7 +207,7 @@ def get_siteobservations_images(
                 and dayRange > -1
                 and is_inside_range(found_timestamps.keys(), observation.date, dayRange)
             ):
-                logger.warning(f'Skipping Timestamp: {timestamp}')
+                logger.info(f'Skipping Timestamp: {timestamp}')
                 continue
             if found.exists() and not force:
                 found_timestamps[observation.date] = True
@@ -216,20 +216,20 @@ def get_siteobservations_images(
                 bbox, timestamp, constellation.slug, baseConstellation == 'WV', scale
             )
             if results is None:
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             bytes = results['bytes']
             percent_black = get_percent_black_pixels(bytes)
             cloudcover = results['cloudcover']
             found_timestamp = results['timestamp']
             if bytes is None:
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             if dayRange != -1 and percent_black < no_data_limit:
                 found_timestamps[found_timestamp] = True
             elif dayRange == -1:
                 found_timestamps[found_timestamp] = True
-            # logger.warning(f'Retrieved Image with timestamp: {timestamp}')
+            # logger.info(f'Retrieved Image with timestamp: {timestamp}')
             output = f'tile_image_{observation.pk}.png'
             image = File(io.BytesIO(bytes), name=output)
             imageObj = Image.open(io.BytesIO(bytes))
@@ -275,11 +275,11 @@ def get_siteobservations_images(
 
     # Now we get a list of all the timestamps and captures that fall in this range.
     worldView = baseConstellation == 'WV'
-    logger.warning('MAXBBOX')
-    logger.warning(max_bbox)
-    logger.warning('timestamp')
-    logger.warning(timestamp)
-    logger.warning(timebuffer)
+    logger.info('MAXBBOX')
+    logger.info(max_bbox)
+    logger.info('timestamp')
+    logger.info(timestamp)
+    logger.info(timebuffer)
     captures = get_range_captures(
         max_bbox, timestamp, baseConstellation, timebuffer, worldView
     )
@@ -298,7 +298,7 @@ def get_siteobservations_images(
         base_site_eval = site_db_model.objects.filter(pk=site_eval_id).first()
     count = 1
     num_of_captures = len(captures)
-    logger.warning(f'Found {num_of_captures} captures')
+    logger.info(f'Found {num_of_captures} captures')
     if num_of_captures == 0:
         self.update_state(
             state='PROGRESS',
@@ -341,7 +341,7 @@ def get_siteobservations_images(
                 bytes = get_raster_bbox(capture.uri, max_bbox, 'PNG', scale)
             if bytes is None:
                 count += 1
-                logger.warning(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
+                logger.info(f'COULD NOT FIND ANY IMAGE FOR TIMESTAMP: {timestamp}')
                 continue
             percent_black = get_percent_black_pixels(bytes)
             cloudcover = capture.cloudcover


### PR DESCRIPTION
This is a prerequisite to configuring Sentry, since `WARNING` logs will set off an issue alert there. 

We may want to go back through and figure out if some of these can be removed, or at least downgraded to `DEBUG` logs. But this change will at least allow us to hook up our deployment to Sentry without blowing it up with issues.