### PR TITLE
Configure sentry logging integration for ERROR logs only

### DIFF
--- a/rdwatch/core/apps.py
+++ b/rdwatch/core/apps.py
@@ -40,7 +40,7 @@ class RDWatchConfig(AppConfig):
                 environment=settings.SENTRY_ENVIRONMENT,
                 release=settings.SENTRY_RELEASE,
                 integrations=[
-                    LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+                    LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
                     DjangoIntegration(),
                     CeleryIntegration(),
                 ],


### PR DESCRIPTION
Setting this to WARNING causes to many extraneous logs to be reported as issues in Sentry. `rio_tiler` in particular is very noisy, and it's difficult to calibrate things because we have no control over the source data its processing.