### PR TITLE
Satellite Fetching Progress

### DIFF
--- a/rdwatch/core/tasks/animation_export.py
+++ b/rdwatch/core/tasks/animation_export.py
@@ -372,9 +372,9 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                 max_image_record = image_record
 
     if max_width_px < 500 or max_height_px < 500:
-        new_height = (max_height_px / max_width_px) * 500
-        max_width_px = int(500)
-        max_height_px = int(new_height)
+        while max_width_px < 500 or max_height_px < 500:
+            max_width_px *= 2
+            max_height_px *= 2
 
     # using the max_image_bbox we apply the rescale_border
     if rescale:
@@ -420,6 +420,17 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
         # Update the rescaled max dimensions
         rescaled_max_width = int(rescaled_image_bbox_width * x_pixel_per_unit)
         rescaled_max_height = int(rescaled_image_bbox_height * y_pixel_per_unit)
+        upscaled = False
+        base_rescaled_max_width = rescaled_max_width
+        base_rescaled_max_height = rescaled_max_height
+        if rescaled_max_width < 500 or rescaled_max_height < 500:
+            while rescaled_max_width < 500 or rescaled_max_height < 500:
+                rescaled_max_width *= 2
+                rescaled_max_height *= 2
+                x_pixel_per_unit = rescaled_max_width / rescaled_image_bbox_width
+                y_pixel_per_unit = rescaled_max_height / rescaled_image_bbox_height
+            upscaled = True
+
     else:
         x_offset = 0
         y_offset = 0
@@ -485,14 +496,20 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
         if rescale:
             # We draw the max_image_record bbox polygon on the center of the screen
             bbox = max_image_record.image_bbox.extent
-            xScale = max_width_px / (bbox[2] - bbox[0])
-            yScale = max_height_px / (bbox[3] - bbox[1])
             # We need the bbox offset size based on the transform bounds difference
             bbox_transform = transformer_other.transform_bounds(
                 bbox[0], bbox[1], bbox[2], bbox[3]
             )
+
             xScale = max_width_px / (bbox_transform[2] - bbox_transform[0])
             yScale = max_height_px / (bbox_transform[3] - bbox_transform[1])
+            if upscaled:
+                xScale = xScale * (rescaled_max_width / base_rescaled_max_width)
+                yScale = yScale * (rescaled_max_height / base_rescaled_max_height)
+            #     baseXScale = width / (bbox_transform[2] - bbox_transform[0])
+            #     baseYScale = height / (bbox_transform[3] - bbox_transform[1])
+            #     xScale = xScale / baseXScale
+            #     yScale = yScale / baseYScale
 
             x_offset = (bbox_transform[0] - output_bbox_size[0]) * xScale
             y_offset = (bbox_transform[1] - output_bbox_size[1]) * yScale

--- a/rdwatch/core/views/satellite_fetching.py
+++ b/rdwatch/core/views/satellite_fetching.py
@@ -1,7 +1,7 @@
 import logging
 
-from ninja import Query, Router
-from ninja.pagination import LimitOffsetPagination, paginate
+from celery.result import AsyncResult
+from ninja import Query, Router, Schema
 from pydantic import UUID4
 
 from django.http import HttpRequest
@@ -12,8 +12,17 @@ router = Router()
 logger = logging.getLogger(__name__)
 
 
-@router.get('/running/', response=list[UUID4])
-@paginate(LimitOffsetPagination)
+class ResultsSchema(Schema):
+    siteId: UUID4
+    info: dict
+
+
+class RunningSatelliteFetchingSchema(Schema):
+    items: list[ResultsSchema]
+    count: int
+
+
+@router.get('/running/', response=RunningSatelliteFetchingSchema)
 def satellite_fetching_running(
     request: HttpRequest, model_runs: list[UUID4] = Query(None)  # noqa: B008
 ):
@@ -22,5 +31,11 @@ def satellite_fetching_running(
     )
     if model_runs is not None and len(model_runs) > 0:
         running_sites = running_sites.filter(site__configuration__in=model_runs)
-    running_site_ids = running_sites.values_list('site_id', flat=True)
-    return running_site_ids
+    running_site_ids = list(running_sites.values('site_id', 'celery_id'))
+    results = []
+    for item in running_site_ids:
+        task = AsyncResult(item['celery_id'])
+        site_id = item['site_id']
+        results.append({'siteId': site_id, 'info': task.info})
+
+    return {'items': results, 'count': len(running_site_ids)}

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -729,11 +729,11 @@ export class ApiService {
     })
   }
 
-  public static getSatelliteFetchingRunning(modelRunIds?: string[], limit=2000, offset=0): CancelablePromise<{items: string[], count: number}> {
+  public static getSatelliteFetchingRunning(modelRunIds?: string[]): CancelablePromise<{items: {siteId: string, info:Record<string, any>}[], count: number}> {
     return __request(OpenAPI, {
       method: 'GET',
       url: `${this.getApiPrefix()}/satellite-fetching/running/`,
-      query: { model_runs: modelRunIds, limit, offset },
+      query: { model_runs: modelRunIds },
     })
   }
 

--- a/vue/src/components/animation/AnimationDownloadDialog.vue
+++ b/vue/src/components/animation/AnimationDownloadDialog.vue
@@ -24,8 +24,8 @@ const outputFormat: Ref<DownloadAnimationSettings["output_format"]> =
 const formatChoices = ref(["mp4", "gif"]);
 const fps = ref(1);
 const pointRadius = ref(5);
-const constellationChoices = ref(["S2", "WV", "L8", "PL"]);
-const selectedSources: Ref<Constellation[]> = ref(["WV", "S2", "WV", "PL"]);
+const constellationChoices = ref(["S2", "WV", "L8"]);
+const selectedSources: Ref<Constellation[]> = ref(["WV", "S2"]);
 const labelChoices = ref(["geom", "date", "source", "obs", "obs_label"]);
 const labels: Ref<DownloadAnimationSettings["labels"]> = ref([
   "geom",

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -30,7 +30,7 @@ const virtualList: Ref<null | VueElement & { $el: HTMLElement } > = ref(null);
 const satelliteFetchingCheck = async () => {
   const downloadList = (await ApiService.getSatelliteFetchingRunning(props.modelRun ? [props.modelRun] : [])).items;
   // Check if we are still downloading any items
-  const stillDownloading = modifiedList.value.some((item) => downloadList.includes(item.id));
+  const stillDownloading = modifiedList.value.some((item) => !!downloadList.find((listItem) => listItem.siteId === item.id));
   if (!stillDownloading && downloadCheckInterval) {
     clearInterval(downloadCheckInterval);
     downloadCheckInterval = null;
@@ -39,9 +39,9 @@ const satelliteFetchingCheck = async () => {
   // We want to make sure we update the list to indicate which items are downloading in the modifiedList
   const newList: SiteDisplay[] = [];
   modifiedList.value.forEach((item) => {
-    if (item.downloading && !downloadList.includes(item.id)) {
+    if (item.downloading && !downloadList.find((listItem) => listItem.siteId === item.id)) {
       item.downloading = false;
-    } else if (!item.downloading && downloadList.includes(item.id)) {
+    } else if (!item.downloading && !!downloadList.find((listItem) => listItem.siteId === item.id)) {
       item.downloading = true;
     }
     newList.push(item)

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -36,7 +36,7 @@ const virtualList: Ref<null | VueElement & { $el: HTMLElement } > = ref(null);
 const satelliteFetchingCheck = async () => {
   const downloadList = (await ApiService.getSatelliteFetchingRunning(props.modelRuns)).items;
   // Check if we are still downloading any items
-  const stillDownloading = modifiedList.value.some((item) => downloadList.includes(item.id));
+  const stillDownloading = modifiedList.value.some((item) => !!downloadList.find((listItem) => listItem.siteId === item.id));
   if (!stillDownloading && downloadCheckInterval) {
     clearInterval(downloadCheckInterval);
     downloadCheckInterval = null;
@@ -45,10 +45,16 @@ const satelliteFetchingCheck = async () => {
   // We want to make sure we update the list to indicate which items are downloading in the modifiedList
   const newList: SiteDisplay[] = [];
   modifiedList.value.forEach((item) => {
-    if (item.downloading && !downloadList.includes(item.id)) {
+    const foundDownloadItem = downloadList.find((listItem) => listItem.siteId === item.id);
+    if (item.downloading && !foundDownloadItem) {
       item.downloading = false;
-    } else if (!item.downloading && downloadList.includes(item.id)) {
+      item.downloadingData = undefined;
+    } else if (!item.downloading && !!foundDownloadItem) {
       item.downloading = true;
+      item.downloadingData = foundDownloadItem.info;
+    }
+    if (foundDownloadItem) {
+      item.downloadingData = foundDownloadItem.info;
     }
     newList.push(item)
   });

--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -11,6 +11,14 @@ import ImageBrowser from './ImageBrowser.vue';
 import ImageToggle from './ImageToggle.vue';
 import AnimationDownloadDialog from "../animation/AnimationDownloadDialog.vue";
 
+export interface satelliteFetchingDownloadingInfo {
+  current: number;
+  total: number;
+  mode: string;
+  source: string;
+  siteEvalId: string;
+}
+
 export interface SiteDisplay {
   number: number;
   id: string;
@@ -30,6 +38,7 @@ export interface SiteDisplay {
   status?: SiteModelStatus;
   timestamp: number;
   downloading: boolean;
+  downloadingData?: satelliteFetchingDownloadingInfo;
   groundTruth?: boolean;
   color_code?: number;
   originator?: string;
@@ -62,6 +71,7 @@ const localSite: Ref<SiteDisplay> = ref({...props.site});
 const imagesActive = computed(() => state.enabledSiteImages.findIndex((item) => item.id === props.site.id) !== -1);
 const hasImages = computed(() =>  props.site.WV > 0 || props.site.S2 > 0 || props.site.PL > 0 || props.site.L8 > 0);
 const downloading = computed(() => props.site.downloading);
+const downloadingData = computed(() => props.site.downloadingData);
 
 const statusMap: Record<SiteModelStatus, { name: string; color: string, icon: string }> = {
   PROPOSAL: { name: "Proposed", color: "orange", icon: "mdi-dots-horizontal-circle" },
@@ -365,7 +375,34 @@ const animationDialog = ref(false);
                 <v-icon>mdi-image-sync</v-icon>
               </v-btn>
             </template>
-            <span>Currently Downloading Images</span>
+            <v-card v-if="downloadingData" width="200">
+              <v-card-title><h4>{{ downloadingData?.mode }} for {{ downloadingData?.source }}</h4></v-card-title>
+              <v-card-text>
+                <v-row dense>
+                  <v-progress-linear
+                    :model-value="downloadingData.current"
+                    :max="downloadingData?.total"
+                    height="25"
+                    label
+                  >
+                    <template #default="{ value }">
+                      <strong>{{ Math.ceil(value) }}%</strong>
+                    </template>
+                  </v-progress-linear>
+                </v-row>
+                <v-row dense>
+                  <v-spacer>
+                  <span>Downloading {{ downloadingData.current }} of {{  downloadingData.total }}</span>
+                  </v-spacer>
+                </v-row>
+                <v-row dense>
+                  <p>The total number is the found images, due to settings for timing and removing NoData/Cloud Cover all images may not be downloaded</p>
+                </v-row>
+              </v-card-text>
+            </v-card>
+            <div v-else>
+              Fetching Progress...
+            </div>
           </v-tooltip>
           <v-tooltip open-delay="300">
             <template #activator="{ props }">


### PR DESCRIPTION
- Updated Animation Generation for RDWATCH database to upscale when rescale is on for images that are lower than 500x500 pixels.  I changed it to use a 2X multiplier until both the width and height are above 500.  This makes it easier to draw the fonts and other items that are needed.
- Updated the satellite-fetching/running endpoint to return back the celery information that is logged during the image downloading progress.
- This image is now a hover card that shows up when hovering over the downloading status indicator.

TODO:
- [ ] Update animation creation for scoring to utilize the same upscaling option for lower resolution images
- [ ] Decide if I want to show more information for the downloading data.
    - [ ] Like showing what source it is on and has completed instead of just showing the current source.
    - [ ] Should I show the options for downloading?
- [ ] Test with a full model-run and make sure the performance isn't too bad with getting all the celery task information.  It may be that some sites are pending and I should indicate that while awaiting for them to start running