### PR TITLE
Fix image viewer not showing up

### DIFF
--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -57,7 +57,7 @@ watch(()=> ApiService.getApiPrefix(), async () => {
       :site-eval-id="state.selectedImageSite.siteId"
       :site-evaluation-name="state.selectedImageSite.siteName"
       :date-range="state.selectedImageSite.dateRange"
-      style="top: 40vh !important; height: 60vh"
+      style="position: relative; top: -60vh !important; height: 60vh"
     />
   </v-main>
   <span>


### PR DESCRIPTION
The image viewer was being pushed beyond the viewport with the recent map-layer CSS changes introduced in #524.