### PR TITLE
Hide image button if no images present

### DIFF
--- a/vue/src/components/siteList/ImageToggle.vue
+++ b/vue/src/components/siteList/ImageToggle.vue
@@ -30,6 +30,7 @@ const openImageBrowser = () => {
 
 <template>
   <v-menu
+    v-if="hasImages"
     open-on-hover
     open-delay="600"
   >


### PR DESCRIPTION
Aashish noticed that if you select a site with no images downloaded it will still provide an image button this simply hides the button if no images are downloaded for a selected site.