### PR TITLE
Remove color_code from /sites/ endpoint, update client

### DIFF
--- a/rdwatch/scoring/views/model_run.py
+++ b/rdwatch/scoring/views/model_run.py
@@ -44,8 +44,6 @@ from rdwatch.core.views.model_run import ModelRunDetailSchema, ModelRunPaginatio
 from rdwatch.scoring.models import (
     AnnotationProposalSet,
     AnnotationProposalSite,
-    EvaluationBroadAreaSearchDetection,
-    EvaluationBroadAreaSearchProposal,
     EvaluationRun,
     Region,
     SatelliteFetching,
@@ -764,62 +762,6 @@ def get_sites_query(model_run_id: UUID4):
                 'downloading': True,
             }
 
-    # Build a mapping of site_id to color code.
-    # We do this in a separate query to avoid a slow subquery in the main query,
-    # due to the EvaluationBroadAreaSearchDetection table being extremely large.
-    # The number of sites in an evaluation run is small enough that it's feasible
-    # to load the site_id->color_code mapping into memory and manually join it
-    # with the sites_list in Python.
-    site_to_color_code_mapping: dict[str, int] = {
-        obj['site_truth']: obj['color_code']
-        for obj in EvaluationBroadAreaSearchDetection.objects.filter(
-            Q(evaluation_run_uuid=model_run_id)
-            & Q(activity_type='overall')
-            & Q(rho=0.5)
-            & Q(tau=0.2)
-            & Q(min_confidence_score=0.0)
-            & Q(
-                Q(min_spatial_distance_threshold__isnull=True)
-                | Q(min_spatial_distance_threshold=100.0)
-            )
-            & Q(
-                Q(central_spatial_distance_threshold__isnull=True)
-                | Q(central_spatial_distance_threshold=500.0)
-            )
-            & Q(max_spatial_distance_threshold__isnull=True)
-            & Q(
-                Q(min_temporal_distance_threshold__isnull=True)
-                | Q(min_temporal_distance_threshold=730.0)
-            )
-            & Q(central_temporal_distance_threshold__isnull=True)
-            & Q(max_temporal_distance_threshold__isnull=True)
-        ).values('site_truth', 'color_code')
-    } | {
-        obj['site_proposal']: obj['color_code']
-        for obj in EvaluationBroadAreaSearchProposal.objects.filter(
-            Q(evaluation_run_uuid=model_run_id)
-            & Q(activity_type='overall')
-            & Q(rho=0.5)
-            & Q(tau=0.2)
-            & Q(min_confidence_score=0.0)
-            & Q(
-                Q(min_spatial_distance_threshold__isnull=True)
-                | Q(min_spatial_distance_threshold=100.0)
-            )
-            & Q(
-                Q(central_spatial_distance_threshold__isnull=True)
-                | Q(central_spatial_distance_threshold=500.0)
-            )
-            & Q(max_spatial_distance_threshold__isnull=True)
-            & Q(
-                Q(min_temporal_distance_threshold__isnull=True)
-                | Q(min_temporal_distance_threshold=730.0)
-            )
-            & Q(central_temporal_distance_threshold__isnull=True)
-            & Q(max_temporal_distance_threshold__isnull=True)
-        ).values('site_proposal', 'color_code')
-    }
-
     for s in site_list['sites']:
         if s['id'] in image_info.keys():
             site_image_info = image_info[s['id']]
@@ -837,8 +779,6 @@ def get_sites_query(model_run_id: UUID4):
         s['L8'] = site_image_info['L8']
         s['PL'] = site_image_info['PL']
         s['downloading'] = site_image_info['downloading']
-
-        s['color_code'] = site_to_color_code_mapping.get(s['site_id'])
 
     return site_list
 

--- a/vue/src/client/services/ApiService.ts
+++ b/vue/src/client/services/ApiService.ts
@@ -64,7 +64,6 @@ export interface SiteInfo {
     bbox: { xmin: number; ymin: number; xmax: number; ymax: number }
     status: SiteModelStatus
     timestamp: number;
-    color_code?: number;
     filename?: string | null;
     downloading: boolean;
     groundtruth?: boolean;

--- a/vue/src/components/siteList/SiteList.vue
+++ b/vue/src/components/siteList/SiteList.vue
@@ -117,7 +117,6 @@ const getSites = async (modelRun: string, initRun = false) => {
           WV: item.WV,
           L8: item.L8,
           PL: item.PL,
-          color_code: item.color_code,
           status: item.status,
           timestamp: item.timestamp,
           groundTruth: item.groundtruth,
@@ -149,15 +148,13 @@ const filterGroundTruth = (list:SiteDisplay[]) => {
     } else {
       if (state.filters.scoringColoring) { // Remove items based on color codes
         returnList = list.filter((item) => {
-          if (item.color_code !== undefined) {
-            const colorKey = scoringColors[item.color_code as scoringColorsKeys];
-            if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
-              return true;
-            }
-            return false;
+          const colorKey = scoringColors[state.modelRunColorCodeMappings[item.modelRunId as string][item.name] as scoringColorsKeys];
+
+          if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
+            return true;
           }
           return false;
-        })
+        });
       } else {
         returnList = list;
       }
@@ -324,12 +321,9 @@ watch([filter, () => state.filters.drawObservations, () => state.filters.drawSit
   } else {
       if (state.filters.scoringColoring) { // Remove items based on color codes
         tempList = tempList.filter((item) => {
-          if (item.color_code !== undefined) {
-            const colorKey = scoringColors[item.color_code as scoringColorsKeys];
-            if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
-              return true;
-            }
-            return false;
+          const colorKey = scoringColors[state.modelRunColorCodeMappings[item.modelRunId as string][item.name] as scoringColorsKeys];
+          if (state.filters.scoringColoring && colorKey && colorKey[state.filters.scoringColoring]) {
+            return true;
           }
           return false;
         });

--- a/vue/src/components/siteList/SiteListCard.vue
+++ b/vue/src/components/siteList/SiteListCard.vue
@@ -35,7 +35,6 @@ export interface SiteDisplay {
   downloadingData?: SatelliteFetchingDownloadingInfo;
   downloadingError?: string;
   groundTruth?: boolean;
-  color_code?: number;
   originator?: string;
   proposal?: boolean;
   details?: {

--- a/vue/src/interactions/mouseEvents.ts
+++ b/vue/src/interactions/mouseEvents.ts
@@ -285,7 +285,7 @@ const drawSitePopupObservation = async (e: MapLayerMouseEvent, remove=false) => 
                   }
                   const start_date = item.properties.start_date ? item.properties.start_date.substring(0, 10) : item.properties.point_date ? item.properties.point_date.substring(0, 10) : 'null';
                   const end_date = item.properties.end_date ? item.properties.end_date.substring(0, 10) : item.properties.point_date ? item.properties.point_date.substring(0, 10) : 'null';
-                  const colorCode = item.properties.color_code as scoringColorsKeys;
+                  const colorCode = state.modelRunColorCodeMappings[item.properties.configuration_id][item.properties.base_site_id] as scoringColorsKeys;
                   const scoreColor  = scoringColors[colorCode] ? scoringColors[colorCode].hex : undefined
                   const scoreLabel  = scoringColors[colorCode] ? scoringColors[colorCode].title : undefined
                   const data = {


### PR DESCRIPTION
I missed some of this in #553. Also, I realized we don't even need to embed the `color_code` in the `/sites/` endpoint response anymore, since we now have the color code mapping endpoint that gets stored in the global Vue state.