### PR TITLE
Pin postgis docker version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   # PostgreSQL
   postgresql:
-    image: postgis/postgis:latest
+    image: postgis/postgis:16-3.5
     environment:
       POSTGRES_USER: rdwatch
       POSTGRES_DB: rdwatch
@@ -35,7 +35,7 @@ services:
 
   # Scoring database
   scoredb:
-    image: postgis/postgis:latest
+    image: postgis/postgis:16-3.5
     environment:
       POSTGRES_USER: scoring
       POSTGRES_DB: scoring


### PR DESCRIPTION
Existing deployment databases (postgresql v16) are not compatible with postgresql v17. Pin to v16 so we don't become incompatible with existing databases if the docker image gets deleted and re-downloaded.