### PR TITLE
fixes display of image-viewer in annotator mode

### DIFF
--- a/vue/src/views/AnnotationViewer.vue
+++ b/vue/src/views/AnnotationViewer.vue
@@ -82,7 +82,7 @@ const updateSiteList = async () => {
       :site-evaluation-name="state.selectedImageSite.siteName"
       :date-range="state.selectedImageSite.dateRange"
       editable
-      style="top:40vh !important; height:60vh"
+      style="position: relative; top: -60vh !important; height: 60vh"
       @update-list="updateSiteList()"
     />
   </v-main>


### PR DESCRIPTION
When testing the SAM stuff I noticed the image viewer wasn't coming up.  This is related to #543.  Added code so that in Annotator Mode the image viewer will display when selecting a site.