### PR TITLE
Configure sentry for Django application

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2728,6 +2728,59 @@ reference = "HEAD"
 resolved_reference = "6fdee8f2727f4506cfbbe553e23b895e27956588"
 
 [[package]]
+name = "sentry-sdk"
+version = "2.14.0"
+description = "Python client for Sentry (https://sentry.io)"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "sentry_sdk-2.14.0-py2.py3-none-any.whl", hash = "sha256:b8bc3dc51d06590df1291b7519b85c75e2ced4f28d9ea655b6d54033503b5bf4"},
+    {file = "sentry_sdk-2.14.0.tar.gz", hash = "sha256:1e0e2eaf6dad918c7d1e0edac868a7bf20017b177f242cefe2a6bcd47955961d"},
+]
+
+[package.dependencies]
+celery = {version = ">=3", optional = true, markers = "extra == \"celery\""}
+certifi = "*"
+django = {version = ">=1.8", optional = true, markers = "extra == \"django\""}
+urllib3 = ">=1.26.11"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+anthropic = ["anthropic (>=0.16)"]
+arq = ["arq (>=0.23)"]
+asyncpg = ["asyncpg (>=0.23)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+celery-redbeat = ["celery-redbeat (>=2)"]
+chalice = ["chalice (>=1.16.0)"]
+clickhouse-driver = ["clickhouse-driver (>=0.2.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+fastapi = ["fastapi (>=0.79.0)"]
+flask = ["blinker (>=1.1)", "flask (>=0.11)", "markupsafe"]
+grpcio = ["grpcio (>=1.21.1)", "protobuf (>=3.8.0)"]
+httpx = ["httpx (>=0.16.0)"]
+huey = ["huey (>=2)"]
+huggingface-hub = ["huggingface-hub (>=0.22)"]
+langchain = ["langchain (>=0.0.210)"]
+litestar = ["litestar (>=2.0.0)"]
+loguru = ["loguru (>=0.5)"]
+openai = ["openai (>=1.0.0)", "tiktoken (>=0.3.0)"]
+opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
+opentelemetry-experimental = ["opentelemetry-distro"]
+pure-eval = ["asttokens", "executing", "pure-eval"]
+pymongo = ["pymongo (>=3.1)"]
+pyspark = ["pyspark (>=2.4.4)"]
+quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+starlette = ["starlette (>=0.19.1)"]
+starlite = ["starlite (>=1.48)"]
+tornado = ["tornado (>=6)"]
+
+[[package]]
 name = "setuptools"
 version = "69.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3052,4 +3105,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11.9,<4"
-content-hash = "f9e7fd65302765473e4fbaff8efafacbfa19e409aea6e8d1de785417b11ece46"
+content-hash = "d1fa960169950a7babfc915b2d33ff785ca071586534f8864fce271b5b4d3c0a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ django-allauth = {extras = ["socialaccount"], version = "^0.63.2"}
 django-login-required-middleware = "^0.9.0"
 django-s3-file-field = {version = "^1.0.1", extras = ["s3"]}
 parver = "^0.5"
+sentry-sdk = {extras = ["celery", "django"], version = "^2.14.0"}
 
 [tool.poetry.group.dev.dependencies]
 django-stubs = "^4.2.7"

--- a/rdwatch/core/apps.py
+++ b/rdwatch/core/apps.py
@@ -1,6 +1,36 @@
+import logging
+
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class RDWatchConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
     name = 'rdwatch.core'
+
+    def ready(self) -> None:
+        if hasattr(settings, 'SENTRY_DSN'):
+            sentry_sdk.init(
+                dsn=settings.SENTRY_DSN,
+                environment=settings.SENTRY_ENVIRONMENT,
+                release=settings.SENTRY_RELEASE,
+                integrations=[
+                    LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+                    DjangoIntegration(),
+                    CeleryIntegration(),
+                ],
+                # Only include rdwatch/ in the default stack trace
+                in_app_include=['rdwatch'],
+                # Send traces for non-exception events too
+                attach_stacktrace=True,
+                # Submit request User info from Django
+                send_default_pii=True,
+                traces_sampler=0.01,
+                profiles_sampler=0.01,
+            )
+        return super().ready()

--- a/rdwatch/settings.py
+++ b/rdwatch/settings.py
@@ -334,3 +334,20 @@ class ProductionConfiguration(BaseConfiguration):
     LOGIN_URL = '/accounts/gitlab/login/'
 
     ACCOUNT_EMAIL_VERIFICATION = 'none'
+
+    SENTRY_DSN = values.Value(
+        None,
+        environ_prefix=_ENVIRON_PREFIX,
+        environ_required=False,
+    )
+    SENTRY_ENVIRONMENT = values.Value(
+        None,
+        environ_prefix=_ENVIRON_PREFIX,
+        environ_required=False,
+    )
+
+    @property
+    def SENTRY_RELEASE(self) -> str:
+        import rdwatch
+
+        return rdwatch.__version__


### PR DESCRIPTION
Installs `sentry_sdk` and adds necessary configuration to Django app. Based in large part on https://github.com/kitware-resonant/django-composed-configuration/blob/master/composed_configuration/_sentry.py and https://github.com/dandi/dandi-archive/blob/master/dandiapi/api/apps.py

Related infrastructure PR: https://smartgitlab.com/kitware/rgd_aws_infrastructure/-/merge_requests/16