### PR TITLE
Fix TimeSlider being cut off visually

### DIFF
--- a/vue/src/components/TimeSlider.vue
+++ b/vue/src/components/TimeSlider.vue
@@ -91,6 +91,7 @@ const maxDate = computed(() => convertUnixToDate(props.max));
 }
 
 .time-slider {
-  box-sizing: content-box;
+  /* avoid getting cut off due to parent overflow: hidden */
+  padding: 24px;
 }
 </style>


### PR DESCRIPTION
The TimeSlider component is cut off visually on the left side.

Before:
<img width="362" alt="Screenshot 2024-11-21 at 3 19 23 PM" src="https://github.com/user-attachments/assets/585892e1-9013-4191-bf9d-29cc7d380da9">

After:
<img width="380" alt="Screenshot 2024-11-21 at 3 19 31 PM" src="https://github.com/user-attachments/assets/46145fa9-0606-4ec3-acf9-216242c9d54c">
