### PR TITLE
Enable Sentry performance tracking

### DIFF
--- a/rdwatch/core/apps.py
+++ b/rdwatch/core/apps.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -12,6 +13,25 @@ from django.conf import settings
 class RDWatchConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
     name = 'rdwatch.core'
+
+    @staticmethod
+    def _get_sentry_trace_sample_rate(*args, **kwargs) -> float:
+        # Routes that should have a 100% trace rate.
+        # All other routes will have a 5% trace rate.
+        priority_routes = [
+            r'^/api/scoring/model-runs/[^/]+/sites/$',
+        ]
+
+        if len(args) and 'wsgi_environ' in args[0]:
+            wsgi_environ = args[0]['wsgi_environ']
+
+            url_path = wsgi_environ.get('PATH_INFO')
+
+            for regex in priority_routes:
+                if re.match(regex, url_path):
+                    return 1.0
+
+        return 0.05
 
     def ready(self) -> None:
         if hasattr(settings, 'SENTRY_DSN'):
@@ -30,7 +50,7 @@ class RDWatchConfig(AppConfig):
                 attach_stacktrace=True,
                 # Submit request User info from Django
                 send_default_pii=True,
-                traces_sampler=0.01,
-                profiles_sampler=0.01,
+                traces_sampler=self._get_sentry_trace_sample_rate,
+                profiles_sample_rate=1.0,
             )
         return super().ready()


### PR DESCRIPTION
I thought I enabled Sentry performance tracking in #512, but it turns out I did that incorrectly. This PR fixes it, and also adds an exception for the `/sites` endpoint that we're currently seeing 504 errors on.

Since we have a monthly quota for how many traces we can send to Sentry, it's usually necessary to configure `sentry_sdk` to only send performance data for a subset of all requests. I've configured it so that for any general request, it has a 5% chance of being recorded by Sentry Performance, _unless_ it's in the `priority_routes` list (in which case, it has a sample rate of 100%, i.e. it will always be recorded).

I've built and deployed this image to the AWS deployment, so you can see some sample traces already in Sentry https://kitware-data.sentry.io/performance/?project=4508054265724928&statsPeriod=90d. 