### PR TITLE
Fix json serialization error

### DIFF
--- a/rdwatch/core/views/site_observation.py
+++ b/rdwatch/core/views/site_observation.py
@@ -192,7 +192,7 @@ def site_observations(request: HttpRequest, evaluation_id: UUID4):
             celery_data['state'] = task.state
             celery_data['status'] = task.status
             celery_data['info'] = (
-                str(task.info) if isinstance(task.info, RuntimeError) else task.info
+                str(task.info) if isinstance(task.info, Exception) else task.info
             )
 
         queryset['job'] = {

--- a/rdwatch/scoring/views/site_observation.py
+++ b/rdwatch/scoring/views/site_observation.py
@@ -203,7 +203,7 @@ def site_observations(request: HttpRequest, evaluation_id: UUID4):
             celery_data['state'] = task.state
             celery_data['status'] = task.status
             celery_data['info'] = (
-                str(task.info) if isinstance(task.info, RuntimeError) else task.info
+                str(task.info) if isinstance(task.info, Exception) else task.info
             )
 
         queryset['job'] = {


### PR DESCRIPTION
Attempting to return *any* exception as a JSON response will result in a `Object of type WorkerLostError is not JSON serializable` error.

Fixes https://kitware-data.sentry.io/issues/6078296720/?project=4508054265724928&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=1