### PR TITLE
Use POST when querying the STAC server

### DIFF
--- a/rdwatch/core/utils/stac_search.py
+++ b/rdwatch/core/utils/stac_search.py
@@ -81,7 +81,7 @@ def stac_search(
         time_str = f'{_fmt_time(timestamp)}Z'
 
     results = stac_catalog.search(
-        method='GET',
+        method='POST',
         bbox=bbox,
         datetime=time_str,
         collections=COLLECTIONS_BY_SOURCE[source],


### PR DESCRIPTION
The L8 STAC server returns incorrect pagination links when using GET search queries.