### PR TITLE
Fix scrolling model lists and local layers

### DIFF
--- a/vue/src/components/LocalLayers.vue
+++ b/vue/src/components/LocalLayers.vue
@@ -58,8 +58,8 @@ const localLayers = computed(() => {
 </script>
 
 <template>
-  <div class="h-100 overflow-y-auto">
-    <div class="text-center">
+  <div class="h-100 overflow-y-auto d-flex flex-column">
+    <div class="text-center py-2">
       <v-btn
         variant="flat"
         color="secondary"
@@ -79,7 +79,7 @@ const localLayers = computed(() => {
         No local layers
       </div>
     </div>
-    <v-list>
+    <v-list class="overflow-y-auto">
       <v-list-item
         v-for="layer in localLayers"
         :key="layer.id"

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -118,7 +118,7 @@ onMounted(() => loadModelRuns('firstPage'));
 </script>
 
 <template>
-  <div class="d-flex flex-column overflow-hidden">
+  <div class="d-flex flex-column overflow-hidden pr-2">
     <div class="d-flex flex-wrap flex-grow-0">
       <v-chip
         v-if="!loading && !loadingSatelliteTimestamps"

--- a/vue/src/components/ModelRunList.vue
+++ b/vue/src/components/ModelRunList.vue
@@ -118,7 +118,7 @@ onMounted(() => loadModelRuns('firstPage'));
 </script>
 
 <template>
-  <div class="d-flex flex-column overflow-hidden pr-2">
+  <div class="d-flex flex-column overflow-hidden h-inherit pr-2">
     <div class="d-flex flex-wrap flex-grow-0">
       <v-chip
         v-if="!loading && !loadingSatelliteTimestamps"

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -164,8 +164,7 @@ const tab = ref();
 
 <template>
   <v-card
-    class="pa-5 pb-1 overflow-y-hidden d-flex flex-column"
-    style="max-height:100vh; min-height:100vh; height: 100vh;"
+    class="pa-5 pb-1 h-100 overflow-y-hidden d-flex flex-column"
   >
     <v-row
       dense
@@ -195,9 +194,12 @@ const tab = ref();
     </v-tabs>
     <v-window
       v-model="tab"
-      class="overflow-visible h-100"
+      class="overflow-hidden flex-grow-1 flex-shrink-1 h-100"
     >
-      <v-window-item value="model-runs">
+      <v-window-item
+        value="model-runs"
+        class="window-item-flex-container"
+      >
         <mode-selector />
         <v-row>
           <TimeSlider
@@ -355,7 +357,7 @@ const tab = ref();
       </v-window-item>
       <v-window-item
         value="local-layers"
-        class="h-100"
+        class="h-100 window-item-flex-container"
       >
         <local-layers />
       </v-window-item>
@@ -439,5 +441,11 @@ const tab = ref();
 .sidebar-icon {
   min-width: 40px;
   min-height: 40px;;
+}
+
+.window-item-flex-container {
+  height: inherit;
+  display: flex;
+  flex-flow: column;
 }
 </style>

--- a/vue/src/components/SideBar.vue
+++ b/vue/src/components/SideBar.vue
@@ -198,150 +198,152 @@ const tab = ref();
     >
       <v-window-item
         value="model-runs"
-        class="window-item-flex-container"
+        class="window-item-flex-container pt-2"
       >
-        <mode-selector />
-        <v-row>
-          <TimeSlider
-            :min="state.timeMin"
-            :max="Math.floor(Date.now() / 1000)"
-          />
-        </v-row>
-        <v-row
-          dense
-          align="center"
-          class="py-2"
-        >
-          <v-spacer />
-          <v-btn
-            variant="tonal"
-            density="compact"
-            class="pa-0 ma-1 sidebar-icon"
-            :color="drawMap ? 'primary' : 'black'"
-            @click="drawMap = !drawMap"
-          >
-            <v-icon>mdi-road</v-icon>
-          </v-btn>
-          <v-btn
-            v-if="selectedRegion !== null && !(filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
-            variant="tonal"
-            density="compact"
-            class="pa-0 ma-1 sidebar-icon"
-            :class="{
-              'animate-flicker': state.satellite.loadingSatelliteImages,
-            }"
-            :color="imagesOn ? 'primary' : 'black'"
-            :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
-            @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
-          >
-            <v-icon>mdi-image</v-icon>
-          </v-btn>
-          <v-tooltip v-else>
-            <template #activator="{ props: props }">
-              <v-btn
-                variant="tonal"
-                v-bind="props"
-                :disabled="!selectedRegion"
-                density="compact"
-                :class="{
-                  'animate-flicker': loadingSatelliteTimestamps,
-                }"
-                class="pa-0 ma-1 sidebar-icon"
-                :color="satelliteLoadingColor"
-                @click="askDownloadSatelliteTimestamps = true"
-              >
-                <v-icon>mdi-satellite-variant</v-icon>
-              </v-btn>
-            </template>
-            <v-alert
-              v-if="!satelliteRegionTooLarge"
-              type="warning"
-              title="Fetch Region Satellite Timestamps"
-              text="This is a long running process that could cause instability on the server.  Please only run this if you are sure you need to use the region satellite feature."
+        <div class="flex-grow-0">
+          <mode-selector />
+          <v-row>
+            <TimeSlider
+              :min="state.timeMin"
+              :max="Math.floor(Date.now() / 1000)"
             />
-            <v-alert
-              v-else
-              type="warning"
-              title="Region Too Large to Fetch Timestamps"
-              text="The Region is too large to fetch timestamps for."
+          </v-row>
+          <v-row
+            dense
+            align="center"
+            class="py-2"
+          >
+            <v-spacer />
+            <v-btn
+              variant="tonal"
+              density="compact"
+              class="pa-0 ma-1 sidebar-icon"
+              :color="drawMap ? 'primary' : 'black'"
+              @click="drawMap = !drawMap"
+            >
+              <v-icon>mdi-road</v-icon>
+            </v-btn>
+            <v-btn
+              v-if="selectedRegion !== null && !(filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
+              variant="tonal"
+              density="compact"
+              class="pa-0 ma-1 sidebar-icon"
+              :class="{
+                'animate-flicker': state.satellite.loadingSatelliteImages,
+              }"
+              :color="imagesOn ? 'primary' : 'black'"
+              :disabled="selectedRegion === null || (filteredSatelliteTimeList.length === 0 && state.satellite.satelliteSources.length !== 0)"
+              @click="imagesOn = selectedRegion !== null && (filteredSatelliteTimeList.length !== 0 || state.satellite.satelliteSources.length === 0) ? !imagesOn : imagesOn"
+            >
+              <v-icon>mdi-image</v-icon>
+            </v-btn>
+            <v-tooltip v-else>
+              <template #activator="{ props: props }">
+                <v-btn
+                  variant="tonal"
+                  v-bind="props"
+                  :disabled="!selectedRegion"
+                  density="compact"
+                  :class="{
+                    'animate-flicker': loadingSatelliteTimestamps,
+                  }"
+                  class="pa-0 ma-1 sidebar-icon"
+                  :color="satelliteLoadingColor"
+                  @click="askDownloadSatelliteTimestamps = true"
+                >
+                  <v-icon>mdi-satellite-variant</v-icon>
+                </v-btn>
+              </template>
+              <v-alert
+                v-if="!satelliteRegionTooLarge"
+                type="warning"
+                title="Fetch Region Satellite Timestamps"
+                text="This is a long running process that could cause instability on the server.  Please only run this if you are sure you need to use the region satellite feature."
+              />
+              <v-alert
+                v-else
+                type="warning"
+                title="Region Too Large to Fetch Timestamps"
+                text="The Region is too large to fetch timestamps for."
+              />
+            </v-tooltip>
+            <v-btn
+              :color="state.filters.showText ? 'primary' : 'gray'"
+              variant="tonal"
+              class="pa-0 ma-1 sidebar-icon"
+              density="compact"
+              @click="toggleText()"
+            >
+              <v-icon>mdi-format-text</v-icon>
+            </v-btn>
+            <v-btn
+              :color="state.mapLegend ? 'primary' : 'gray'"
+              variant="tonal"
+              class="pa-0 ma-1 sidebar-icon"
+              density="compact"
+              @click="state.mapLegend = !state.mapLegend"
+            >
+              <v-icon>mdi-map-legend</v-icon>
+            </v-btn>
+            <v-tooltip>
+              <template #activator="{ props: props }">
+                <v-btn
+                  variant="tonal"
+                  v-bind="props"
+                  density="compact"
+                  class="pa-0 ma-1 sidebar-icon"
+                  :color="groundtruth ? 'primary' : 'gray'"
+                  @click="groundtruth = !groundtruth"
+                >
+                  <v-icon>mdi-check-decagram</v-icon>
+                </v-btn>
+              </template>
+              <span> Toggle Ground Truth in the list</span>
+            </v-tooltip>
+            <v-btn
+              :color="expandSettings ? 'primary' : 'gray'"
+              variant="tonal"
+              class="pa-0 ma-1 sidebar-icon"
+              density="compact"
+              @click="expandSettings = !expandSettings"
+            >
+              <v-icon>mdi-cog</v-icon>
+            </v-btn>
+          </v-row>
+          <v-row
+            dense
+            class="mt-3"
+          >
+            <PerformerFilter
+              v-model="selectedPerformer"
+              cols="6"
+              class="px-1"
+              hide-details
             />
-          </v-tooltip>
-          <v-btn
-            :color="state.filters.showText ? 'primary' : 'gray'"
-            variant="tonal"
-            class="pa-0 ma-1 sidebar-icon"
-            density="compact"
-            @click="toggleText()"
+            <RegionFilter
+              v-model="selectedRegion"
+              cols="6"
+              class="px-1"
+              hide-details
+            />
+          </v-row>
+          <v-row
+            v-if="ApiService.isScoring()"
+            class="pt-2"
+            dense
           >
-            <v-icon>mdi-format-text</v-icon>
-          </v-btn>
-          <v-btn
-            :color="state.mapLegend ? 'primary' : 'gray'"
-            variant="tonal"
-            class="pa-0 ma-1 sidebar-icon"
-            density="compact"
-            @click="state.mapLegend = !state.mapLegend"
-          >
-            <v-icon>mdi-map-legend</v-icon>
-          </v-btn>
-          <v-tooltip>
-            <template #activator="{ props: props }">
-              <v-btn
-                variant="tonal"
-                v-bind="props"
-                density="compact"
-                class="pa-0 ma-1 sidebar-icon"
-                :color="groundtruth ? 'primary' : 'gray'"
-                @click="groundtruth = !groundtruth"
-              >
-                <v-icon>mdi-check-decagram</v-icon>
-              </v-btn>
-            </template>
-            <span> Toggle Ground Truth in the list</span>
-          </v-tooltip>
-          <v-btn
-            :color="expandSettings ? 'primary' : 'gray'"
-            variant="tonal"
-            class="pa-0 ma-1 sidebar-icon"
-            density="compact"
-            @click="expandSettings = !expandSettings"
-          >
-            <v-icon>mdi-cog</v-icon>
-          </v-btn>
-        </v-row>
-        <v-row
-          dense
-          class="mt-3"
-        >
-          <PerformerFilter
-            v-model="selectedPerformer"
-            cols="6"
-            class="px-1"
-            hide-details
-          />
-          <RegionFilter
-            v-model="selectedRegion"
-            cols="6"
-            class="px-1"
-            hide-details
-          />
-        </v-row>
-        <v-row
-          v-if="ApiService.isScoring()"
-          class="pt-2"
-          dense
-        >
-          <ModeFilter
-            v-model="selectedModes"
-            class="px-1"
-            hide-details
-          />
-          <EvalFilter
-            v-model="selectedEval"
-            class="px-1"
-            hide-details
-          />
-        </v-row>
+            <ModeFilter
+              v-model="selectedModes"
+              class="px-1"
+              hide-details
+            />
+            <EvalFilter
+              v-model="selectedEval"
+              class="px-1"
+              hide-details
+            />
+          </v-row>
+        </div>
         <v-row
           dense
           class="modelRuns"

--- a/vue/src/components/TimeSlider.vue
+++ b/vue/src/components/TimeSlider.vue
@@ -33,7 +33,7 @@ const maxDate = computed(() => convertUnixToDate(props.max));
 </script>
 
 <template>
-  <v-container class="mr-2">
+  <v-container class="mr-2 time-slider">
     <v-row
       align="center"
       justify="center"
@@ -88,5 +88,9 @@ const maxDate = computed(() => convertUnixToDate(props.max));
 <style scoped>
 .calendar {
   opacity: 1.0;
+}
+
+.time-slider {
+  box-sizing: content-box;
 }
 </style>

--- a/vue/src/components/annotationViewer/SideBar.vue
+++ b/vue/src/components/annotationViewer/SideBar.vue
@@ -130,10 +130,9 @@ const satelliteLoadingColor = computed(() => {
 
 <template>
   <v-card
-    class="pa-5 overflow-y-hidden"
-    style="max-height:100vh; min-height:100vh;"
+    class="pa-5 pb-1 h-100 overflow-hidden d-flex flex-column"
   >
-    <div>
+    <div class="flex-grow-0">
       <v-row
         dense
       >
@@ -255,7 +254,7 @@ const satelliteLoadingColor = computed(() => {
     </div>
     <v-row
       dense
-      class="modelRuns"
+      class="modelRuns h-inherit overflow-hidden"
     >
       <ModelRunListVue
         :filters="queryFilters"

--- a/vue/src/index.css
+++ b/vue/src/index.css
@@ -4,3 +4,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.h-inherit {
+  height: inherit;
+}

--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -68,12 +68,12 @@ const updateSiteList = async () => {
     location="left"
     width="400"
     sticky
-    style="max-height:100vh;"
     permanent
+    class="h-100 overflow-hidden"
   >
     <SideBar />
   </v-navigation-drawer>
-  <v-main style="z-index:1">
+  <v-main style="z-index:1; height: 100%">
     <layer-selection />
     <MapLibre :compact="!!state.selectedImageSite" />
     <ImageViewer

--- a/vue/src/views/RGD.vue
+++ b/vue/src/views/RGD.vue
@@ -44,8 +44,8 @@ watch(()=> ApiService.getApiPrefix(), async () => {
     location="left"
     width="400"
     sticky
-    style="max-height: 100vh"
     permanent
+    class="h-100 overflow-hidden"
   >
     <SideBar />
   </v-navigation-drawer>


### PR DESCRIPTION
I noticed that scrolling long model lists and local layers is broken. Updated CSS to properly scroll on those long lists.

The changes in `SideBar.vue` look extensive, but in reality I only modified some classes and nested all of the elements from `<mode-selector />` to `<EvalFilter />` in a `<div class="flex-grow-0">`.