### PR TITLE
Optimize scoring vector tiles

### DIFF
--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -876,4 +876,11 @@ export class ApiService {
     })
   }
 
+  public static getModelRunColorCodes(id: string): CancelablePromise<Record<string, number>> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: `${this.getApiPrefix()}/model-runs/${id}/vector-tile/color-codes/`,
+    })
+  }
+
 }

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -133,6 +133,9 @@ const getSites = async (modelRun: string, initRun = false) => {
       if (downloadingAny && downloadCheckInterval === null) {
         checkDownloading();
       }
+
+      state.modelRunColorCodeMappings[modelRun] = await ApiService.getModelRunColorCodes(modelRun);
+
       return modList;
     }
     return [];

--- a/vue/src/store.ts
+++ b/vue/src/store.ts
@@ -190,6 +190,7 @@ export const state = reactive<{
   modelRuns: KeyedModelRun[],
   totalNumModelRuns: number;
   openedModelRuns: Set<KeyedModelRun["key"]>;
+  modelRunColorCodeMappings: Record<string, Record<string, number>>;
   gifSettings: {
     fps: number;
     pointSize: number;
@@ -276,6 +277,7 @@ export const state = reactive<{
   modelRuns: [],
   totalNumModelRuns: 0,
   openedModelRuns: new Set<KeyedModelRun["key"]>(),
+  modelRunColorCodeMappings: {},
   gifSettings: { fps: 1, pointSize: 1, lineThicknessFactor: 1 },
   performerMapping: {},
   performerIds: [],


### PR DESCRIPTION
This removes the expensive `color_code` subquery and adds a new endpoint that returns the color mapping by itself. The endpoint is cached, but even on cache misses it is much faster than the previous method.

I've updated the client to handle this new approach. This required reworking how the color_code MapLibre filter worked quite a bit.
