### PR TITLE
Fix crash due to missing `error` key

### DIFF
--- a/rdwatch/scoring/views/satellite_fetching.py
+++ b/rdwatch/scoring/views/satellite_fetching.py
@@ -22,7 +22,7 @@ def satellite_fetching_running(
     )
     if model_runs is not None and len(model_runs) > 0:
         running_sites = running_sites.filter(model_run_uuid__in=model_runs)
-    running_site_ids = list(running_sites.values('site', 'celery_id'))
+    running_site_ids = list(running_sites.values('site', 'celery_id', 'error'))
     results = []
     for item in running_site_ids:
         task = AsyncResult(item['celery_id'])


### PR DESCRIPTION
This fixes https://kitware-data.sentry.io/issues/6029101458/?alert_rule_id=15484485&alert_timestamp=1730232466058&alert_type=email&environment=rgdtedev&notification_uuid=511df48d-a61e-49d2-8472-831143d5b282&project=4508054265724928&referrer=alert_email