### PR TITLE
Update Circle Thickness, extend thickness/point size range, fix Scoring coloring

### DIFF
--- a/rdwatch/core/tasks/animation_export.py
+++ b/rdwatch/core/tasks/animation_export.py
@@ -573,6 +573,9 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                 y_offset,
             )
             color = label_mapped.get('color', (255, 255, 255))
+            circle_line_width = int(
+                (max(max_height_px, max_width_px) * line_thickness_factor) / 100
+            )
             draw.ellipse(
                 (
                     pixel_point[0] - point_radius,
@@ -581,6 +584,7 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                     pixel_point[1] + point_radius,
                 ),
                 outline=color,
+                width=circle_line_width,
             )
 
         # Drawing labels of timestamp

--- a/rdwatch/scoring/tasks/animation_export.py
+++ b/rdwatch/scoring/tasks/animation_export.py
@@ -427,6 +427,9 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                 y_offset,
             )
             color = label_mapped.get('color', (255, 255, 255))
+            circle_line_width = int(
+                (max(max_height_px, max_width_px) * line_thickness_factor) / 100
+            )
             draw.ellipse(
                 (
                     pixel_point[0] - point_radius,
@@ -435,6 +438,7 @@ def create_animation(self, site_evaluation_id: UUID4, settings: dict[str, Any]):
                     pixel_point[1] + point_radius,
                 ),
                 outline=color,
+                width=circle_line_width,
             )
 
         # Drawing labels of timestamp

--- a/vue/src/components/animation/AnimationDownloadDialog.vue
+++ b/vue/src/components/animation/AnimationDownloadDialog.vue
@@ -255,7 +255,7 @@ const cancel = debounce(() => emit("close"), 5000, { leading: true });
             <v-slider
               v-model="pointRadius"
               min="1"
-              max="20"
+              max="50"
               step="1"
               label="Point size"
               thumb-label="always"
@@ -269,7 +269,7 @@ const cancel = debounce(() => emit("close"), 5000, { leading: true });
             <v-slider
               v-model.number="lineThicknessFactor"
               min="0.1"
-              max="2"
+              max="10"
               step="0.1"
               label="Line Width Factor"
               thumb-label="always"

--- a/vue/src/components/imageViewer/ImageFilter.vue
+++ b/vue/src/components/imageViewer/ImageFilter.vue
@@ -301,7 +301,7 @@ watch([
           <v-slider
             v-model.number="lineThicknessFactor"
             :min="0.1"
-            :max="2"
+            :max="10"
             :step="0.1"
             density="compact"
             color="primary"

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -134,7 +134,9 @@ const getSites = async (modelRun: string, initRun = false) => {
         checkDownloading();
       }
 
-      state.modelRunColorCodeMappings[modelRun] = await ApiService.getModelRunColorCodes(modelRun);
+      if (ApiService.isScoring()) {
+        state.modelRunColorCodeMappings[modelRun] = await ApiService.getModelRunColorCodes(modelRun);
+      }
 
       return modList;
     }


### PR DESCRIPTION
- Allow line thickness to apply to scoring/core animation exporting
- Increase the line thickness range
- Increase the circle point radius
- Fix an error with the color_code being called when not in the scoring mode causing an error.