### PR TITLE
Image viewer line thickness

### DIFF
--- a/rdwatch/core/tasks/animation_export.py
+++ b/rdwatch/core/tasks/animation_export.py
@@ -304,6 +304,7 @@ class GenerateAnimationSchema(BaseModel):
     include: list[Literal['obs', 'nonobs']] = ['obs', 'nonobs']
     rescale: bool = False
     rescale_border: int = Field(1, ge=0)  # Border rescale should be an integer >= 0
+    line_thickness_factor: float = 1.0
 
 
 @shared_task
@@ -321,6 +322,7 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
         'noData': settingsSchema.noData,
         'include': settingsSchema.include,
     }
+    line_thickness_factor = settingsSchema.line_thickness_factor
 
     # Fetch the SiteEvaluation instance
     try:
@@ -540,7 +542,10 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                     for lon, lat in transformed_coords
                 ]
                 color = label_mapped.get('color', (255, 255, 255))
-                draw.polygon(pixel_coords, outline=color)
+                polyline_width = int(
+                    (max(max_height_px, max_width_px) * line_thickness_factor) // 100
+                )
+                draw.polygon(pixel_coords, outline=color, width=polyline_width)
         if not polygon and observation:
             point = observation.point
         if not point:

--- a/rdwatch/core/tasks/animation_export.py
+++ b/rdwatch/core/tasks/animation_export.py
@@ -543,7 +543,7 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                 ]
                 color = label_mapped.get('color', (255, 255, 255))
                 polyline_width = int(
-                    (max(max_height_px, max_width_px) * line_thickness_factor) // 100
+                    (max(max_height_px, max_width_px) * line_thickness_factor) / 100
                 )
                 draw.polygon(pixel_coords, outline=color, width=polyline_width)
         if not polygon and observation:

--- a/rdwatch/scoring/tasks/animation_export.py
+++ b/rdwatch/scoring/tasks/animation_export.py
@@ -151,6 +151,7 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
         'noData': settingsSchema.noData,
         'include': settingsSchema.include,
     }
+    line_thickness_factor = settingsSchema.line_thickness_factor
 
     # Fetch the SiteEvaluation instance
     try:
@@ -382,7 +383,10 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                     for lon, lat in transformed_coords
                 ]
                 color = label_mapped.get('color', (255, 255, 255))
-                draw.polygon(pixel_coords, outline=color)
+                polyline_width = int(
+                    (max(max_height_px, max_width_px) * line_thickness_factor) / 100
+                )
+                draw.polygon(pixel_coords, outline=color, width=polyline_width)
             elif polygon.geom_type == 'MultiPolygon':
                 # Handle MultiPolygon by iterating over each polygon
                 for poly in polygon:

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -129,6 +129,7 @@ export interface DefaultAnimationSettings {
   cloudCover: number;
   rescale: boolean;
   rescale_border: number;
+  line_thickness_factor: number;
 }
 
 export interface DownloadAnimationSettings {
@@ -142,6 +143,7 @@ export interface DownloadAnimationSettings {
   include: ('obs'|'nonobs')[];
   rescale: boolean;
   rescale_border: number;
+  line_thickness_factor: number;
 }
 
 export interface DownloadAnimationState {

--- a/vue/src/components/animation/AnimationDownloadDialog.vue
+++ b/vue/src/components/animation/AnimationDownloadDialog.vue
@@ -26,6 +26,7 @@ const outputFormat: Ref<DownloadAnimationSettings["output_format"]> =
 const formatChoices = ref(["mp4", "gif"]);
 const fps = ref(props.defaults ? props.defaults.fps : 1);
 const pointRadius = ref(props.defaults ? props.defaults.point_radius : 5);
+const lineThicknessFactor = ref(props.defaults?.line_thickness_factor ?? 1);
 const constellationChoices = ref( ["S2", "WV", "L8"]);
 const selectedSources: Ref<Constellation[]> = ref(props.defaults?.sources || ["WV", "S2"]);
 const labelChoices = ref(["geom", "date", "source", "obs", "obs_label"]);
@@ -83,8 +84,9 @@ const download = debounce(
       include: include.value,
       rescale: rescale.value,
       rescale_border: rescaleBorder.value,
+      line_thickness_factor: lineThicknessFactor.value,
     };
-    
+
     const response = props.type === 'site' ?
     await ApiService.generateSiteAnimation(props.id,downloadSettings) :
      await ApiService.generateModelRunAnimation(props.id, downloadSettings);
@@ -125,7 +127,7 @@ const cancel = debounce(() => emit("close"), 5000, { leading: true });
         </v-tab>
       </v-tabs>
     </v-card-title>
-    <v-card-text    
+    <v-card-text
       style="max-height:70vh; overflow-y:auto"
     >
       <div v-if="currentTab === 'download'">
@@ -242,6 +244,35 @@ const cancel = debounce(() => emit("close"), 5000, { leading: true });
               max="5"
               step="0.1"
               :label="`Rescale Border ${rescaleBorder.toFixed(2)}X`"
+              thumb-label="always"
+            />
+          </v-row>
+          <v-row
+            dense
+            align="center"
+            class="pb-5"
+          >
+            <v-slider
+              v-model="pointRadius"
+              min="1"
+              max="20"
+              step="1"
+              label="Point size"
+              thumb-label="always"
+            />
+          </v-row>
+          <v-row
+            dense
+            align="center"
+            class="pb-5"
+          >
+            <v-slider
+              v-model.number="lineThicknessFactor"
+              min="0.1"
+              max="2"
+              step="0.1"
+              label="Line Width Factor"
+              thumb-label="always"
             />
           </v-row>
         </v-form>

--- a/vue/src/components/imageViewer/ImageFilter.vue
+++ b/vue/src/components/imageViewer/ImageFilter.vue
@@ -32,6 +32,15 @@ const downloadingGifPointSize = computed({
   },
 });
 
+const lineThicknessFactor = computed({
+  get() {
+    return state.gifSettings.lineThicknessFactor;
+  },
+  set(val: number) {
+    state.gifSettings = { ...state.gifSettings, lineThicknessFactor: val };
+  },
+});
+
 const playbackFps = computed({
   get() {
     return state.gifSettings.fps || 1;
@@ -72,7 +81,13 @@ watch([
   () => state.imageFilter.sources,
   () => state.imageFilter.obsFilter,
   () => state.imageFilter.cloudCover,
-  () => state.imageFilter.noData], () => {
+  () => state.imageFilter.noData,
+  () => props.rescaleImage,
+  rescaleBorder,
+  playbackFps,
+  downloadingGifPointSize,
+  lineThicknessFactor,
+], (newData, [,,,,,oldRescaleBorder]) => {
   const defaultAnimationSettings: DefaultAnimationSettings = {
     cloudCover: state.imageFilter.cloudCover,
     noData: state.imageFilter.noData,
@@ -82,23 +97,13 @@ watch([
     rescale_border: rescaleBorder.value,
     fps: playbackFps.value,
     point_radius: downloadingGifPointSize.value,
-  }
-  console.log('Emitting Animation Defaults');
-  emit('animationDefaults', defaultAnimationSettings);
-})
-watch(rescaleBorder, () => {
-  const defaultAnimationSettings: DefaultAnimationSettings = {
-    cloudCover: state.imageFilter.cloudCover,
-    noData: state.imageFilter.noData,
-    sources: state.imageFilter.sources,
-    include: state.imageFilter.obsFilter.map((item) => item === 'non-observations' ? 'nonobs' : 'obs'),
-    rescale: props.rescaleImage,
-    rescale_border: rescaleBorder.value,
-    fps: playbackFps.value,
-    point_radius: downloadingGifPointSize.value,
+    line_thickness_factor: lineThicknessFactor.value,
   }
   emit('animationDefaults', defaultAnimationSettings);
-  emit('rescaleBBox', rescaleBorder.value);
+
+  if (rescaleBorder.value !== oldRescaleBorder) {
+    emit('rescaleBBox', rescaleBorder.value);
+  }
 })
 </script>
 
@@ -284,6 +289,28 @@ watch(rescaleBorder, () => {
         <v-col>
           <span class="pl-2">
             {{ downloadingGifPointSize }}px
+          </span>
+        </v-col>
+        <v-col
+          cols="2"
+          class="slider-label"
+        >
+          <span>Line Width Factor:</span>
+        </v-col>
+        <v-col cols="7">
+          <v-slider
+            v-model.number="lineThicknessFactor"
+            :min="0.1"
+            :max="2"
+            :step="0.1"
+            density="compact"
+            color="primary"
+            hide-details
+          />
+        </v-col>
+        <v-col>
+          <span class="pl-2">
+            {{ lineThicknessFactor }}
           </span>
         </v-col>
       </v-row>

--- a/vue/src/components/imageViewer/ImageViewer.vue
+++ b/vue/src/components/imageViewer/ImageViewer.vue
@@ -126,6 +126,10 @@ const currentTimestamp = computed(() => {
   return new Date().toISOString().split("T")[0];
 });
 
+const lineThicknessFactor = computed(() => {
+  return animationDefaults.value?.line_thickness_factor ?? 1;
+});
+
 watch(currentTimestamp, () => {
   currentDate.value = currentTimestamp.value;
 });
@@ -219,6 +223,7 @@ const load = async (newValue?: string, oldValue?: string) => {
       props.fullscreen,
       rescalingBBox.value,
       state.gifSettings.pointSize,
+      lineThicknessFactor.value,
     );
   }
   loading.value = false;
@@ -248,6 +253,7 @@ watch(
     drawGroundTruth,
     rescaleImage,
     rescalingBBox,
+    lineThicknessFactor,
   ],
   () => {
     if (
@@ -275,6 +281,7 @@ watch(
           props.fullscreen,
           rescalingBBox.value,
           state.gifSettings.pointSize,
+          lineThicknessFactor.value,
         );
       }
       if (

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -155,7 +155,7 @@ const drawData = (
                 }
               });
               const lineDivisor = Math.max(canvas.width, canvas.height);
-              context.lineWidth = lineDivisor * lineThicknessFactor / 100;
+              context.lineWidth = Math.floor(lineDivisor * lineThicknessFactor / 100);
               context.strokeStyle = getColorFromLabel(poly.label);
               context.stroke();
             });

--- a/vue/src/components/imageViewer/imageUtils.ts
+++ b/vue/src/components/imageViewer/imageUtils.ts
@@ -53,6 +53,7 @@ const drawData = (
     fullscreen = false,
     canvasScale = 1,
     radiusMultiplier = 1,
+    lineThicknessFactor = 1,
     ) => {
       const context = canvas.getContext('2d');
       const imageObj = new Image();
@@ -154,7 +155,7 @@ const drawData = (
                 }
               });
               const lineDivisor = Math.max(canvas.width, canvas.height);
-              context.lineWidth = lineDivisor/ 100.0;
+              context.lineWidth = lineDivisor * lineThicknessFactor / 100;
               context.strokeStyle = getColorFromLabel(poly.label);
               context.stroke();
             });
@@ -306,7 +307,7 @@ const normalizePolygon = (bbox: BaseBBox, imageWidth: number, imageHeight: numbe
           imageNormalizePoly[imageNormalizePoly.length -1].push({x: image_x, y: image_y});
           });
         });
-      } 
+      }
     });
   } else if (polygon.type === 'Point') {
         imageNormalizePoly.push([]);

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -182,10 +182,11 @@ export const state = reactive<{
   modelRuns: KeyedModelRun[],
   totalNumModelRuns: number;
   openedModelRuns: Set<KeyedModelRun["key"]>;
-  gifSettings: { 
-    fps: number,
-    pointSize: number,
-  },
+  gifSettings: {
+    fps: number;
+    pointSize: number;
+    lineThicknessFactor: number;
+  };
   performerIds: number[],
   performerMapping: Record<number, Performer>,
   proposals: {
@@ -271,7 +272,7 @@ export const state = reactive<{
   modelRuns: [],
   totalNumModelRuns: 0,
   openedModelRuns: new Set<KeyedModelRun["key"]>(),
-  gifSettings: { fps: 1, pointSize: 1},
+  gifSettings: { fps: 1, pointSize: 1, lineThicknessFactor: 1 },
   performerMapping: {},
   performerIds: [],
   proposals: {},


### PR DESCRIPTION
A new UI element, "line thickness factor", provides users with the means to adjust the polygon line thickness in both the viewer and the animation export.

Other changes:
- show the point size slider in the animation dialog
- sync the point size + rescale parameters to the animation dialog

New line width controls:

<img width="333" alt="image" src="https://github.com/user-attachments/assets/99b8a1f8-38cb-4625-a415-54e6eb5fbde2">
