### PR TITLE
Allow for viewing local geojson layers

### DIFF
--- a/vue/src/actions/localMapLayers.ts
+++ b/vue/src/actions/localMapLayers.ts
@@ -1,6 +1,4 @@
 import { state } from "../store";
-import { getGeoJSONBounds } from "../utils";
-import { FitBoundsEvent } from "./map";
 
 let id = 1;
 
@@ -15,8 +13,6 @@ export function addLocalMapLayer(feature: GeoJSON.GeoJSON): number {
     geojson: feature,
   };
   state.localMapFeatureIds.push(id);
-
-  FitBoundsEvent.trigger(getGeoJSONBounds(feature));
 
   return id;
 }

--- a/vue/src/actions/localMapLayers.ts
+++ b/vue/src/actions/localMapLayers.ts
@@ -1,9 +1,15 @@
 import { state } from "../store";
+import { getGeoJSONBounds } from '../utils';
+import { FitBoundsEvent } from '../actions/map';
 
-let id = 1;
+let _id = 1;
 
 function nextId() {
-  return id++;
+  return _id++;
+}
+
+function defaultLayerName(layerId: number) {
+  return `Layer ${layerId}`;
 }
 
 export function addLocalMapLayer(feature: GeoJSON.GeoJSON): number {
@@ -11,6 +17,8 @@ export function addLocalMapLayer(feature: GeoJSON.GeoJSON): number {
   state.localMapFeatureById[id] = {
     id,
     geojson: feature,
+    visible: true,
+    name: defaultLayerName(id),
   };
   state.localMapFeatureIds.push(id);
 
@@ -25,3 +33,30 @@ export function removeLocalMapLayer(id: number) {
   delete state.localMapFeatureById[id];
 }
 
+export function focusLayer(layerId: number) {
+  const layer = state.localMapFeatureById[layerId];
+  if (!layer) return;
+
+  const bounds = getGeoJSONBounds(layer.geojson);
+  FitBoundsEvent.trigger(bounds);
+}
+
+export function setLayerVisibility(layerId: number, visible: boolean) {
+  const layer = state.localMapFeatureById[layerId];
+  if (!layer) return;
+
+  state.localMapFeatureById[layerId] = {
+    ...layer,
+    visible,
+  };
+}
+
+export function setLayerName(layerId: number, name: string) {
+  const layer = state.localMapFeatureById[layerId];
+  if (!layer) return;
+
+  state.localMapFeatureById[layerId] = {
+    ...layer,
+    name: name.trim().length ? name : defaultLayerName(layerId),
+  };
+}

--- a/vue/src/actions/localMapLayers.ts
+++ b/vue/src/actions/localMapLayers.ts
@@ -1,0 +1,31 @@
+import { state } from "../store";
+import { getGeoJSONBounds } from "../utils";
+import { FitBoundsEvent } from "./map";
+
+let id = 1;
+
+function nextId() {
+  return id++;
+}
+
+export function addLocalMapLayer(feature: GeoJSON.GeoJSON): number {
+  const id = nextId();
+  state.localMapFeatureById[id] = {
+    id,
+    geojson: feature,
+  };
+  state.localMapFeatureIds.push(id);
+
+  FitBoundsEvent.trigger(getGeoJSONBounds(feature));
+
+  return id;
+}
+
+export function removeLocalMapLayer(id: number) {
+  const idx = state.localMapFeatureIds.indexOf(id);
+  if (idx === -1) return;
+
+  state.localMapFeatureIds.splice(idx, 1);
+  delete state.localMapFeatureById[id];
+}
+

--- a/vue/src/actions/map.ts
+++ b/vue/src/actions/map.ts
@@ -1,0 +1,3 @@
+import { type BoundingBox, createEventHook } from '../utils';
+
+export const FitBoundsEvent = createEventHook<BoundingBox>();

--- a/vue/src/components/LocalLayers.vue
+++ b/vue/src/components/LocalLayers.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { addLocalMapLayer, removeLocalMapLayer } from '../actions/localMapLayers';
+import { addLocalMapLayer, focusLayer, removeLocalMapLayer, setLayerName, setLayerVisibility } from '../actions/localMapLayers';
 import { state } from '../store';
-import { getGeoJSONBounds } from '../utils';
-import { FitBoundsEvent } from '../actions/map';
 
 const isLoading = ref(false);
 
@@ -51,14 +49,6 @@ function deleteLayer(layerId: number) {
   removeLocalMapLayer(layerId);
 }
 
-function focusLayer(layerId: number) {
-  const layer = state.localMapFeatureById[layerId];
-  if (!layer) return;
-
-  const bounds = getGeoJSONBounds(layer.geojson);
-  FitBoundsEvent.trigger(bounds);
-}
-
 const localLayers = computed(() => {
   return state.localMapFeatureIds.map(
     (id) => state.localMapFeatureById[id],
@@ -93,8 +83,13 @@ const localLayers = computed(() => {
       <v-list-item
         v-for="layer in localLayers"
         :key="layer.id"
-        :title="`Layer ${layer.id}`"
       >
+        <v-text-field
+          variant="underlined"
+          :placeholder="`Layer ${layer.id}`"
+          :model-value="layer.name"
+          @model-value:update="setLayerName(layer.id, $event)"
+        />
         <template #append>
           <v-btn
             color="grey-darken-1"
@@ -108,6 +103,20 @@ const localLayers = computed(() => {
               location="bottom"
             >
               Focus
+            </v-tooltip>
+          </v-btn>
+          <v-btn
+            color="grey-darken-1"
+            icon
+            variant="text"
+            @click="setLayerVisibility(layer.id, !layer.visible)"
+          >
+            <v-icon>{{ layer.visible ? 'mdi-eye' : 'mdi-eye-off' }}</v-icon>
+            <v-tooltip
+              activator="parent"
+              location="bottom"
+            >
+              Toggle Visibility
             </v-tooltip>
           </v-btn>
           <v-btn

--- a/vue/src/components/LocalLayers.vue
+++ b/vue/src/components/LocalLayers.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { addLocalMapLayer, removeLocalMapLayer } from '../actions/localMapLayers';
+import { state } from '../store';
+import { getGeoJSONBounds } from '../utils';
+import { FitBoundsEvent } from '../actions/map';
+
+async function loadFiles(files: File[]) {
+  await Promise.all(files.map(async (file) => {
+    const data = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = function() {
+        resolve(reader.result as string);
+      };
+      reader.onerror = reject;
+      reader.readAsText(file, 'utf-8');
+    });
+    addLocalMapLayer(JSON.parse(data));
+  }));
+}
+
+async function promptForGeoJSONs() {
+  const files = await new Promise<File[]>((resolve) => {
+    const fileEl = document.createElement('input');
+    fileEl.setAttribute('type', 'file');
+    fileEl.setAttribute('multiple', 'multiple');
+    fileEl.setAttribute('accept', '.geojson');
+    fileEl.addEventListener('change', () => {
+      const files = Array.from(fileEl.files ?? []);
+      resolve(files);
+    });
+    fileEl.click();
+  });
+
+  await loadFiles(files);
+}
+
+function deleteLayer(layerId: number) {
+  removeLocalMapLayer(layerId);
+}
+
+function focusLayer(layerId: number) {
+  const layer = state.localMapFeatureById[layerId];
+  if (!layer) return;
+
+  const bounds = getGeoJSONBounds(layer.geojson);
+  FitBoundsEvent.trigger(bounds);
+}
+
+const localLayers = computed(() => {
+  return state.localMapFeatureIds.map(
+    (id) => state.localMapFeatureById[id],
+  );
+})
+
+</script>
+
+<template>
+  <div>
+    <div class="text-center">
+      <v-btn
+        variant="flat"
+        color="secondary"
+        @click="promptForGeoJSONs"
+      >
+        <template #prepend>
+          <v-icon>mdi-plus</v-icon>
+        </template>
+        Add local .geojson file
+      </v-btn>
+      <div
+        v-if="!localLayers.length"
+        class="mt-8 text-grey-darken-2"
+      >
+        No local layers
+      </div>
+    </div>
+    <v-list>
+      <v-list-item
+        v-for="layer in localLayers"
+        :key="layer.id"
+        :title="`Layer ${layer.id}`"
+      >
+        <template #append>
+          <v-btn
+            color="grey-darken-1"
+            icon
+            variant="text"
+            @click="focusLayer(layer.id)"
+          >
+            <v-icon>mdi-target</v-icon>
+            <v-tooltip
+              activator="parent"
+              location="bottom"
+            >
+              Focus
+            </v-tooltip>
+          </v-btn>
+          <v-btn
+            color="grey-darken-1"
+            icon
+            variant="text"
+            @click="deleteLayer(layer.id)"
+          >
+            <v-icon>mdi-delete</v-icon>
+            <v-tooltip
+              activator="parent"
+              location="bottom"
+            >
+              Delete
+            </v-tooltip>
+          </v-btn>
+        </template>
+      </v-list-item>
+    </v-list>
+  </div>
+</template>

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -17,7 +17,7 @@ import { setSatelliteTimeStamp } from "../mapstyle/satellite-image";
 import { isEqual, throttle } from 'lodash';
 import { updateImageMapSources } from "../mapstyle/images";
 import { FitBoundsEvent } from "../actions/map";
-import { BoundingBox } from "../utils";
+import { type BoundingBox, getGeoJSONBounds } from "../utils";
 
 const mapContainer: ShallowRef<null | HTMLElement> = shallowRef(null);
 const map: ShallowRef<null | Map> = shallowRef(null);
@@ -194,6 +194,11 @@ watch([shallowRef(map), () => state.localMapFeatureIds], ([, newIds]) => {
       },
     });
   });
+
+  if (addedIds.length === 1) {
+    const data = state.localMapFeatureById[addedIds[0]].geojson;
+    fitBounds(getGeoJSONBounds(data));
+  }
 }, { immediate: true, deep: true });
 
 </script>

--- a/vue/src/components/MapLibre.vue
+++ b/vue/src/components/MapLibre.vue
@@ -15,16 +15,7 @@ import { satelliteLoading } from "../interactions/satelliteLoading";
 import { setReference } from "../interactions/fillPatterns";
 import { setSatelliteTimeStamp } from "../mapstyle/satellite-image";
 import { isEqual, throttle } from 'lodash';
-import { nextTick } from "vue";
 import { updateImageMapSources } from "../mapstyle/images";
-
-interface Props {
-  compact?: boolean
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  compact: false,
-});
 
 const mapContainer: ShallowRef<null | HTMLElement> = shallowRef(null);
 const map: ShallowRef<null | Map> = shallowRef(null);
@@ -156,22 +147,13 @@ watch(
   (val) => fitBounds(val)
 );
 
-watch(() => props.compact, () => {
-  // Wait for it to resize the map based on CSS before resizing and fitting
-  nextTick(() => {
-    map.value?.resize();
-    if (props.compact) {
-      fitBounds(state.bbox);
-    }
-  });
-});
 
 </script>
 
 <template>
   <div
     ref="mapContainer"
-    :class="{map: !compact, compactMap: compact, mapProposalAdjust: compact}"
+    class="map"
   />
 </template>
 
@@ -179,20 +161,9 @@ watch(() => props.compact, () => {
 @import "maplibre-gl/dist/maplibre-gl.css";
 
 .map {
-  position: fixed;
-  width: 100vw;
-  height: 100vh;
+  height: 100%;
   inset: 0;
   z-index: -1;
-}
-
-.compactMap {
-  position: fixed;
-  width: 100%;
-  max-height:50vh;
-  height: 50vh;
-  z-index: -1;
-  inset: 0;
 }
 
 .mapboxgl-popup {
@@ -207,6 +178,6 @@ watch(() => props.compact, () => {
 
 /* hides the editing controls in the viewer */
 .mapboxgl-ctrl-group {
-  display: none; 
+  display: none;
 }
 </style>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -15,6 +15,7 @@ import type { Ref } from "vue";
 import { changeTime } from "../interactions/timeStepper";
 import { useRoute } from "vue-router";
 import ModeSelector from './ModeSelector.vue';
+import LocalLayers from "./LocalLayers.vue";
 
 
 const route = useRoute();
@@ -157,6 +158,8 @@ const satelliteLoadingColor = computed(() => {
   }
   return 'black'
 })
+
+const tab = ref();
 </script>
 
 <template>
@@ -164,176 +167,196 @@ const satelliteLoadingColor = computed(() => {
     class="pa-5 pb-1 overflow-y-hidden d-flex flex-column"
     style="max-height:100vh; min-height:100vh;"
   >
-    <div>
-      <v-row
-        dense
-      >
-        <ErrorPopup />
-        <div class="d-flex flex-column align-center mx-auto pb-4">
-          <img
-            height="38"
-            src="../assets/logo.svg"
-            alt="Resonant GeoData"
-            draggable="false"
-          >
-          <span class="text-caption">{{ state.appVersion }}</span>
-        </div>
-      </v-row>
-      <mode-selector />
-      <v-row>
-        <TimeSlider
-          :min="state.timeMin"
-          :max="Math.floor(Date.now() / 1000)"
-        />
-      </v-row>
-      <v-row
-        dense
-        align="center"
-        class="py-2"
-      >
-        <v-spacer />
-        <v-btn
-          variant="tonal"
-          density="compact"
-          class="pa-0 ma-1 sidebar-icon"
-          :color="drawMap ? 'primary' : 'black'"
-          @click="drawMap = !drawMap"
-        >
-          <v-icon>mdi-road</v-icon>
-        </v-btn>
-        <v-btn
-          v-if="selectedRegion !== null && !(filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
-          variant="tonal"
-          density="compact"
-          class="pa-0 ma-1 sidebar-icon"
-          :class="{
-            'animate-flicker': state.satellite.loadingSatelliteImages,
-          }"
-          :color="imagesOn ? 'primary' : 'black'"
-          :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
-          @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
-        >
-          <v-icon>mdi-image</v-icon>
-        </v-btn>
-        <v-tooltip v-else>
-          <template #activator="{ props: props }">
-            <v-btn
-              variant="tonal"
-              v-bind="props"
-              :disabled="!selectedRegion"
-              density="compact"
-              :class="{
-                'animate-flicker': loadingSatelliteTimestamps,
-              }"
-              class="pa-0 ma-1 sidebar-icon"
-              :color="satelliteLoadingColor"
-              @click="askDownloadSatelliteTimestamps = true"
-            >
-              <v-icon>mdi-satellite-variant</v-icon>
-            </v-btn>
-          </template>
-          <v-alert
-            v-if="!satelliteRegionTooLarge"
-            type="warning"
-            title="Download Region Satellite Timestamps"
-            text="This is a long running process that could cause instability on the server.  Please only run this if you are sure you need to use the region satellite feature."
-          />
-          <v-alert
-            v-else
-            type="warning"
-            title="Region Too Large to Download Timestamps"
-            text="The Region is too large to download timestamps for."
-          />
-        </v-tooltip>
-        <v-btn
-          :color="state.filters.showText ? 'primary' : 'gray'"
-          variant="tonal"
-          class="pa-0 ma-1 sidebar-icon"
-          density="compact"
-          @click="toggleText()"
-        >
-          <v-icon>mdi-format-text</v-icon>
-        </v-btn>
-        <v-btn
-          :color="state.mapLegend ? 'primary' : 'gray'"
-          variant="tonal"
-          class="pa-0 ma-1 sidebar-icon"
-          density="compact"
-          @click="state.mapLegend = !state.mapLegend"
-        >
-          <v-icon>mdi-map-legend</v-icon>
-        </v-btn>
-        <v-tooltip>
-          <template #activator="{ props: props }">
-            <v-btn
-              variant="tonal"
-              v-bind="props"
-              density="compact"
-              class="pa-0 ma-1 sidebar-icon"
-              :color="groundtruth ? 'primary' : 'gray'"
-              @click="groundtruth = !groundtruth"
-            >
-              <v-icon>mdi-check-decagram</v-icon>
-            </v-btn>
-          </template>
-          <span> Toggle Ground Truth in the list</span>
-        </v-tooltip>
-        <v-btn
-          :color="expandSettings ? 'primary' : 'gray'"
-          variant="tonal"
-          class="pa-0 ma-1 sidebar-icon"
-          density="compact"
-          @click="expandSettings = !expandSettings"
-        >
-          <v-icon>mdi-cog</v-icon>
-        </v-btn>
-      </v-row>
-      <v-row
-        dense
-        class="mt-3"
-      >
-        <PerformerFilter
-          v-model="selectedPerformer"
-          cols="6"
-          class="px-1"
-          hide-details
-        />
-        <RegionFilter
-          v-model="selectedRegion"
-          cols="6"
-          class="px-1"
-          hide-details
-        />
-      </v-row>
-      <v-row
-        v-if="ApiService.isScoring()"
-        class="pt-2"
-        dense
-      >
-        <ModeFilter
-          v-model="selectedModes"
-          class="px-1"
-          hide-details
-        />
-        <EvalFilter
-          v-model="selectedEval"
-          class="px-1"
-          hide-details
-        />
-      </v-row>
-    </div>
     <v-row
       dense
-      class="modelRuns"
+      class="flex-grow-0"
     >
-      <SettingsPanel v-if="expandSettings" />
-      <ModelRunListVue
-        v-if="!expandSettings"
-        :filters="queryFilters"
-        class="flex-grow-1"
-        @modelrunlist="currentModelRunList = $event"
-      />
+      <ErrorPopup />
+      <div class="d-flex flex-column align-center mx-auto pb-4">
+        <img
+          height="38"
+          src="../assets/logo.svg"
+          alt="Resonant GeoData"
+          draggable="false"
+        >
+        <span class="text-caption">{{ state.appVersion }}</span>
+      </div>
     </v-row>
+    <v-tabs
+      v-model="tab"
+      class="mb-4"
+    >
+      <v-tab value="model-runs">
+        Model Runs
+      </v-tab>
+      <v-tab value="local-layers">
+        Local Layers
+      </v-tab>
+    </v-tabs>
+    <v-window
+      v-model="tab"
+      class="overflow-visible"
+    >
+      <v-window-item value="model-runs">
+        <mode-selector />
+        <v-row>
+          <TimeSlider
+            :min="state.timeMin"
+            :max="Math.floor(Date.now() / 1000)"
+          />
+        </v-row>
+        <v-row
+          dense
+          align="center"
+          class="py-2"
+        >
+          <v-spacer />
+          <v-btn
+            variant="tonal"
+            density="compact"
+            class="pa-0 ma-1 sidebar-icon"
+            :color="drawMap ? 'primary' : 'black'"
+            @click="drawMap = !drawMap"
+          >
+            <v-icon>mdi-road</v-icon>
+          </v-btn>
+          <v-btn
+            v-if="selectedRegion !== null && !(filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
+            variant="tonal"
+            density="compact"
+            class="pa-0 ma-1 sidebar-icon"
+            :class="{
+              'animate-flicker': state.satellite.loadingSatelliteImages,
+            }"
+            :color="imagesOn ? 'primary' : 'black'"
+            :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
+            @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
+          >
+            <v-icon>mdi-image</v-icon>
+          </v-btn>
+          <v-tooltip v-else>
+            <template #activator="{ props: props }">
+              <v-btn
+                variant="tonal"
+                v-bind="props"
+                :disabled="!selectedRegion"
+                density="compact"
+                :class="{
+                  'animate-flicker': loadingSatelliteTimestamps,
+                }"
+                class="pa-0 ma-1 sidebar-icon"
+                :color="satelliteLoadingColor"
+                @click="askDownloadSatelliteTimestamps = true"
+              >
+                <v-icon>mdi-satellite-variant</v-icon>
+              </v-btn>
+            </template>
+            <v-alert
+              v-if="!satelliteRegionTooLarge"
+              type="warning"
+              title="Download Region Satellite Timestamps"
+              text="This is a long running process that could cause instability on the server.  Please only run this if you are sure you need to use the region satellite feature."
+            />
+            <v-alert
+              v-else
+              type="warning"
+              title="Region Too Large to Download Timestamps"
+              text="The Region is too large to download timestamps for."
+            />
+          </v-tooltip>
+          <v-btn
+            :color="state.filters.showText ? 'primary' : 'gray'"
+            variant="tonal"
+            class="pa-0 ma-1 sidebar-icon"
+            density="compact"
+            @click="toggleText()"
+          >
+            <v-icon>mdi-format-text</v-icon>
+          </v-btn>
+          <v-btn
+            :color="state.mapLegend ? 'primary' : 'gray'"
+            variant="tonal"
+            class="pa-0 ma-1 sidebar-icon"
+            density="compact"
+            @click="state.mapLegend = !state.mapLegend"
+          >
+            <v-icon>mdi-map-legend</v-icon>
+          </v-btn>
+          <v-tooltip>
+            <template #activator="{ props: props }">
+              <v-btn
+                variant="tonal"
+                v-bind="props"
+                density="compact"
+                class="pa-0 ma-1 sidebar-icon"
+                :color="groundtruth ? 'primary' : 'gray'"
+                @click="groundtruth = !groundtruth"
+              >
+                <v-icon>mdi-check-decagram</v-icon>
+              </v-btn>
+            </template>
+            <span> Toggle Ground Truth in the list</span>
+          </v-tooltip>
+          <v-btn
+            :color="expandSettings ? 'primary' : 'gray'"
+            variant="tonal"
+            class="pa-0 ma-1 sidebar-icon"
+            density="compact"
+            @click="expandSettings = !expandSettings"
+          >
+            <v-icon>mdi-cog</v-icon>
+          </v-btn>
+        </v-row>
+        <v-row
+          dense
+          class="mt-3"
+        >
+          <PerformerFilter
+            v-model="selectedPerformer"
+            cols="6"
+            class="px-1"
+            hide-details
+          />
+          <RegionFilter
+            v-model="selectedRegion"
+            cols="6"
+            class="px-1"
+            hide-details
+          />
+        </v-row>
+        <v-row
+          v-if="ApiService.isScoring()"
+          class="pt-2"
+          dense
+        >
+          <ModeFilter
+            v-model="selectedModes"
+            class="px-1"
+            hide-details
+          />
+          <EvalFilter
+            v-model="selectedEval"
+            class="px-1"
+            hide-details
+          />
+        </v-row>
+        <v-row
+          dense
+          class="modelRuns"
+        >
+          <SettingsPanel v-if="expandSettings" />
+          <ModelRunListVue
+            v-if="!expandSettings"
+            :filters="queryFilters"
+            class="flex-grow-1"
+            @modelrunlist="currentModelRunList = $event"
+          />
+        </v-row>
+      </v-window-item>
+      <v-window-item value="local-layers">
+        <local-layers />
+      </v-window-item>
+    </v-window>
     <v-dialog
       v-model="askDownloadSatelliteTimestamps"
       width="600"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -165,7 +165,7 @@ const tab = ref();
 <template>
   <v-card
     class="pa-5 pb-1 overflow-y-hidden d-flex flex-column"
-    style="max-height:100vh; min-height:100vh;"
+    style="max-height:100vh; min-height:100vh; height: 100vh;"
   >
     <v-row
       dense
@@ -184,7 +184,7 @@ const tab = ref();
     </v-row>
     <v-tabs
       v-model="tab"
-      class="mb-4"
+      class="mb-4 flex-shrink-0"
     >
       <v-tab value="model-runs">
         Model Runs
@@ -195,7 +195,7 @@ const tab = ref();
     </v-tabs>
     <v-window
       v-model="tab"
-      class="overflow-visible"
+      class="overflow-visible h-100"
     >
       <v-window-item value="model-runs">
         <mode-selector />
@@ -353,7 +353,10 @@ const tab = ref();
           />
         </v-row>
       </v-window-item>
-      <v-window-item value="local-layers">
+      <v-window-item
+        value="local-layers"
+        class="h-100"
+      >
         <local-layers />
       </v-window-item>
     </v-window>

--- a/vue/src/components/annotationViewer/AnnotationList.vue
+++ b/vue/src/components/annotationViewer/AnnotationList.vue
@@ -11,6 +11,7 @@ import ImagesDownloadDialog from "../ImagesDownloadDialog.vue";
 import SiteListCard from "../siteList/SiteListCard.vue";
 import { SiteDisplay } from "../siteList/SiteListCard.vue";
 import SiteListHeader from "../siteList/SiteListHeader.vue";
+import { FitBoundsEvent } from "../../actions/map";
 
 const props = defineProps<{
   modelRun: string | null;
@@ -153,7 +154,7 @@ watch(clickedInfo, () => {
           dateRange: [found.startDate, found.endDate]
         }
       }
-      state.bbox = found.bbox;
+      FitBoundsEvent.trigger(found.bbox);
       scrollVirtualList(found.id);
     }
   } else {
@@ -170,7 +171,7 @@ const selectSite = (item: SiteDisplay) => {
           dateRange: [item.startDate, item.endDate]
         }
   }
-      state.bbox = item.bbox;
+  FitBoundsEvent.trigger(item.bbox);
 }
 
 watch(() => props.selectedEval, () => {

--- a/vue/src/mapstyle/index.ts
+++ b/vue/src/mapstyle/index.ts
@@ -15,8 +15,9 @@ import {
   layers as satelliteLayers,
 } from "./satellite-image";
 import type { StyleSpecification } from "maplibre-gl";
-import { EnabledSiteOverviews,  MapFilters, SatelliteData, siteOverviewSatSettings } from "../store";
+import { EnabledSiteOverviews, type LocalGeoJSONFeature, MapFilters, SatelliteData, siteOverviewSatSettings } from "../store";
 import { buildImageLayerFilter, buildImageSourceFilter } from "./images";
+import { localGeoJSONLayers, localGeoJSONSources } from "./localgeojson";
 
 const tileServerURL =
   import.meta.env.VITE_TILE_SERVER_URL || "https://basemap.kitware.watch";
@@ -28,6 +29,7 @@ export const style = (
   settings: siteOverviewSatSettings,
   modelRunIds: string[],
   regionIds: number[],
+  localGeoJSONFeatures: LocalGeoJSONFeature[],
   randomKey=''
 ): StyleSpecification => ({
   version: 8,
@@ -37,6 +39,7 @@ export const style = (
     ...buildImageSourceFilter(timestamp, enabledSiteImages, settings),
     ...buildRdwatchtilesSources(timestamp, modelRunIds, regionIds, randomKey),
     ...openmaptilesSources(filters),
+    ...localGeoJSONSources(localGeoJSONFeatures),
   },
   sprite: `${tileServerURL}/sprites/osm-liberty`,
   glyphs: `${tileServerURL}/fonts/{fontstack}/{range}.pbf`,
@@ -51,5 +54,6 @@ export const style = (
     ...satelliteLayers(timestamp, satellite),
     ...buildImageLayerFilter(timestamp, enabledSiteImages, settings),
     ...rdwatchtilesLayers(timestamp, filters, modelRunIds, regionIds),
+    ...localGeoJSONLayers(localGeoJSONFeatures),
   ],
 });

--- a/vue/src/mapstyle/localgeojson.ts
+++ b/vue/src/mapstyle/localgeojson.ts
@@ -1,0 +1,46 @@
+import { LayerSpecification } from "maplibre-gl";
+import { LocalGeoJSONFeature } from "../store";
+
+export function localGeoJSONSources(localMapFeatures: LocalGeoJSONFeature[]) {
+  return localMapFeatures.reduce((acc, feature) => {
+    return {
+      ...acc,
+      [`local-source-${feature.id}`]: {
+        type: 'geojson',
+        data: feature.geojson,
+      },
+    }
+  }, {});
+}
+
+export function localGeoJSONLayers(localMapFeatures: LocalGeoJSONFeature[]) {
+  return localMapFeatures.flatMap((feature) => {
+    return [
+      {
+        id: `local-layer-${feature.id}:fill`,
+        type: 'fill',
+        source: `local-source-${feature.id}`,
+        layout: {
+          visibility: feature.visible ? 'visible' : 'none',
+        },
+        paint: {
+          'fill-color': '#088',
+          'fill-opacity': 0.5
+        },
+      },
+      {
+        id: `local-layer-${feature.id}:outline`,
+        type: 'line',
+        source: `local-source-${feature.id}`,
+        layout: {
+          visibility: feature.visible ? 'visible' : 'none',
+        },
+        paint: {
+          'line-color': '#055',
+          'line-width': 2,
+        },
+      },
+    ] as LayerSpecification[];
+  })
+}
+

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -220,6 +220,8 @@ export const state = reactive<{
       activeFilters: QueryArguments;
     };
   };
+  localMapFeatureIds: number[]
+  localMapFeatureById: Record<number, { id: number, geojson: GeoJSON.GeoJSON }>
 }>({
   appVersion: '',
   dataSource: null,
@@ -300,6 +302,8 @@ export const state = reactive<{
       activeFilters: {},
     },
   },
+  localMapFeatureIds: [],
+  localMapFeatureById: {},
 });
 
 export const filteredSatelliteTimeList = computed(() => {

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -162,6 +162,8 @@ export interface KeyedModelRun extends ModelRun {
 export interface LocalGeoJSONFeature {
   id: number;
   geojson: GeoJSON.GeoJSON;
+  visible: boolean;
+  name: string;
 }
 
 export const state = reactive<{

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -159,6 +159,11 @@ export interface KeyedModelRun extends ModelRun {
   key: string;
 }
 
+export interface LocalGeoJSONFeature {
+  id: number;
+  geojson: GeoJSON.GeoJSON;
+}
+
 export const state = reactive<{
   appVersion: string;
   dataSource: string | null;
@@ -183,7 +188,7 @@ export const state = reactive<{
   modelRuns: KeyedModelRun[],
   totalNumModelRuns: number;
   openedModelRuns: Set<KeyedModelRun["key"]>;
-  gifSettings: { 
+  gifSettings: {
     fps: number,
     pointSize: number,
   },
@@ -221,7 +226,7 @@ export const state = reactive<{
     };
   };
   localMapFeatureIds: number[]
-  localMapFeatureById: Record<number, { id: number, geojson: GeoJSON.GeoJSON }>
+  localMapFeatureById: Record<number, LocalGeoJSONFeature>
 }>({
   appVersion: '',
   dataSource: null,

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -53,7 +53,57 @@ const createEventHook = <T = unknown>() => {
 
 export type BoundingBox = { xmin: number; ymin: number; xmax: number; ymax: number };
 
+const unionBoundingBox = (b1: BoundingBox, b2: BoundingBox): BoundingBox => {
+  return {
+    xmin: Math.min(b1.xmin, b2.xmin),
+    xmax: Math.max(b1.xmax, b2.xmax),
+    ymin: Math.min(b1.ymin, b2.ymin),
+    ymax: Math.max(b1.ymax, b2.ymax),
+  }
+}
+
+/**
+ * Gets the bounding box for a geojson.
+ *
+ * Assumes WGS84 coordinates.
+ */
+const getGeoJSONBounds = (geojson: GeoJSON.GeoJSON): BoundingBox => {
+  let bounds: BoundingBox = {
+    xmin: 180,
+    xmax: -180,
+    ymin: 90,
+    ymax: -90,
+  };
+
+  if (geojson.type === 'FeatureCollection') {
+    geojson.features.forEach((feature) => {
+      bounds = unionBoundingBox(bounds, getGeoJSONBounds(feature.geometry));
+    })
+  } else if (geojson.type === 'Feature') {
+    bounds = unionBoundingBox(bounds, getGeoJSONBounds(geojson.geometry));
+  } else if (geojson.type === 'GeometryCollection') {
+    geojson.geometries.forEach((geom) => {
+      bounds = unionBoundingBox(bounds, getGeoJSONBounds(geom));
+    })
+  } else {
+    geojson.coordinates.flat(Infinity).forEach((val, idx) => {
+      if (idx % 2 == 0) {
+        // longitude
+        bounds.xmin = Math.min(bounds.xmin, val as number);
+        bounds.xmax = Math.max(bounds.xmax, val as number);
+      } else {
+        // latitude
+        bounds.ymin = Math.min(bounds.ymin, val as number);
+        bounds.ymax = Math.max(bounds.ymax, val as number);
+      }
+    });
+  }
+  return bounds;
+}
+
 export {
     timeRangeFormat,
     downloadPresignedFile,
+    createEventHook,
+    getGeoJSONBounds,
 }

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -1,7 +1,5 @@
 import { SiteOverview } from "./store"
 
-
-
 const timeRangeFormat = (range: SiteOverview['timerange']) => {
     if (range === null || (range.max === null && range.min === null)) {
       return '--'
@@ -12,7 +10,7 @@ const timeRangeFormat = (range: SiteOverview['timerange']) => {
     }
     return '--'
   }
-  
+
   async function downloadPresignedFile(url: string, filename: string) {
     try {
         const response = await fetch(url);
@@ -31,6 +29,29 @@ const timeRangeFormat = (range: SiteOverview['timerange']) => {
         console.error('Error downloading file:', error);
     }
 }
+
+export type EventCallback<T> = (e: T) => void;
+
+const createEventHook = <T = unknown>() => {
+  const cbs = new Set<EventCallback<T>>();
+
+  const off = (fn: EventCallback<T>) => {
+    cbs.delete(fn);
+  };
+
+  const on = (fn: EventCallback<T>) => {
+    cbs.add(fn);
+    return { off: () => off(fn) };
+  };
+
+  const trigger = (e: T) => {
+    Array.from(cbs).forEach((fn) => fn(e));
+  };
+
+  return { on, off, trigger };
+}
+
+export type BoundingBox = { xmin: number; ymin: number; xmax: number; ymax: number };
 
 export {
     timeRangeFormat,

--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -49,7 +49,7 @@ watch(()=> ApiService.getApiPrefix(), async () => {
   >
     <SideBar />
   </v-navigation-drawer>
-  <v-main style="z-index: 1">
+  <v-main style="z-index: 1; height: 100%">
     <layer-selection />
     <MapLibre />
     <ImageViewer


### PR DESCRIPTION
Users can now visualize local geojson files in RD-WATCH.

[Screen Recording 2024-10-22 at 3.19.43 PM.webm](https://github.com/user-attachments/assets/292e3f1a-be57-4b3b-890c-b89e194b667c)

Nice-to-haves and other considerations:
* toggle layer visibility
* nicer layer names (based on what?)
* edit geometry styles
* should the annotator view also support viewing local geojsons?

Other changes:
* The map is no longer partially covered by the sidebar
* An event is used for triggering `map.fitBounds()` instead of a state variable
* minor whitespace changes that were automatically done by my editor