### PR TITLE
grab only a single most recent groundTruthLink from the list

### DIFF
--- a/rdwatch/core/views/model_run.py
+++ b/rdwatch/core/views/model_run.py
@@ -239,7 +239,7 @@ def get_queryset():
                                 proposal=None,
                             )
                             .order_by('-created')
-                            .values_list('pk')
+                            .values_list('pk')[:1]  # grab first in the list
                         ),
                         None,
                     ),


### PR DESCRIPTION
Knew about this issue for links for proposals, just need to add it for other the base groundTruth links:
https://github.com/ResonantGeoData/RD-WATCH/blob/main/rdwatch/core/views/model_run.py#L268
